### PR TITLE
Fixes title of Optional Features section

### DIFF
--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Versioning 
+title: Optional features
 weight: 130
 ---
 


### PR DESCRIPTION
### Context
Searching for things under the new "Optional Features" section (for example "Welsh") indexes the wrong section 

### Changes proposed in this pull request
A fix for the title 