### PR TITLE
Remove link to Wikipedia

### DIFF
--- a/source/documentation/about-govuk-pay.md
+++ b/source/documentation/about-govuk-pay.md
@@ -3,8 +3,8 @@ GOV.UK Pay makes it easy for public sector organisations to take payments. It pr
 GOV.UK Pay is currently in beta development. The payment pages are responsive
 and work on both desktop and mobile.
 
-The platform can connect your service to different [payment service providers
-(PSPs)](https://en.wikipedia.org/wiki/Payment_service_provider).
+The platform can connect your service to different payment service providers
+(PSPs).
 
 During beta, GOV.UK Pay will support credit and debit card payments only. Over
 time, further payment methods, such as direct debit or eWallet, will be added.


### PR DESCRIPTION
### Context
We shouldn't link to an uncited Wikipedia article. We could write our own content, but it would detract from the point of this page. We could link to somewhere like the FCA's definition, but it's not as good as Wikipedia. On balance, the best/simplest thing to do is to expect that users will look elsewhere for this definition, if they actually need it. If we see a clearly articulated user need for this, we can reintroduce it at a later time.


### Changes proposed in this pull request
Remove link to uncited Wikipedia article.
