### PR TITLE
Removes instances of login as verb

### DIFF
--- a/source/documentation/04-quick-start-guide.md
+++ b/source/documentation/04-quick-start-guide.md
@@ -29,7 +29,7 @@ This section explains how to get started with our API Explorer and make a test A
 
 The quickest way to learn about the API is to use the <a href="https://gds-payments.gelato.io/api-explorer/" target="blank">API Explorer</a> (link opens in new window) with the API key that you just created.
 
-1. Go to the <a href="https://gds-payments.gelato.io/api-explorer/" target="blank">API Explorer</a> (link opens in new window), log in, and click the “Add API Key” button.<br/><br/>
+1. Go to the <a href="https://gds-payments.gelato.io/api-explorer/" target="blank">API Explorer</a> (link opens in new window), sign in, and click the “Add API Key” button.<br/><br/>
 ![](images/pay-add-api-key.png)
 <br/><br/>
 1.  In the resulting pop-up, enter the following values:

--- a/source/documentation/06-api-reference.md
+++ b/source/documentation/06-api-reference.md
@@ -140,7 +140,7 @@ These error codes provide more information about why a request failed.
 
 The API error codes in this section are driven by payment status. You can see which payments have these error codes using either of the following methods:
 
-- log into the [GOV.UK Pay admin site](https://selfservice.payments.service.gov.uk/), go to _Transactions_ and click on a payment with a "failed", "cancelled" or "error" status.
+- Sign in to the [GOV.UK Pay admin site](https://selfservice.payments.service.gov.uk/), go to _Transactions_ and click on a payment with a "failed", "cancelled" or "error" status.
 - use the API to look at the `state` object in a payment's API response, for example:
 
     ```

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -91,7 +91,7 @@ If you want to use 3D Secure authentication for your payments, ask your Worldpay
 
 ## ePDQ setup
 
-To set up ePDQ to work with GOV.UK Pay, you must sign into the ePDQ admin site and:
+To set up ePDQ to work with GOV.UK Pay, you must sign in to the ePDQ admin site and:
 
 1. Add payment methods to your account.
 1. Set up account security parameters.

--- a/source/documentation/10-switching-to-production.md
+++ b/source/documentation/10-switching-to-production.md
@@ -79,7 +79,7 @@ The API endpoint for live is now the same as for testing: https://publicapi.paym
 
 You must change some settings in your Worldpay account to get it ready for live use.
 
-1. Log in to Worldpay and in your Worldpay profile, set *Capture delay* to "Off".<br /><br />![](images/pay-worldpay-autocaptureoff.png)
+1. Sign in to Worldpay and in your Worldpay profile, set *Capture delay* to "Off".<br /><br />![](images/pay-worldpay-autocaptureoff.png)
 2. Still in Worldpay, go to *Profile > Merchant Channel* and set the endpoint for HTTP notifications from Worldpay to GOV.UK Pay to _https://notifications.payments.service.gov.uk/v1/api/notifications/worldpay_
 <br /><br />
 Use the same URL for Test and Live channels within Worldpay. The completed settings should look like this:
@@ -91,7 +91,7 @@ If you want to use 3D Secure authentication for your payments, ask your Worldpay
 
 ## ePDQ setup
 
-To set up ePDQ to work with GOV.UK Pay, you must log into the ePDQ admin site and:
+To set up ePDQ to work with GOV.UK Pay, you must sign into the ePDQ admin site and:
 
 1. Add payment methods to your account.
 1. Set up account security parameters.
@@ -102,7 +102,7 @@ To set up ePDQ to work with GOV.UK Pay, you must log into the ePDQ admin site an
 
 ![](images/epq-2.png)
 
-1. Log into the [ePDQ admin site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index). On the homepage, go to _Configuration > Payment methods_ and select _Choose new payment methods_
+1. Sign in to the [ePDQ admin site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index). On the homepage, go to _Configuration > Payment methods_ and select _Choose new payment methods_
 
 1. Click _Add_ next to the relevant payment method.
 1. On the _Contract data_ tab:


### PR DESCRIPTION
We shouldn't use "login" or "log in" as a verb: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#sign-in-or-log-in