### PR TITLE
Improve "Before you start" section and add information about payment links

### DIFF
--- a/source/before_you_start/index.html.md.erb
+++ b/source/before_you_start/index.html.md.erb
@@ -7,34 +7,21 @@ weight: 30
 
 Before you start testing GOV.UK Pay, you should:
 
-* read the ["Get started" guide](https://www.payments.service.gov.uk/getstarted/) and decided that GOV.UK Pay is right for your service
-* sign up for [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/create-service/register)
-* read the government guidance on [deploying new software](https://www.gov.uk/service-manual/making-software/deployment.html).
+* read the ["Get started"
+guide](https://www.payments.service.gov.uk/getstarted/) to decide if
+GOV.UK Pay is right for your service 
+* sign up for [the GOV.UK Pay admin
+tool](https://selfservice.payments.service.gov.uk/create-service/register) 
+* read the government guidance on [deploying new
+software](https://www.gov.uk/service-manual/making-software/deployment.html).
 
-If you want to build a technical integration between your service and GOV.UK Pay, your service team should have the necessary skills. You can refer to the [Service Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have) for more information. This does not apply if you only use [payment links](/payment_links/#payment-links). 
+If you want to build a technical integration between your service and GOV.UK
+Pay, your service team should have the necessary skills. You can refer to the
+[Service
+Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have)
+for more information. This does not apply if you only use [payment
+links](/payment_links/#payment-links).
 
-## Sign up and test GOV.UK Pay 
-
-  
-
->If you are new to the GOV.UK Pay API, we recommend you take a look at the quick start guide, which explains how to access the API and start exploring what it can do.
-
-## How long will it take?
-
-The time taken to integrate will vary depending on team and capability; for example, it took a single developer five days to integrate a Home Office service with GOV.UK Pay.
-
-## Try the service out
-
-You can try GOV.UK Pay before integrating with the API. 
-
-You must be logged into a GOV.UK Pay __test__ account to try these features out.
-
-### Make a demo payment
-
-You can [try the payment experience as a user](https://selfservice.payments.service.gov.uk/make-a-demo-payment), and then view the completed payment as a GOV.UK Pay administrator.
-
-### Test your service with your users 
-
-You can [create a reusable link](https://selfservice.payments.service.gov.uk/test-with-your-users) to integrate your service prototype with GOV.UK Pay, and test with your users.
-
+If you are new to the GOV.UK Pay API, you can read the "[Quick start guide]"
+section of this documentation.
 

--- a/source/before_you_start/index.html.md.erb
+++ b/source/before_you_start/index.html.md.erb
@@ -15,8 +15,8 @@ tool](https://selfservice.payments.service.gov.uk/create-service/register)
 * read the government guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html).
 
-If you want to build a technical integration between your service and GOV.UK
-Pay, your service team should have the necessary skills. You can refer to the
+If you want to build a technical integration between your service and the GOV.UK
+Pay API, your service team should have the necessary skills. You can refer to the
 [Service
 Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have)
 for more information. This does not apply if you only use [payment
@@ -25,3 +25,13 @@ links](/payment_links/#payment-links).
 If you are new to the GOV.UK Pay API, you can read the "[Quick start guide]"
 section of this documentation.
 
+You may also want to use payment links rather than integrate with the GOV.UK Pay
+API if your service:  
+
+* is non-digital and uses paper applications to process payments
+* is non-digital and has low transaction volumes
+* asks users for payment by sending email or letters
+* does not have a development team that can integrate your service with GOV.UK Pay
+
+You can read more in the ["Payment links"](/payment_links/#payment-links)
+section.

--- a/source/before_you_start/index.html.md.erb
+++ b/source/before_you_start/index.html.md.erb
@@ -5,15 +5,17 @@ weight: 30
 
 # Before you start
 
-To start using GOV.UK Pay, you'll need:
+Before you start testing GOV.UK Pay, you should:
 
-- a service that needs to process payments
-- a [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/create-service/register) 
-- a service team with the development skills to build the technical integration between your service and GOV.UK Pay; refer to the [Service Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have) for more information (this does not apply if you only use [payment links](/payment_links/#payment-links))
+* read the ["Get started" guide](https://www.payments.service.gov.uk/getstarted/) and decided that GOV.UK Pay is right for your service
+* sign up for [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/create-service/register)
+* read the government guidance on [deploying new software](https://www.gov.uk/service-manual/making-software/deployment.html).
+
+If you want to build a technical integration between your service and GOV.UK Pay, your service team should have the necessary skills. You can refer to the [Service Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have) for more information. This does not apply if you only use [payment links](/payment_links/#payment-links). 
+
+## Sign up and test GOV.UK Pay 
+
   
-Check the [Getting Started guide](https://www.payments.service.gov.uk/getstarted/) to ensure that your team is ready to start using GOV.UK Pay.
-
-Make sure you’re also familiar with the government guidance on [deploying new software](https://www.gov.uk/service-manual/making-software/deployment.html).
 
 >If you are new to the GOV.UK Pay API, we recommend you take a look at the quick start guide, which explains how to access the API and start exploring what it can do.
 
@@ -34,4 +36,5 @@ You can [try the payment experience as a user](https://selfservice.payments.serv
 ### Test your service with your users 
 
 You can [create a reusable link](https://selfservice.payments.service.gov.uk/test-with-your-users) to integrate your service prototype with GOV.UK Pay, and test with your users.
+
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -18,6 +18,18 @@ Services testing with sandbox accounts can optionally use HTTP (rather than HTTP
 for return URLs. You can read more about this in [the "Security"
 section](/security/#https). 
 
+### Make a demo payment
+
+You can [try the payment experience as a
+user](https://selfservice.payments.service.gov.uk/make-a-demo-payment), and
+then view the completed payment as a GOV.UK Pay administrator.
+
+### Test your service with your users 
+
+You can [create a reusable
+link](https://selfservice.payments.service.gov.uk/test-with-your-users) to
+integrate your service prototype with GOV.UK Pay, and test with your users.
+
 ## Integration testing
 
 To check your integration with GOV.UK Pay is working as expected, you’ll need to run a series of tests.


### PR DESCRIPTION
### Context
The "Before you start" section breaks GOV.UK style slightly, in places. 

Separately, I'm also not entirely convinced we actually need this section. I've proposed moving some of the content to the "Testing" section in this PR, but we could move the rest of the content to the landing page and more strongly emphasise the features/product page on that. I'm not sure about having an explicit "Integration" section. 

I would also suggest that we either rename the "Quick start guide" section to "API quick start guide" (or at least better reflect that that section is specifically about using the API) or that we rework that section to make it more generalised than just the API. 

### Changes proposed in this pull request
1. Moves some of the content from "Before you start" to the "Testing GOV.UK Pay" section. The content in question is about testing different aspects of the platform so I think it would be better suited there.
2. Changes some language to conform to GOV.UK style and reworks the language. 
3. Deletes the "How long will it take?" section. I think having one is fine but in the form it's in at the moment (i.e. prior to this PR), it's not helpful to give an example that will only be directly applicable to a few people. 
4. Adds information about payment links. This is partly duplicated from that section: I'm actually not convinced that's a bad thing but I'll think about it. 