### PR TITLE
Remove incomplete information for sake of clarity

### DIFF
--- a/source/documentation/14-security.md
+++ b/source/documentation/14-security.md
@@ -30,10 +30,7 @@ Make sure you’ve fully tested your integration with GOV.UK Pay. When doing so,
 
 ## Securing user information
 
-GOV.UK Pay does not store full card numbers or CVV data for security reasons. This means you will not be able to search for transactions using card numbers. You’ll only be able to look up certain transactions using the:
-
- - payment ID
- - reference metadata put into the system when creating the payment ID
+GOV.UK Pay does not store full card numbers or CVV data for security reasons. This means you will not be able to search for transactions using card numbers.
 
 ## Payment Card Industry (PCI) compliance
 


### PR DESCRIPTION
@katiebates commented that:

> for looking up individual payments, this is true, but you can also search transactions by email address, card brand, from/to date, reference and state. also soon you'll be able to search by last 4 digits (and cardholder name), since we do store this info.

For this reason, I recommend the best change as far as this [section of the] documentation is concerned is to remove the line with incomplete information.

Unless we do need to add all of this. Once I can add Katie as a reviewer I'll need to add her to review this. 