### PR TITLE
Change link to Wikipedia page re. PSPs to one from FCA

### DIFF
--- a/source/documentation/02-about-govuk-pay.md
+++ b/source/documentation/02-about-govuk-pay.md
@@ -4,7 +4,7 @@ GOV.UK Pay is currently in beta development. The payment pages are responsive
 and work on both desktop and mobile.
 
 The platform can connect your service to different [payment service providers
-(PSPs)](https://en.wikipedia.org/wiki/Payment_service_provider).
+(PSPs)](https://www.handbook.fca.org.uk/handbook/glossary/G2619.html).
 
 During beta, GOV.UK Pay will support credit and debit card payments only. Over
 time, further payment methods, such as direct debit or eWallet, will be added.


### PR DESCRIPTION
### Context
The current landing page links to a Wikipedia article on PSPs; if possible, we should try to avoid using Wikipedia links since they can be easily edited by anybody, in theory 

### Changes proposed in this pull request
Changes Wikipedia link to an FCA one: https://www.handbook.fca.org.uk/handbook/glossary/G2619.html
