### PR TITLE
Minor language changes in delayed capture

### DIFF
--- a/source/documentation/delayed_capture.md
+++ b/source/documentation/delayed_capture.md
@@ -1,8 +1,8 @@
 GOV.UK Pay supports the delayed capture of payments.
 
-To use delayed capture, include `"delayed_capture": true` in the body of a [create new payment](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment) [external link] request.
+To use this feature, include `"delayed_capture": true` in the body of a [create new payment](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment) request (link opens in new window). 
 
-The user experience matches the current payment flow. Once the user selects “Confirm” on the “Confirm your details” page, your service can send a delayed capture request by calling the `POST /v1/payments/{paymentId}/capture` endpoint.
+The user experience matches the current payment flow. Once the user selects __Confirm__ on the __Confirm your details__ page, your service can call the `POST /v1/payments/{paymentId}/capture` endpoint to send a delayed capture request.
 
 There are 4 possible responses:
 
@@ -17,6 +17,6 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 90 minutes of when the payment is created, regardless of how long the user takes to complete the payment flow, or it will expire.
+Your service must send the delayed capture request within 90 minutes of the payment creation, regardless of how long the user takes to complete the payment flow. Otherwise, it will expire.
 
 If your service has enabled payment receipt emails, GOV.UK Pay will send a payment receipt email to the user once your service's capture request is received and accepted.


### PR DESCRIPTION
### Context
The new delayed capture content in the optional features section needed some minor changes to bring it in line stylistically with the rest of the docs. Some interface text needed emboldening. 

### Changes proposed in this pull request
Removes some small passive language parts and amends an interface text section to bold