### PR TITLE
Style/language changes in 'Contribute' page

### DIFF
--- a/source/documentation/15-contribute.md
+++ b/source/documentation/15-contribute.md
@@ -1,12 +1,12 @@
 # Contribute
 
-GOV.UK Pay's main application code is public and freely available under an [MIT Licence](https://en.wikipedia.org/wiki/MIT_License) and the GOV.UK Pay team [codes in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/) in our [GitHub account](https://github.com/alphagov?q=pay-).
+GOV.UK Pay's main application code is public and freely available under an MIT License and the GOV.UK Pay team [codes in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). You can [find us on GitHub](https://github.com/alphagov?q=pay-).
 
-We are experimenting with taking in Open Source contributions from our live partner services and we hope to widen this further  after learning more about integrating outside contributions into our workflow.
+We are experimenting with taking in open-source contributions from our live partner services. We hope to widen this further  after learning more about integrating external contributions into our workflow.
 
->If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you: please [email us](mailto:govuk-pay-support@digital.cabinet-office.gov.uk)
+>If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you. Please email us at [mailto:govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-## Key Open Source components
+## Open-source components on GOV.UK Pay
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 


### PR DESCRIPTION
- 'MIT License' is a proper noun and should be treated in US English
- The MIT License link shouldn't go to a Wikipedia page: in this case we shouldn't actually need to link to a generic page and it would be far better if we could link to our actual licence 
- 'Open source' should not be capitalised and should be hyphenated when used as compound adjective
- We shouldn't use "email us" as a link; it should be spelled out fully per GOV.UK style 
- The header 'Open-source components on GOV.UK Pay' gets the point across better
- Other minor language changes