### PR TITLE
Remove link to Wikipedia

### DIFF
--- a/source/documentation/02-about-govuk-pay.md
+++ b/source/documentation/02-about-govuk-pay.md
@@ -3,8 +3,8 @@ GOV.UK Pay makes it easy for public sector organisations to take payments. It pr
 GOV.UK Pay is currently in beta development. The payment pages are responsive
 and work on both desktop and mobile.
 
-The platform can connect your service to different [payment service providers
-(PSPs)](https://en.wikipedia.org/wiki/Payment_service_provider).
+The GOV.UK platform can connect your service to different payment service providers
+(PSPs), which give merchants a way to accept electronic payments. Acquiring banks partner with PSPs to provide this service, or can act as PSPs themselves. Acquiring banks (or ‘acquirers’) are members of a card network such as MasterCard or Visa. They process credit or debit card transactions through these networks on behalf of a merchant.  
 
 During beta, GOV.UK Pay will support credit and debit card payments only. Over
 time, further payment methods, such as direct debit or eWallet, will be added.

--- a/source/documentation/02-about-govuk-pay.md
+++ b/source/documentation/02-about-govuk-pay.md
@@ -4,7 +4,7 @@ GOV.UK Pay is currently in beta development. The payment pages are responsive
 and work on both desktop and mobile.
 
 The GOV.UK platform can connect your service to different payment service providers
-(PSPs), which give merchants a way to accept electronic payments. Acquiring banks partner with PSPs to provide this service, or can act as PSPs themselves. Acquiring banks (or ‘acquirers’) are members of a card network such as MasterCard or Visa. They process credit or debit card transactions through these networks on behalf of a merchant.  
+(PSPs).
 
 During beta, GOV.UK Pay will support credit and debit card payments only. Over
 time, further payment methods, such as direct debit or eWallet, will be added.


### PR DESCRIPTION
### Context
The existing content describes PSPs using a Wikipedia link, which is also un-cited. 

This is an alternative to https://github.com/alphagov/pay-tech-docs/pull/139

### Changes proposed in this pull request
I wrote some content about PSPs. This would serve as an alternative to https://github.com/alphagov/pay-tech-docs/pull/139

See also: ongoing discussions re. whether we should carry on using a glossary