### PR TITLE
Attempt to standardise naming to GOV.UK Pay throughout

### DIFF
--- a/source/documentation/about-govuk-pay.md
+++ b/source/documentation/about-govuk-pay.md
@@ -19,7 +19,7 @@ The platform currently supports one-off payments (like fees, fines or licence
 payments). In the future, it will also support recurring payments, for
 example, monthly tax payments.
 
-The GOV.UK Pay platform does not currently support payments to cardholders, for example, payments of benefits, or grants. The platform only supports taking payments, or providing refunds.
+GOV.UK Pay does not currently support payments to cardholders, for example, payments of benefits, or grants. The platform only supports taking payments, or providing refunds.
 
 There are ten departments and agencies currently partnering with the platform:
 

--- a/source/documentation/api-reference.md
+++ b/source/documentation/api-reference.md
@@ -1,6 +1,6 @@
 # API reference
 
-The GOV.UK Pay platform is based on REST principles with endpoints returning data in JSON format, and standard HTTP error response codes. The platform API allows you to:
+GOV.UK Pay is based on REST principles with endpoints returning data in JSON format, and standard HTTP error response codes. The platform API allows you to:
 
 - initiate and complete payments
 - view the event history for individual payments
@@ -60,7 +60,7 @@ The response will include a ``status`` value as described in the table below, an
 
 ## HTTP status codes
 
-You will encounter typical HTTP success and error response codes when using the Pay API. Generally any:
+You will encounter typical HTTP success and error response codes when using the GOV.UK Pay API. Generally any:
 
 - 100 code is informational
 - 200 code indicates you’ve been successful

--- a/source/documentation/before-you-start.md
+++ b/source/documentation/before-you-start.md
@@ -1,12 +1,12 @@
 # Before you start
 
-To start using the GOV.UK Pay platform, you'll need:
+To start using GOV.UK Pay, you'll need:
 
 - a service that needs to process payments
 - a [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/create-service/register) 
 - a service team with the development skills to build the technical integration between your service and GOV.UK Pay; refer to the [Service Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have) for more information (this does not apply if you only use [payment links](/payment_links/#payment-links))
   
-Check the [Getting Started guide](https://www.payments.service.gov.uk/getstarted/) to ensure that your team is ready to start using the GOV.UK Pay platform.
+Check the [Getting Started guide](https://www.payments.service.gov.uk/getstarted/) to ensure that your team is ready to start using GOV.UK Pay.
 
 Make sure you’re also familiar with the government guidance on [deploying new software](https://www.gov.uk/service-manual/making-software/deployment.html).
 
@@ -18,7 +18,7 @@ The time taken to integrate will vary depending on team and capability; for exam
 
 ## Try the service out
 
-You can try the GOV.UK Pay service before integrating with the API. 
+You can try GOV.UK Pay before integrating with the API. 
 
 You must be logged into a GOV.UK Pay __test__ account to try these features out.
 

--- a/source/documentation/payment-flow-overview.md
+++ b/source/documentation/payment-flow-overview.md
@@ -41,7 +41,7 @@ This page should make it clear to the user that they are about to pay for your p
 
 The page should include clear information on what is being purchased. You do not need to tell the user that they are being handed over to GOV.UK Pay’s pages to make their payment.
 
-When the user clicks **Continue** in the example page, the service makes a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment" target="blank">Create new payment</a> call to the Pay API (link opens in new window). The body of the call contains information in JSON format. 
+When the user clicks **Continue** in the example page, the service makes a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment" target="blank">Create new payment</a> call to the GOV.UK Pay API (link opens in new window). The body of the call contains information in JSON format. 
 
 For example:
 

--- a/source/documentation/quick-start-guide.md
+++ b/source/documentation/quick-start-guide.md
@@ -1,6 +1,6 @@
 # Quick start guide
 
-The GOV.UK Pay platform is based on REST principles with endpoints returning data in JSON format, and standard HTTP error response codes. The platform API allows you to:
+GOV.UK Pay is based on REST principles with endpoints returning data in JSON format, and standard HTTP error response codes. The platform API allows you to:
 
 - initiate and complete payments
 - issue refunds
@@ -73,7 +73,7 @@ The ``return_url`` is the URL of a page on your service that the user will be re
 
 1. Submit the payment.
 
-## View transaction at GOV.UK Pay Admin site
+## View transaction at GOV.UK Pay admin site
 
 1. Go to the [service admin site](https://selfservice.payments.service.gov.uk/) and select **Transactions**. 
 

--- a/source/documentation/security.md
+++ b/source/documentation/security.md
@@ -8,7 +8,7 @@ Please do not disclose the suspected breach publicly until it has been fixed.
 
 ## Securing your developer keys
 
-The GOV.UK Pay platform will let you create as many API keys as you want.
+GOV.UK Pay will let you create as many API keys as you want.
 
 We suggest letting all your developers experiment with their own test keys in the Sandbox environment, but keys for real integrations should only be shared with the minimum number of people necessary. This is because these keys can be used to create and manipulate payments. Do not commit these keys to public source code repositories.
 
@@ -55,7 +55,7 @@ Your requirements depend on the number of transactions that you process as a mer
 
 If you process fewer than 6 million transactions per scheme per year, you may be able to self-assess by completing one of the PCI DSS Self-Assessment Questionnaire (SAQ); this is a self-assessment tool to assess security for cardholder data.
 
-When using the GOV.UK Pay service, the SAQ A questionnaire should apply. You should be eligible to complete the SAQ A questionnaire if you fulfil all the eligibility criteria and comply with SAQ A requirements 2, 8, 9 and 12:
+When using GOV.UK Pay, the SAQ A questionnaire should apply. You should be eligible to complete the SAQ A questionnaire if you fulfil all the eligibility criteria and comply with SAQ A requirements 2, 8, 9 and 12:
 
 - the SAQ A questionnaire can be found in the [PCI documents library](https://www.pcisecuritystandards.org/document_library) [external link]
 - more detailed information on meeting requirements 2 and 8 can be found in [this article](https://pcissc.secure.force.com/faq/articles/Frequently_Asked_Question/How-do-PCI-DSS-Requirements-2-and-8-apply-to-SAQ-A-merchants) [external link]

--- a/source/documentation/versioning.md
+++ b/source/documentation/versioning.md
@@ -2,20 +2,20 @@
 
 The current version of the GOV.UK Pay API is 1.0.2.
 
-When we add new properties to the JSON responses, the Pay API version number will not change. You should develop your service to ignore properties it does not understand.
+When we add new properties to the JSON responses, the GOV.UK Pay API version number will not change. You should develop your service to ignore properties it does not understand.
 
-New, dated versions of the public API will be released if JSON values are removed in a backwards incompatible manner. All these versions of the Pay API will be documented in our Revision History table below.
+New, dated versions of the public API will be released if JSON values are removed in a backwards incompatible manner. All these versions of the GOV.UK Pay API will be documented in our Revision History table below.
 
 Our version number will be updated in the URL when there is a release. All releases will be marked with full version numbers.
 
 
-## Updating to the latest Pay API
+## Updating to the latest GOV.UK Pay API
 
 We’ll send you an email to let you know about any new versions of our API.
 
 If you want to update to our latest API, make sure you test your code before committing to the change.
 
->We’ll support each version of the early beta Pay API for at least 1 month after we issue an upgrade notice. As the API matures, we may increase this support period to 3 or 6 months.
+>We’ll support each version of the early beta GOV.UK Pay API for at least 1 month after we issue an upgrade notice. As the API matures, we may increase this support period to 3 or 6 months.
 
 Soon, we hope to let you check which version of our API you’re currently running by checking your dashboard.
 


### PR DESCRIPTION
### Context
There are discrepancies in naming ("Pay", "GOV.UK Pay", "The GOV.UK Pay platform" etc.). It should be "GOV.UK Pay" throughout. 

### Changes proposed in this pull request
Attempt to standardise to "GOV.UK Pay". 