### PR TITLE
Adds search in Gemfile and config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
-gem 'govuk_tech_docs', '1.5.0'
+gem 'govuk_tech_docs', :git => 'https://github.com/alphagov/tech-docs-gem.git', ref:'de0c518324f01cbb107fcd5dc685a44cdca4ac00'
+gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'
 
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,30 @@
+GIT
+  remote: git://github.com/alphagov/middleman-search.git
+  revision: 50d072378c6f92a78ea02fed366ec6453aea8552
+  specs:
+    middleman-search (0.10.0)
+      execjs (~> 2.6)
+      middleman-core (>= 3.2)
+      nokogiri (~> 1.6)
+
+GIT
+  remote: https://github.com/alphagov/tech-docs-gem.git
+  revision: de0c518324f01cbb107fcd5dc685a44cdca4ac00
+  ref: de0c518324f01cbb107fcd5dc685a44cdca4ac00
+  specs:
+    govuk_tech_docs (1.5.0)
+      activesupport
+      chronic (~> 0.10.2)
+      middleman (~> 4.0)
+      middleman-autoprefixer (~> 2.7.0)
+      middleman-compass (>= 4.0.0)
+      middleman-livereload
+      middleman-search
+      middleman-sprockets (~> 4.0.0)
+      middleman-syntax (~> 3.0.0)
+      nokogiri
+      redcarpet (~> 3.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -41,18 +68,6 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.3)
     ffi (1.9.25)
-    govuk_tech_docs (1.5.0)
-      activesupport
-      chronic (~> 0.10.2)
-      middleman (~> 4.0)
-      middleman-autoprefixer (~> 2.7.0)
-      middleman-compass (>= 4.0.0)
-      middleman-livereload
-      middleman-search
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.0.0)
-      nokogiri
-      redcarpet (~> 3.3.2)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -110,10 +125,6 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    middleman-search (0.10.0)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
-      therubyracer (~> 0.12.2)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -163,10 +174,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs (= 1.5.0)
+  govuk_tech_docs!
+  middleman-search!
   therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -28,4 +28,6 @@ max_toc_heading_level: 8
 google_site_verification: "IJ5HOXpZrISM6la-YO_iX0rBUC5YFftpexygcKLsNs4"
 
 multipage_nav: true
-collapsible_nav: true 
+collapsible_nav: true
+
+enable_search: true


### PR DESCRIPTION
This is testable at https://govukpay-docs-test.cloudapps.digital/

This hasn't yet been published to Rubygems and should still be considered an experimental feature. There are still outstanding issues concerning the indexing of section titles (try searching "Payment links") for example. 

Nonetheless, if we are continuing with multi-page then we should have a search function. 

For further context, contract work has recently been completed on the tech docs tool: this is what has given us multi-page, search, and upcoming API reference functionality. 

We need to use an experimental Gemfile to get search until a new version is published to Rubygems, which should happen soon. (See changes to the Gemfile in this PR). 