### PR TITLE
Simplify support information

### DIFF
--- a/source/documentation/16-support-contact-and-more-information.md
+++ b/source/documentation/16-support-contact-and-more-information.md
@@ -1,28 +1,8 @@
-# Support, contact and more information
+# Support
 
-## Support hours and service
+## Incident severity 
 
-In hours:
-
-- On site support: Mon-Fri 9.30am-5.30pm
-- Full support of GOV.UK Pay for all ticket priorities
-- 2 dedicated support people, with additional cover from the whole team as required
-
-Out of hours:
-
-- On call support: Mon-Fri 5.30pm-9.30am Sat-Sun 24x7
-- P1 priority only
-- 2 dedicated on call support people, with escalation as necessary
-
-## Asking for support
-
-You can ask for support via email. The severity of the incident affects who you should ask for support:
-
-- For all non-P1 support queries, get in touch by emailing [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). This will raise a support ticket.
-
-- In emergencies, Service teams can raise a P1 incident by emailing us. This will raise a high priority ticket and __could alert the team in the middle of the night, so please only use it for P1 incidents__. Please do not share this address with people outside your team.
-
-Incident severity is defined below:
+GOV.UK Pay incident severities are defined as follows:
 
 | Classification | AKA | Example | Initial response time | Update Time |
 | :--- | :--- | :--- | :--- | :--- |
@@ -31,77 +11,31 @@ Incident severity is defined below:
 | P3 | Significant | Users experiencing intermittent or degraded service due to platform issue | 1 business day or next working day | 2 business days |
 | P4 | Minor | Component failure that is not immediately service impacting | 2 business days | weekly |
 
-Please always raise support tickets using the email addresses supplied above rather than relying on a personal email address. This ensures your issue will be dealt with as soon as possible.
+## Hours of service
 
-Support requests are raised both automatically and manually. Our automated monitoring and system alerts feed into our helpdesk ticketing system.
+In-hours support is from Monday-Friday 9:30am-5:30pm and covers all ticket priorities (P1-4). 
 
-## Communication
+Out-of-hours support covers P1 support tickets only, during:
 
-The Pay support team will contact you via two methods:
+- Monday-Friday 5:30pm-9:30am
+- Saturday-Sunday 24x7
 
-1. If you have raised a support request, we will communicate with you individually using our Zendesk ticketing system via [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). This will ensure that you are not relying on a single individual for comms.
+## Contact us 
 
-2. We will provide general incident updates to all GOV.UK Pay users through an email mailing list. All users of GOV.UK Pay will be subscribed to this list. You can choose to unsubscribe, but should ensure that anyone who needs to know about incident or maintenance alerts is subscribed. If you would like someone subscribed to this list please email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+If you raise a support request, a member of the GOV.UK Pay team will contact you using
+Zendesk.  
 
-## Who deals with support issues
+### P1 support queries (critical incidents)
 
-At all times, we have a dedicated Support Lead and Secondary (rotated weekly) who draw on additional support as required from other members of the team.
+For P1 support queries, you will receive instructions from us when you
+sign on as a partner. 
 
-Additionally, a manager will act as the Support escalation route.
+### P2-P4 support queries (non-critical incidents) 
 
-For an incident, an Incident Lead and an Incident Comms person will be assigned.
+For all non-P1 support queries, contact us via email at
+[govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-## How do we respond
+### General feedback 
 
-In general, our priority is to ensure high availability of the service.
+If you have any feedback or questions, please email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). 
 
-However, in the event of a critical P1 incident we may need to isolate the issue and take GOV.UK Pay offline in order to minimise any security breach until we can investigate fully.
-
-For general or non urgent support queries our service levels are:
-
-| First reply service level | First resolution service level |
-| :--- | :--- |
-| 80% within two working days | 80% within 5 working days |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
-## Resolution and Closure
-
-For all incidents:
-
-- Resolution occurs when the Incident Lead, in consultation with the initiator, confirms that the matter reported is no longer impacting the service.
-- Any follow up work will be tracked as part of business as usual.
-- An incident post mortem will be held for all P1 incidents, and for any others where one is needed. The outputs will be made available to our beta partners.
-
-## Feedback on support matters
-
-If we are not responding to your requests for support in the way that you would expect or your problem is not addressed in this documentation, please [email us](mailto:govuk-pay-support@digital.cabinet-office.gov.uk), including any error messages you’re getting.
-
-## Newsletter and blogs
-
-GOV.UK Pay publishes a newsletter every few weeks. This will help you stay updated with any new features we release.
-
-We’ll also blog about our progress using the [Government as a Platform blog](https://governmentasaplatform.blog.gov.uk/) or the [GDS blog](https://gds.blog.gov.uk/).
-
-Posts we've published are:
-
- - [Introducing GOV.UK Pay](https://gds.blog.gov.uk/2015/10/15/introducing-gov-uk-pay/)
- - [Making payments more convenient and efficient](https://gds.blog.gov.uk/2015/07/23/making-payments-more-convenient-and-efficient/)
- - [Building GOV.UK Pay](https://governmentasaplatform.blog.gov.uk/2016/03/31/building-pay/)
- - [Partners in research](https://governmentasaplatform.blog.gov.uk/2016/06/30/partners-in-research/)
- - [Building trust in online card payments](https://governmentasaplatform.blog.gov.uk/2016/04/21/trust-online-payments/)
- - [A hack day to test Government as a Platform](https://gds.blog.gov.uk/2016/02/05/a-hack-day-to-test-government-as-a-platform/)
- - [GOV.UK Pay gets Payment Card Industry (PCI) accreditation](https://governmentasaplatform.blog.gov.uk/2016/07/29/pay-pci-accreditation/)
- - [GOV.UK Pay is ready for business](https://governmentasaplatform.blog.gov.uk/2016/09/16/ready-for-business/)
-
-## Press coverage
-More coverage of the platform can be found in press reports. Published articles include:
-
- - Computer Weekly [unveiling the payments platform](http://www.computerweekly.com/news/4500250431/GDS-unveils-payments-platform-protoype-in-government-as-a-platform-strategy) (23 July 2015)
- - Government Computing [writing about the prototype](http://central-government.governmentcomputing.com/news/gds-develops-payments-platform-prototype-4630065) (23 July 2015)
- - Payment Eye [outlining our 4 main goals](http://www.paymenteye.com/2015/07/24/uk-government-develops-prototype-payments-platform/) (24 July 2015)
- - Diginomica on [how GOV.UK fits with the government as a platform strategy](http://diginomica.com/2015/08/13/gds-government-as-a-platform-ambitions-are-misunderstood-its-not-about-control/#.VjoZK6RD014) (18 August 2015)
- - IT Pro covering [our first partnerships](http://www.itpro.co.uk/government-it-strategy/25031/gds-payment-tool-govuk-pay-enters-beta-testing) (15 October 2015)
- - Computer Weekly writing about [our background and launch](http://www.computerweekly.com/news/4500255549/GDS-payments-platform-Govuk-Pay-to-start-taking-real-payments) (15 October 2015)
- - UKAuthority.com covering our [move into beta](http://www.ukauthority.com/news/5700/common-payments-platform-moves-into-beta) (16 October 2015)
- - Computer Weekly [interviews GOV.UK Pay's Product Manager](http://www.computerweekly.com/news/4500272567/Interview-Till-Wirth-product-manager-Govuk-Pay-at-GDS) (11 February 2016)

--- a/source/documentation/16-support-contact-and-more-information.md
+++ b/source/documentation/16-support-contact-and-more-information.md
@@ -25,17 +25,17 @@ Out-of-hours support covers P1 support tickets only, during:
 
 ## Contact us 
 
-If you raise a support request, a member of the GOV.UK Pay team will contact you using
-Zendesk.  
+If you raise a support request, the GOV.UK Pay team will contact you using the 
+Zendesk ticketing system. 
 
 ### P1 support queries (critical incidents)
 
-For P1 support queries, you will receive instructions from us when you
+For P1 support requests, you will receive instructions from us when you
 sign on as a partner. 
 
 ### P2-P4 support queries (non-critical incidents) 
 
-For all non-P1 support queries, contact us via email at
+For all non-P1 support requests, contact us via email at
 [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
 ### General feedback 

--- a/source/documentation/16-support-contact-and-more-information.md
+++ b/source/documentation/16-support-contact-and-more-information.md
@@ -1,5 +1,8 @@
 # Support
 
+You can subscribe to our public status page for updates on the status of our system:
+https://payments.statuspage.io/
+
 ## Incident severity 
 
 GOV.UK Pay incident severities are defined as follows:

--- a/source/documentation/16-support-contact-and-more-information.md
+++ b/source/documentation/16-support-contact-and-more-information.md
@@ -21,7 +21,7 @@ In-hours support is from Monday-Friday 9:30am-5:30pm and covers all ticket prior
 Out-of-hours support covers P1 support tickets only, during:
 
 - Monday-Friday 5:30pm-9:30am
-- Saturday-Sunday 24x7
+- Saturday-Sunday and bank holidays 24x7
 
 ## Contact us 
 


### PR DESCRIPTION
Proposal to simplify the information in the 'support' section. Much of this is duplicated unnecessarily from what's sent to partners when they sign on, some is incorrect or outdated, and some doesn't conform to our house style. 