### PR TITLE
Support #2788803 Updating documentation

### DIFF
--- a/source/documentation/04-quick-start-guide.md
+++ b/source/documentation/04-quick-start-guide.md
@@ -43,7 +43,7 @@ The quickest way to learn about the API is to use the <a href="https://gds-payme
 You will now make a test API call to GOV.UK Pay by creating a new payment. This is the call your service will make when 
 initiating a payment using GOV.UK Pay.
 
-1. To test the API Explorer, select General from the API Explorer **Resource** dropdown menu. Select <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/general/create-new-payment" target="blank">Create new payment</a> (link opens in new window) from the API Explorer **Action** dropdown menu. Click on the **Body** tab lower down to see an example JSON body that you would send when creating a payment.
+1. To test the API Explorer, select General from the API Explorer **Resource** dropdown menu. Select <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment" target="blank">Create new payment</a> (link opens in new window) from the API Explorer **Action** dropdown menu. Click on the **Body** tab lower down to see an example JSON body that you would send when creating a payment.
 
 ```javascript
 {

--- a/source/documentation/05-payment-overview.md
+++ b/source/documentation/05-payment-overview.md
@@ -40,7 +40,7 @@ Note that this page might be the end point of a series of pages you host which a
 
 The user clicks **Continue**.
 
-At this point, your service makes a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/general/create-new-payment" target="blank">Create new payment</a> call to the Pay API (link opens in new window). The body of the call contains information in JSON format:
+At this point, your service makes a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment" target="blank">Create new payment</a> call to the Pay API (link opens in new window). The body of the call contains information in JSON format:
 
 
 ```javascript
@@ -175,7 +175,7 @@ The `return_url` should specify a page on your service. When the user visits the
 
 See the [Integration details](https://docs.payments.service.gov.uk/#integration-details) section for more details about how to match the user to the payment.
 
-To check the status of the payment, you must make a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/v1/find-payment-by-id" target="blank">Find payment by ID</a> API call (link opens in new window), using the ``payment_id`` of the payment as the parameter.
+To check the status of the payment, you must make a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id" target="blank">Find payment by ID</a> API call (link opens in new window), using the ``payment_id`` of the payment as the parameter.
 
 The URL to do this is the same as the ``self`` URL provided in the response when the payment was first created.
 

--- a/source/documentation/06-api-reference.md
+++ b/source/documentation/06-api-reference.md
@@ -17,10 +17,10 @@ The same base URL is now used for testing and live. The API key you use determin
 
 For full details of each API action, see the API Browser:
 
-- <a href="https://gds-payments.gelato.io/docs/versions/1.0.1/resources/general" target="blank">General functions</a> (link opens in new window)
-- <a href="https://gds-payments.gelato.io/docs/versions/1.0.1/resources/payment-id" target="blank">Payment ID functions</a> (link opens in new window)
+- <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general" target="blank">General functions</a> (link opens in new window)
+- <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id" target="blank">Payment ID functions</a> (link opens in new window)
 
-You can also use our interactive <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1//" target="blank">API Explorer</a> (link opens in new window) to try out API calls and view responses.
+You can also use our interactive <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2//" target="blank">API Explorer</a> (link opens in new window) to try out API calls and view responses.
 
 See the [Quick Start Guide](https://docs.payments.service.gov.uk/#quick-start-guide) section for how to set up the API Explorer. Make sure you enter your sandbox API key to avoid generating real payments!
 
@@ -43,7 +43,7 @@ This diagram gives an overview of the payment status lifecycle and the possible 
 
 ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/pay-transaction-states.png)
 
-You can check the status of a given payment using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/v1/find-payment-by-id" target="blank">Find payment by ID</a> API call (link opens in new window).
+You can check the status of a given payment using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id" target="blank">Find payment by ID</a> API call (link opens in new window).
 
 The response will include a ``status`` value as described in the table below, and a true/false ``finished`` value which indicates if the status can change.
 

--- a/source/documentation/07-integration-details.md
+++ b/source/documentation/07-integration-details.md
@@ -17,7 +17,7 @@ You will receive the ``next_url``  to which you should direct the user to comple
 
 ## Tracking the progress of a payment
 
-You can track the progress of a payment while the user is on GOV.UK Pay using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/v1/find-payment-by-id" target="blank">Find payment by ID</a> call (link opens in new window).
+You can track the progress of a payment while the user is on GOV.UK Pay using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id" target="blank">Find payment by ID</a> call (link opens in new window).
 
 NOTE: The status of the payment will go through several phases until it either succeeds or fails. See the [API reference section](https://docs.payments.service.gov.uk/#api-reference) for more details.
 
@@ -57,7 +57,7 @@ If a user does not have enough funds in their account to make a payment, the cur
 
 ## Cancelling a payment
 
-You can cancel a payment that is not yet in a final state by using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/payment-id/cancel-payment" target="blank">Cancel payment</a> API call (link opens in new window).
+You can cancel a payment that is not yet in a final state by using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/cancel-payment" target="blank">Cancel payment</a> API call (link opens in new window).
 
 
 ## Financial reporting integration

--- a/source/documentation/08-refunding-payments.md
+++ b/source/documentation/08-refunding-payments.md
@@ -19,7 +19,7 @@ In the sandbox, you will not see the ``pending`` status as there is no delay in 
 
 ## Payment refund status and partial refunds
 
-You can find out the refund status of a payment with the API using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/v1/find-payment-by-id" target="blank">Find payment by ID</a> or <a href="https://gds-payments.gelato.io/docs/versions/1.0.1/resources/general/endpoints/search-payments" target="blank">Search payments</a> functions (links open in new window).
+You can find out the refund status of a payment with the API using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id" target="blank">Find payment by ID</a> or <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general/endpoints/search-payments" target="blank">Search payments</a> functions (links open in new window).
 
 The response will contain a ``refund_summary`` section. Here is an example of that section of the response for a completed £50 payment with no previous refunds:
 
@@ -49,7 +49,7 @@ Here's another example:
 
 In this case, the original payment was for £90. The ``amount_available`` value shows that only £60 is available to be refunded, because £30 has already been refunded in one or more partial refunds (as shown by ``amount_submitted``).
 
-If you needed to know the details of the partial refunds (for example, whether there had been a single refund of £30 or multiple smaller refunds), you could use the API function to <a href="https://gds-payments.gelato.io/docs/versions/1.0.1/resources/payment-id/endpoints/get-all-refunds-for-a-payment" target="blank">Get all refunds for a payment</a> (link opens in new window).
+If you needed to know the details of the partial refunds (for example, whether there had been a single refund of £30 or multiple smaller refunds), you could use the API function to <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id/endpoints/get-all-refunds-for-a-payment" target="blank">Get all refunds for a payment</a> (link opens in new window).
 
 ## Specifying the expected refund available
 
@@ -69,7 +69,7 @@ When a refund request is rejected due to a refund amount available mismatch, the
 
 ## Refunding with the API
 
-You can initiate a refund with the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/payment-id/submit-a-refund-for-a-payment" target="blank">Submit a refund for a payment</a> function (link opens in new window).
+You can initiate a refund with the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/submit-a-refund-for-a-payment" target="blank">Submit a refund for a payment</a> function (link opens in new window).
 
 You need to specify the ``paymentId`` of the original payment, and provide the amount to refund (in pence).
 
@@ -84,14 +84,14 @@ You should check that the amount you attempt to refund does not exceed the ``amo
 
 Each refund has a unique ``refund_id``.
 
-You can use the <a href="https://gds-payments.gelato.io/docs/versions/1.0.1/resources/payment-id/endpoints/get-all-refunds-for-a-payment" target="blank">Get all refunds for a payment</a> function (link opens in new window) to get information all the refunds for a payment (including their ``refund_id``s).
+You can use the <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id/endpoints/get-all-refunds-for-a-payment" target="blank">Get all refunds for a payment</a> function (link opens in new window) to get information all the refunds for a payment (including their ``refund_id``s).
 
-You can retrieve information about an individual refund using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/payment-id/find-payment-refund-by-id" target="blank">Find payment refund by ID</a> function (link opens in new window).
+You can retrieve information about an individual refund using the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id" target="blank">Find payment refund by ID</a> function (link opens in new window).
 
 
 ## Handling refund errors
 
-When you try to create a refund with the API, it may fail immediately - for example if you try to refund more than the amount available. In that case, the original <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/payment-id/submit-a-refund-for-a-payment" target="blank">Submit a refund for a payment</a> request (link opens in new window) will return an error code and a description of what it means. (A refund attempt that fails like this with an error code is not assigned a refundId and is not available using <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/payment-id/find-payment-refund-by-id" target="blank">Find payment refund by ID</a> (link opens in new window)).
+When you try to create a refund with the API, it may fail immediately - for example if you try to refund more than the amount available. In that case, the original <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/submit-a-refund-for-a-payment" target="blank">Submit a refund for a payment</a> request (link opens in new window) will return an error code and a description of what it means. (A refund attempt that fails like this with an error code is not assigned a refundId and is not available using <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id" target="blank">Find payment refund by ID</a> (link opens in new window)).
 
 If accepted by GOV.UK Pay, a refund may still go on to fail at the PSP. This may happen if the card involved is cancelled or has expired, or if your account with the PSP does not have enough funds to cover the refund.
 
@@ -117,7 +117,7 @@ Initially, in a live environment, the status returned will be ``submitted``. Aft
 | error                    | It was not possible for the payment processor to make the refund.                                                  |
 
 
-To handle this, you must use <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1/payment-id/find-payment-refund-by-id" target="blank">Find payment refund by ID</a> (link opens in new window) to check the processing status of the refund until it changes to either ``success`` or ``error``.
+To handle this, you must use <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id" target="blank">Find payment refund by ID</a> (link opens in new window) to check the processing status of the refund until it changes to either ``success`` or ``error``.
 
 It will typically take 30 minutes for the status to change. We suggest you check the status after 30 minutes, and do not repeat more than once every 5 minutes.
 


### PR DESCRIPTION
All documentation links are pointing to 1.0.1 which has been deprecated by v1.0.2.
There is also no documentation specifying the expected values for the different payment type states when searching for a payment when using the api.
The payment states can be found when viewing https://govukpay-docs.cloudapps.digital/#payment-status-lifecycle, but should also be linked to in the example column for state in the gelato documentation.
The card type values can be found when viewing https://docs.payments.service.gov.uk/#card-types, but should also be linked to in the example column for card_brand in the gelato documentation.

solo @belindac