### PR TITLE
Switching to live updates

### DIFF
--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -89,7 +89,7 @@ Go to _Configuration > Technical information_
 1. On the _Technical information_ page, click the _Data and origin verification_ tab.
 1. Scroll to the _Checks for e-Commerce & Alias Gateway_ section.
 1. Leave the _URL of the merchant page containing the payment form that will call the page: orderstandard.asp_ field blank.
-1. Enter a strong plaintext string SHA-IN passphrase; this will be used when setting up the GOV.UK account credentials.
+1. Enter a strong SHA-IN passphrase (plain text, not a hash); this will be used when setting up the GOV.UK Pay account credentials.
 1. Scroll down to the _Checks for Barclaycard Direct Link_ section.
 1. Leave the _IP address_ blank.
 1. Enter the same SHA-IN passphrase as the _Checks for e-Commerce & Alias Gateway_ section and click _Save_.
@@ -118,7 +118,7 @@ Go to _Configuration > Technical information_
 ![](images/epq-6.png)
 
 1. Scroll to the _All transaction submission modes > Security for request parameters_ section.
-1. Enter a strong plaintext string SHA-OUT passphrase; this will be used when setting up the GOV.UK account credentials.
+1. Enter a strong SHA-OUT passphrase (plain text, not a hash); this will be used when setting up the GOV.UK Pay account credentials.
 1. Leave the _Basic Authentication Credentials_ blank.
 1. Set _Timing of the request_ to _For each offline status change (payment, cancellation, etc.)_
 1. Enter **https://notifications.payments.service.gov.uk/v1/api/notifications/epdq** into the _URL on which the merchant wishes to receive a deferred HTTP request, should the status of a transaction change offline_ field.

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -15,6 +15,9 @@ To set up your live account credentials:
 1. Complete the fields on this page; these will vary depending on which live service you use.
 1. Click _Save credentials_ to go back to the _Account Credentials_ page.
 
+>For an _ePDQ_ live account, enter the SHA-IN passphrase created on the _Data and origin verification_ page, and the SHA-OUT passphrase created on the _All transaction submission modes_ page
+
+
 ## Generate API Key
 
 Refer to the documentation for instructions on how to [generate an API key for use with your live code](https://govukpay-docs.cloudapps.digital/#generate-api-key-for-api-explorer).

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -10,13 +10,26 @@ To set up your live account credentials:
 
 1. Go to the [GOV.UK Pay admin site](https://selfservice.payments.service.gov.uk/login).
 1. Sign in to your GOV.UK Pay account.
-1. Go to _My Services_ and click on the _ePDQ Live_ service.
+1. Go to _My Services_ and click on the live service you want to set up.
 1. Go to _Settings > Account Credentials > Edit credentials_.
 1. Complete the fields on this page; these will vary depending on which live service you use.
-1. Click _Save credentials_ to go back to the _Account Credentials_ page.
 
->For an _ePDQ_ live account, enter the SHA-IN passphrase created on the _Data and origin verification_ page, and the SHA-OUT passphrase created on the _All transaction submission modes_ page
+### ePDQ
 
+Complete the fields on this page:
+- _PSP ID_ - enter your PSP ID for ePDQ
+- _Username_ - enter the API user’s username
+- _Password_ - enter the API user’s password
+- _SHA-IN passphrase_ - this passphrase is created on the [_Data and origin verification_ page](/#set-up-checks-for-e-commerce-amp-alias-gateway)
+- _SHA-OUT passphrase_ - this passphrase is created on the [_All transaction submission modes_ page](/#set-up-security-for-request-parameters)
+- click _Save credentials_ to go back to the _Account Credentials_ page
+
+### Worldpay
+
+- _Merchant ID_ - enter your merchant ID for Worldpay
+- _Username_ - enter the API user's username
+- _Password_ - enter the API User's password
+- click _Save credentials_ to go back to the _Account Credentials_ page
 
 ## Generate API Key
 

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -12,12 +12,7 @@ To set up your live account credentials:
 1. Sign in to your GOV.UK Pay account.
 1. Go to _My Services_ and click on the _ePDQ Live_ service.
 1. Go to _Settings > Account Credentials > Edit credentials_.
-1. Complete the fields on this page:
-  - _PSP ID_ - enter your PSP ID for ePDQ
-  - _Username_ - enter the API user’s username
-  - _Password_ - enter the API user’s password
-  - _SHA-IN passphrase_ - enter the SHA-IN passphrase created on the Data and origin verification page
-  - _SHA-OUT passphrase_ - enter the SHA-OUT passphrase created on the Transaction feedback page
+1. Complete the fields on this page; these will vary depending on which live service you use.
 1. Click _Save credentials_ to go back to the _Account Credentials_ page.
 
 ## Generate API Key

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -86,7 +86,7 @@ Go to _Configuration > Technical information_
 1. On the _Technical information_ page, click the _Data and origin verification_ tab.
 1. Scroll to the _Checks for e-Commerce & Alias Gateway_ section.
 1. Leave the _URL of the merchant page containing the payment form that will call the page: orderstandard.asp_ field blank.
-Enter a strong SHA-IN passphrase; this will be used when setting up the GOV.UK account credentials.
+1. Enter a strong plain text string SHA-IN passphrase; this will be used when setting up the GOV.UK account credentials.
 1. Scroll down to the _Checks for Barclaycard Direct Link_ section.
 1. Leave the _IP address_ blank.
 1. Enter the same SHA-IN passphrase as the _Checks for e-Commerce & Alias Gateway_ section and click _Save_.
@@ -115,7 +115,7 @@ Enter a strong SHA-IN passphrase; this will be used when setting up the GOV.UK a
 ![](images/epq-6.png)
 
 1. Scroll to the _All transaction submission modes > Security for request parameters_ section.
-1. Enter a strong SHA-OUT passphrase; this will be used when setting up the GOV.UK account credentials.
+1. Enter a strong plain text string SHA-OUT passphrase; this will be used when setting up the GOV.UK account credentials.
 1. Leave the _Basic Authentication Credentials_ blank.
 1. Set _Timing of the request_ to _For each offline status change (payment, cancellation, etc.)_
 1. Enter **https://notifications.payments.service.gov.uk/v1/api/notifications/epdq** into the _URL on which the merchant wishes to receive a deferred HTTP request, should the status of a transaction change offline_ field.

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -89,7 +89,7 @@ Go to _Configuration > Technical information_
 1. On the _Technical information_ page, click the _Data and origin verification_ tab.
 1. Scroll to the _Checks for e-Commerce & Alias Gateway_ section.
 1. Leave the _URL of the merchant page containing the payment form that will call the page: orderstandard.asp_ field blank.
-1. Enter a strong plain text string SHA-IN passphrase; this will be used when setting up the GOV.UK account credentials.
+1. Enter a strong plaintext string SHA-IN passphrase; this will be used when setting up the GOV.UK account credentials.
 1. Scroll down to the _Checks for Barclaycard Direct Link_ section.
 1. Leave the _IP address_ blank.
 1. Enter the same SHA-IN passphrase as the _Checks for e-Commerce & Alias Gateway_ section and click _Save_.
@@ -118,7 +118,7 @@ Go to _Configuration > Technical information_
 ![](images/epq-6.png)
 
 1. Scroll to the _All transaction submission modes > Security for request parameters_ section.
-1. Enter a strong plain text string SHA-OUT passphrase; this will be used when setting up the GOV.UK account credentials.
+1. Enter a strong plaintext string SHA-OUT passphrase; this will be used when setting up the GOV.UK account credentials.
 1. Leave the _Basic Authentication Credentials_ blank.
 1. Set _Timing of the request_ to _For each offline status change (payment, cancellation, etc.)_
 1. Enter **https://notifications.payments.service.gov.uk/v1/api/notifications/epdq** into the _URL on which the merchant wishes to receive a deferred HTTP request, should the status of a transaction change offline_ field.

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -27,8 +27,8 @@ Complete the fields on this page:
 ### Worldpay
 
 - _Merchant ID_ - enter your merchant ID for Worldpay
-- _Username_ - enter the API user's username
-- _Password_ - enter the API User's password
+- _Username_ - enter the XML username
+- _Password_ - enter the XML password
 - click _Save credentials_ to go back to the _Account Credentials_ page
 
 ## Generate API Key


### PR DESCRIPTION
Updates to the Switching to Live section:
- Changes to the GOV.UK Pay account setup to remove ePDQ-only information
- Specify that SHA-IN and SHA-OUT passphrases are plain text strings

Related to story: https://payments-platform.atlassian.net/browse/PP-2831