### PR TITLE
Remove 'case studies' section

### DIFF
--- a/source/case_studies/index.html.md.erb
+++ b/source/case_studies/index.html.md.erb
@@ -1,6 +1,0 @@
----
-title: Case studies
-weight: 170
----
-
-<%= partial 'documentation/case-studies' %>

--- a/source/documentation/case-studies.md
+++ b/source/documentation/case-studies.md
@@ -1,5 +1,0 @@
-# Case Studies
-
-We’re looking forward to producing these. Please bear with us.
-
->If you are a beta partner and think your service could to be featured in our case study section, please contact us.


### PR DESCRIPTION
### Context
Removes the case studies section. I've been through the links in the rest of the documentation and haven't found any links to this, so this should be sufficient. I've also built this locally to test, and nothing breaks. 

### Changes proposed in this pull request
Removes the files in the docs that render as the case studies section. 