### PR TITLE
Signposting of external link, bold for interface text

### DIFF
--- a/source/payment_links/index.html.md.erb
+++ b/source/payment_links/index.html.md.erb
@@ -51,6 +51,6 @@ You can now send the live payment link to your users.
 
 ### Reference number and confirmation
 
-Your users will receive a reference number and confirmation email when they use a payment link. You can find the reference number on the [Transactions page](https://selfservice.payments.service.gov.uk/transactions). You will not receive a transaction reference number by default, unless you tell your users to send them to you.
+Your users will receive a reference number and confirmation email when they use a payment link. You can find the reference number on the [__Transactions__ page of the GOV.UK Pay admin site](https://selfservice.payments.service.gov.uk/transactions) [external link]. You will not receive a transaction reference number by default, unless you tell your users to send them to you.
 
 GOV.UK Pay creates and hosts the payment confirmation page.


### PR DESCRIPTION
### Context
Per GOV.UK style we should signpost external links and use bold for interface text 

### Changes proposed in this pull request
Changes to fix problems outlined in 'Context'
