### PR TITLE
Renames integration details section

### DIFF
--- a/source/taking_payments/index.html.md.erb
+++ b/source/taking_payments/index.html.md.erb
@@ -1,13 +1,9 @@
 ---
-title: Integration details
+title: Making payments 
 weight: 70
 ---
 
-# Integration details
-
-This section gives more technical detail about how to integrate your service with GOV.UK Pay.
-
-## Creating a payment
+# Making payments
 
 When you make a payment, you will need to supply a ``reference``. This is a unique identifier for the payment. If your organisation already has an existing identifier for payments, you can use it here.
 


### PR DESCRIPTION
### Context
A quick fix to rename the "Integration details" section to 'Making payments'. In the long run we'll likely revisit this section but for the time being @heathd and @tillwirth concluded (and I concur) that "Integration details" isn't an appropriate title for the section 

### Changes proposed in this pull request
Renames to "Making payments" and removes preamble section