### PR TITLE
Fix link

### DIFF
--- a/source/documentation/quick-start-guide.md
+++ b/source/documentation/quick-start-guide.md
@@ -23,7 +23,9 @@ This section explains how to get started with our API Explorer and make a test A
 <br /><br />Your API key will be shown on the screen for you to copy.<br /><br /> ![](images/NewKeygenerate+image+3.png)
 
 
-<blockquote>You must store your API keys away securely. Make sure you never share this key in publicly accessible documents or repositories, or with people who should not be using the GOV.UK Pay API directly. [Read our security section](/security/#security) for more information on how to keep your API key safe.</blockquote>
+<blockquote>You must store your API keys away securely. Make sure you never share this key in publicly accessible documents or repositories, or with people who should not be using the GOV.UK Pay API directly.</blockquote>
+ 
+[Read the "Security" section](/security/#security) for more information on how to keep your API key safe.
 
 ## API Explorer setup
 


### PR DESCRIPTION
### Context
This doesn't render properly live because it's in a blockquote. See: https://docs.payments.service.gov.uk/quick_start_guide/#generate-api-key-for-api-explorer

### Changes proposed in this pull request
Fixes link, adopts new standard for referencing sections

### Guidance to review
I will do a more wholesale review of this and other sections in time; this is just a fix of something obviously broken for now 