### PR TITLE
Make 90 minutes payment expiry time more explicit

### DIFF
--- a/source/documentation/05-payment-overview.md
+++ b/source/documentation/05-payment-overview.md
@@ -210,6 +210,12 @@ If your service uses the resume payment feature:
 - you will minimise the number of expired payments
 - you won’t unnecessarily create new payments
 
+## Payment flow: Payment expires
+
+Payments that are not confirmed and completed after 90 minutes will expire automatically. 
+
+If the payment was authorised but incomplete, GOV.UK PAY will send a cancellation to the payment provider. This will raise a [P0020 API error](/#api-errors-caused-by-payment-statuses).
+
 ### Incomplete payments
 
 An incomplete payment will have a status of `created`, `started` or `submitted`. These payment types have a `next_URL`. The `next_URL` is where you should direct the user next in the payment process. You will receive a `next_URL` every time you query the status of a payment using the API.

--- a/source/documentation/07-integration-details.md
+++ b/source/documentation/07-integration-details.md
@@ -50,7 +50,7 @@ The user may close their browser or lose internet connection in the middle of th
 
 You can still check on the status of these payments by making a GET request using the Location Header or Self Link, the same way you would if they were redirected, but just after a set time (eg, an hour).
 
->Note: GOV.UK Pay will eventually expire incomplete payments, but you should expect an occasional success or failure if the user experienced problems right at the moment of the redirect.
+>Note: GOV.UK Pay will expire incomplete payments after 90 minutes, but you should expect an occasional success or failure if the user experienced problems right at the moment of the redirect.
 
 If a user does not have enough funds in their account to make a payment, the current GOV.UK Pay frontend will not let them try again with separate card details. This will soon be fixed as part of the beta.
 


### PR DESCRIPTION
Added "Payment flow: Payment expires" section. 

Changed "GOV.UK Pay will eventually expire incomplete payments" to "GOV.UK Pay will expire incomplete payments after 90 minutes" in the "When a user doesn’t complete their payment journey" section.