### PR TITLE
Better signposting in 'Switching to live' landing page

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -18,9 +18,8 @@ link](/payment_links/#payment-links) functionality.
 
 Please read the guidance on what to do [before you switch to live](/switching_to_live/before_you_switch_to_live/#before-you-switch-to-live) first.
 
-GOV.UK Pay currently supports
-[ePDQ](/switching_to_live/set_up_a_live_epdq_account),
-[Smartpay](/switching_to_live/set_up_a_live_smartpay_account) and
-[Worldpay](/switching_to_live/set_up_a_live_worldpay_account) live gateways.
+You can then read about switching to live for: 
 
-
+* [ePDQ](/switching_to_live/set_up_a_live_epdq_account) accounts
+* [Smartpay](/switching_to_live/set_up_a_live_smartpay_account) accounts
+* [Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts 


### PR DESCRIPTION
### Context
Better signposting for landing page for 'Switching to live'. 

### Changes proposed in this pull request
Slight changes to language to make it more obvious that people can use the left-hand navigation bar to find information on different live gateways. 

### Guidance to review
https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live