### PR TITLE
Update Internal Tech Doc links

### DIFF
--- a/source/documentation/02-about-govuk-pay.md
+++ b/source/documentation/02-about-govuk-pay.md
@@ -16,4 +16,4 @@ The platform currently supports one-off payments (like fees, fines or licence pa
 
 There are [4 departments and agencies currently partnering with the platform](https://gds.blog.gov.uk/2015/10/15/introducing-gov-uk-pay/).
 
-To find out more about GOV.UK Pay, read our [blogs and newsletters](https://gds-payments.gelato.io/docs/versions/1.0.0/support-contact-and-more-information).
+To find out more about GOV.UK Pay, read our [blogs and newsletters](https://govukpay-docs.cloudapps.digital/#support-contact-and-more-information).

--- a/source/documentation/04-quick-start-guide.md
+++ b/source/documentation/04-quick-start-guide.md
@@ -28,7 +28,7 @@ To use the GOV.UK Pay API, you will need your own individual staff account. A st
 ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/DescribeAPIKey+image2.png)
 <br /><br />Your API key will be shown on the screen for you to copy.<br /><br /> ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/NewKeygenerate+image+3.png)
 
-<blockquote>You must store your API keys away securely. Make sure you never share this key in publicly accessible documents or repositories, or with people who shouldn't be using the GOV.UK Pay API directly. <a href="https://gds-payments.gelato.io/docs/versions/1.0.0/security">Read our security section</a> for more information on how to keep your API key safe.</blockquote>
+<blockquote>You must store your API keys away securely. Make sure you never share this key in publicly accessible documents or repositories, or with people who shouldn't be using the GOV.UK Pay API directly. <a href="https://govukpay-docs.cloudapps.digital/#security">Read our security section</a> for more information on how to keep your API key safe.</blockquote>
 
 #### API Explorer setup
 
@@ -66,7 +66,7 @@ The ``return_url`` is the URL of a page on your service that the user will be re
 <br/><br/>
 ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/pay-api-explorer-response.png)
 
-1. Go to the ``next_url`` with your browser. You'll see the payment screen. Refer to the [Testing GOV.UK Pay](https://gds-payments.gelato.io/docs/versions/1.0.0/testing-gov-uk-pay) section to find a mock credit card number that you can enter to simulate a payment in the sandbox environment. For the rest of the details, enter some test information, bearing in mind that:
+1. Go to the ``next_url`` with your browser. You'll see the payment screen. Refer to the [Testing GOV.UK Pay](https://govukpay-docs.cloudapps.digital/#testing-gov-uk-pay) section to find a mock credit card number that you can enter to simulate a payment in the sandbox environment. For the rest of the details, enter some test information, bearing in mind that:
     + the expiry date must be in the future
     + the postcode must be valid
 

--- a/source/documentation/05-payment-overview.md
+++ b/source/documentation/05-payment-overview.md
@@ -121,7 +121,7 @@ The ``return_url`` should specify a page on your service. When the user visits t
   + match the returning user with their payment (with a secure cookie, or a secure random ID string included in the ``return_url``)
   + check the status of the payment using an API call
 
-See the [Integration details](https://gds-payments.gelato.io/docs/versions/1.0.0/integration-details) section for more details about how to match the user to the payment.
+See the [Integration details](https://govukpay-docs.cloudapps.digital/#integration-details) section for more details about how to match the user to the payment.
 
 To check the status of the payment, you must make a [**Find payment by ID**](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.0/v1/find-payment-by-id) API call, using the ``payment_id`` of the payment as the parameter.
 
@@ -151,4 +151,4 @@ In this example, the payment was successful, and the payment journey is finished
 
 It is up to your page at the ``return_url`` to show an appropriate message based on the state of the payment. For example, for a completed payment, you would likely want to confirm that the payment has been received and explain what will happen next. For a failed payment, you should make clear that payment failed and offer the user a chance to try again.
 
-Now that you understand the payment process, see the [Integration details](https://gds-payments.gelato.io/docs/versions/1.0.0/integration-details) section for more  about how you can integrate your service with GOV.UK Pay.
+Now that you understand the payment process, see the [Integration details](https://govukpay-docs.cloudapps.digital/#integration-details) section for more  about how you can integrate your service with GOV.UK Pay.

--- a/source/documentation/06-api-reference.md
+++ b/source/documentation/06-api-reference.md
@@ -22,7 +22,7 @@ For full details of each API action, see the API Browser:
 
 You can also use our interactive [API Explorer](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.0/) to try out API calls and view responses.
 
-See the [Quick Start Guide](https://gds-payments.gelato.io/docs/versions/1.0.0/quick-start-guide) section for how to set up the API Explorer. Make sure you enter your sandbox API key to avoid generating real payments!
+See the [Quick Start Guide](https://govukpay-docs.cloudapps.digital/#quick-start-guide) section for how to set up the API Explorer. Make sure you enter your sandbox API key to avoid generating real payments!
 
 
 

--- a/source/documentation/07-integration-details.md
+++ b/source/documentation/07-integration-details.md
@@ -19,7 +19,7 @@ You will receive the ``next_url``  to which you should direct the user to comple
 
 You can track the progress of a payment while the user is on GOV.UK Pay using the [**Find payment by ID**](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.0/v1/find-payment-by-id) call.
 
-NOTE: The status of the payment will go through several phases until it either succeeds or fails. See the [API reference section](https://gds-payments.gelato.io/docs/versions/1.0.0/api-reference) for more details.
+NOTE: The status of the payment will go through several phases until it either succeeds or fails. See the [API reference section](https://govukpay-docs.cloudapps.digital/#api-reference) for more details.
 
 #### Choosing the return URL and matching user to payment
 

--- a/source/documentation/18-glossary-of-terms.md
+++ b/source/documentation/18-glossary-of-terms.md
@@ -1,6 +1,5 @@
 # Glossary of terms
-
-
+This section defines commonly used terms in GOV.UK Pay.
 
 | Term                 | Definition                        |
 | -------------     |-------------------------- |


### PR DESCRIPTION
Updated internal tech doc links so that they point to the correct place in the new location of the tech docs, rather than pre-existing gelato documentation. Also added in an extra sentence into the Glossary section so that the table renders correctly.