### PR TITLE
Simplify landing page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -5,15 +5,10 @@ weight: 10
 
 # GOV.UK Pay documentation 
 
-If you are a user of the GOV.UK Pay platform, you can use this documentation
-as a reference. 
-
-Use the left-hand navigation bar to move to different sections of the
+Use the left-hand navigation bar to learn about the different sections of the
 documentation.
 
-## New to GOV.UK Pay 
-
-If you are new to GOV.UK Pay, you can read about the platform on our
+If you are completely new to GOV.UK Pay, you may want to read about the platform on our
 [product page](https://www.payments.service.gov.uk/) and our [features
 page](https://www.payments.service.gov.uk/features). 
 


### PR DESCRIPTION
### Context
In hindsight I think this is better: this way we're not necessarily asserting that people should use the products and features page, but recommending it for people who are completely new to the platform.

### Changes proposed in this pull request
Simplifies landing page a bit. 
