### PR TITLE
New landing page for documentation

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,16 +3,21 @@ title: Documentation – GOV.UK Pay
 weight: 10
 ---
 
-# GOV.UK Pay technical documentation 
+# GOV.UK Pay documentation 
 
-You can use this technical documentation as a reference if you are a user of
-the GOV.UK Pay platform. 
+If you are a user of the GOV.UK Pay platform, you can use this documentation
+as a reference. 
 
 Use the left-hand navigation bar to move to different sections of the
 documentation.
 
-If you are new to GOV.UK Pay, you can read about it on [our features
-page](https://www.payments.service.gov.uk/features).
+## New to GOV.UK Pay 
+
+If you are new to GOV.UK Pay, you can read all about the platform on our
+[product page](https://www.payments.service.gov.uk/) and our [features
+page](https://www.payments.service.gov.uk/features). 
+
+You can also [contact us](/support_contact_and_more_information/#contact-us).
 
 ## How many services are using GOV.UK Pay? 
 
@@ -21,5 +26,5 @@ dashboard](https://www.gov.uk/performance/govuk-pay).
 
 ## How much does it cost?
 
-There is no charge to use GOV.UK Pay. You will still need to pay your PSP's
-transaction fees.
+There is no charge to use GOV.UK Pay. You will still need to pay your payment
+service provider's (PSP's) transaction fees.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -11,12 +11,8 @@ the GOV.UK Pay platform.
 Use the left-hand navigation bar to move to different sections of the
 documentation.
 
-GOV.UK Pay is a free and secure online payment service for government and
-public sector organisations. The platform can connect your service to
-different payment service providers (PSPs).
-
 If you are new to GOV.UK Pay, you can read about it on [our features
-page](https://www.payments.service.gov.uk/).
+page](https://www.payments.service.gov.uk/features).
 
 ## How many services are using GOV.UK Pay? 
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -13,11 +13,11 @@ documentation.
 
 ## New to GOV.UK Pay 
 
-If you are new to GOV.UK Pay, you can read all about the platform on our
+If you are new to GOV.UK Pay, you can read about the platform on our
 [product page](https://www.payments.service.gov.uk/) and our [features
 page](https://www.payments.service.gov.uk/features). 
 
-You can also [contact us](/support_contact_and_more_information/#contact-us).
+You can also [contact us](/support_contact_and_more_information/#contact-us) if you have any questions or feedback.
 
 ## How many services are using GOV.UK Pay? 
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,44 +3,27 @@ title: Documentation – GOV.UK Pay
 weight: 10
 ---
 
-# About GOV.UK Pay 
+# GOV.UK Pay technical documentation 
 
-GOV.UK Pay makes it easy for public sector organisations to take payments. It provides a standard set of GOV.UK branded pages which can be incorporated into a service to take payments, and an admin console which enables services to administer and process payments taken through GOV.UK Pay. Much of GOV.UK Pay’s functionality can be incorporated into existing case management tools via our API.
+You can use this technical documentation as a reference if you are a user of
+the GOV.UK Pay platform. 
 
-GOV.UK Pay is currently in beta development. The payment pages are responsive
-and work on both desktop and mobile.
+Use the left-hand navigation bar to move to different sections of the
+documentation.
 
-The platform can connect your service to different payment service providers
-(PSPs).
+GOV.UK Pay is a free and secure online payment service for government and
+public sector organisations. The platform can connect your service to
+different payment service providers (PSPs).
 
-During beta, GOV.UK Pay will support credit and debit card payments only. Over
-time, further payment methods, such as direct debit or eWallet, will be added.
+If you are new to GOV.UK Pay, you can read about it on [our features
+page](https://www.payments.service.gov.uk/).
 
-Your service only needs to integrate with GOV.UK Pay once to let your users
-make credit and debit card payments. When GOV.UK Pay is expanded to accept
-other payment methods, your service will not have to undertake any new
-integration. Using GOV.UK Pay will save your team time compared to
-implementing support for multiple PSPs and payment methods from scratch.
+## How many services are using GOV.UK Pay? 
 
-The platform currently supports one-off payments (like fees, fines or licence
-payments). In the future, it will also support recurring payments, for
-example, monthly tax payments.
-
-GOV.UK Pay does not currently support payments to cardholders, for example, payments of benefits, or grants. The platform only supports taking payments, or providing refunds.
-
-There are ten departments and agencies currently partnering with the platform:
-
-- Ministry of Justice
-- Home Office
-- Disclosure and Barring Service
-- Office of the Public Guardian
-- HM Courts and Tribunals Service
-- Disclosure Scotland 
-- Foreign and Commonwealth Office 
-- Ministry of Defence
-- Department for Digital, Culture, Media & Sport
-- Department for International Trade 
+You can see how many services are using GOV.UK Pay on [our performance
+dashboard](https://www.gov.uk/performance/govuk-pay). 
 
 ## How much does it cost?
 
-There is no charge to use GOV.UK Pay. You will still need to pay your PSP's transaction fees.
+There is no charge to use GOV.UK Pay. You will still need to pay your PSP's
+transaction fees.


### PR DESCRIPTION
### Context
A new landing page for the technical documentation (i.e. where users end up when they first see it, unless they're following a specific link). Instead of the "About GOV.UK Pay" page, which I highly doubt anybody reads, they are now linked to the more appropriate (and more regularly maintained) features page on GOV.UK and in this page they are now given a simple description about the platform and what it does in case they end up on the docs first as part of their user journey - this is relatively unlikely but worth accounting for. The landing page also now offers an explanation of how to navigate through the technical documentation. 

### Changes proposed in this pull request
Almost entirely new landing page 

### Guidance to review
Use the rich text preview to see how this would appear in situ 