### PR TITLE
First attempt at drafting some content on not needing HTTPS for sandbox

### DIFF
--- a/source/documentation/security.md
+++ b/source/documentation/security.md
@@ -82,4 +82,6 @@ Your service manager may also be asked to supply extra evidence on your internal
 
 GOV.UK Pay follows [government HTTPS security guidelines](https://www.gov.uk/service-manual/domain-names/https.html). The Hypertext Transfer Protocol Secure (HTTPS), which involves the Transport Layer Security  (TLS) protocol is used by the platform to authenticate servers / clients and to provide secure connections.
 
-Your government service will only be able to integrate with the GOV.UK Pay if it also uses HTTPS.
+To take a payment with a live GOV.UK Pay account, you must use HTTPs. 
+
+To take a payment with a sandbox account, [you can use HTTP](/testing_govuk_pay/#testing-gov-uk-pay).

--- a/source/documentation/security.md
+++ b/source/documentation/security.md
@@ -82,6 +82,8 @@ Your service manager may also be asked to supply extra evidence on your internal
 
 GOV.UK Pay follows [government HTTPS security guidelines](https://www.gov.uk/service-manual/domain-names/https.html). The Hypertext Transfer Protocol Secure (HTTPS), which involves the Transport Layer Security  (TLS) protocol is used by the platform to authenticate servers / clients and to provide secure connections.
 
-To take a payment with a live GOV.UK Pay account, you must use HTTPs. 
+You must use HTTPS for all direct communication between your service and
+GOV.UK Pay. 
 
-To take a payment with a sandbox account, [you can use HTTP](/testing_govuk_pay/#testing-gov-uk-pay).
+Return URLs for live services using GOV.UK Pay must use HTTPS, but [you can use HTTP for return
+URLs with sandbox accounts](/testing_govuk_pay/#testing-gov-uk-pay).

--- a/source/documentation/testing-govuk-pay.md
+++ b/source/documentation/testing-govuk-pay.md
@@ -9,6 +9,11 @@ When testing, you’ll need to ensure:
  - REST calls succeed with 200 API codes
  - you’ve tested the user journey from your service to the payments platform using end-to-end/smoke tests
 
+You can make payments using HTTP with sandbox accounts, when testing. 
+
+If you make your account live, you [must use HTTPS](/security/#https) to make
+payments.  
+
 ## Integration testing
 
 To check your integration with GOV.UK Pay is working as expected, you’ll need to run a series of tests.

--- a/source/documentation/testing-govuk-pay.md
+++ b/source/documentation/testing-govuk-pay.md
@@ -9,7 +9,7 @@ When testing, you’ll need to ensure:
  - REST calls succeed with 200 API codes
  - you’ve tested the user journey from your service to the payments platform using end-to-end/smoke tests
 
-Services that use sandbox accounts can optionally use HTTP (rather than HTTPS)
+Services testing with sandbox accounts can optionally use HTTP (rather than HTTPS)
 for return URLs. You can read more about this in [the "Security"
 section](/security/#https). 
 

--- a/source/documentation/testing-govuk-pay.md
+++ b/source/documentation/testing-govuk-pay.md
@@ -9,10 +9,9 @@ When testing, you’ll need to ensure:
  - REST calls succeed with 200 API codes
  - you’ve tested the user journey from your service to the payments platform using end-to-end/smoke tests
 
-You can make payments using HTTP with sandbox accounts, when testing. 
-
-If you make your account live, you [must use HTTPS](/security/#https) to make
-payments.  
+Services that use sandbox accounts can optionally use HTTP (rather than HTTPS)
+for return URLs. You can read more about this in [the "Security"
+section](/security/#https). 
 
 ## Integration testing
 


### PR DESCRIPTION
### Context
@tillwirth asked me to specify in the documentation that it's possible to use HTTP with sandbox accounts when making payments.

### Changes proposed in this pull request
First attempt at restructuring some parts of the documentation to reflect the above request, mindful that we still enforce HTTPS for live accounts.

### Guidance to review
Needs review from the product side and/or tech side to verify the language makes sense. 