### PR TITLE
Remove exclamation mark

### DIFF
--- a/source/documentation/06-api-reference.md
+++ b/source/documentation/06-api-reference.md
@@ -22,7 +22,7 @@ For full details of each API action, see the API Browser:
 
 You can also use our interactive <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.1//" target="blank">API Explorer</a> (link opens in new window) to try out API calls and view responses.
 
-See the [Quick Start Guide](https://docs.payments.service.gov.uk/#quick-start-guide) section for how to set up the API Explorer. Make sure you enter your sandbox API key to avoid generating real payments!
+See the [Quick Start Guide](https://docs.payments.service.gov.uk/#quick-start-guide) section for how to set up the API Explorer. Make sure you enter your sandbox API key to avoid generating real payments.
 
 
 


### PR DESCRIPTION
We shouldn't use exclamation marks in government documentation. This rogue one should be a full stop.