### PR TITLE
Fix broken "payment links" link

### DIFF
--- a/source/documentation/payment-flow-overview.md
+++ b/source/documentation/payment-flow-overview.md
@@ -2,7 +2,7 @@
 
 This section outlines how your service will interact with GOV.UK Pay after integration.
 
->This does not apply to users who use the [self-service payments](/quick_start_guide//#self-service-payments) functionality.
+>This does not apply to users who use the [payment links](/payment_links/#payment-links) functionality.
 
 ## Overview 
 


### PR DESCRIPTION
### Context
Broken link after we moved 'payment links' to own section

### Changes proposed in this pull request
Fixes link
