### PR TITLE
Remove unnecessary links in 'Prerequisites' for payment links

### DIFF
--- a/source/documentation/payment-links.md
+++ b/source/documentation/payment-links.md
@@ -9,7 +9,7 @@ You may want to use payment links rather than integrate with the GOV.UK Pay API 
 
 ### Prerequisites
 
-Before you set up a payment link, you must have a [live service](/switching_to_production/#switching-to-live). You do not need an [API key](/#generate-api-key-for-api-explorer) or to use the [API explorer](/#api-explorer-setup).
+Before you set up a payment link, you must have a [live service](/switching_to_production/#switching-to-live). 
 
 ### Create a payment link
 


### PR DESCRIPTION

### Context
These are for things you don't need, so there's no need for them in a 'prerequisites' section


### Changes proposed in this pull request
Removes unnecessary links

