### PR TITLE
Link to payment links product page 

### DIFF
--- a/source/payment_links/index.html.md.erb
+++ b/source/payment_links/index.html.md.erb
@@ -12,6 +12,8 @@ You may want to use payment links rather than integrate with the GOV.UK Pay API 
 - asks users for payment by sending email or letters
 - does not have a development team that can integrate your service with GOV.UK Pay
 
+You can read more about payment links on [the product page](https://www.payments.service.gov.uk/payment-links/).
+
 ### Prerequisites
 
 Before you set up a payment link, you must have a [live service](/switching_to_live/#switching-to-live). 


### PR DESCRIPTION
### Changes proposed in this pull request
Adds link to payment links product page in the relevant section in the docs

### Guidance to review
https://docs.payments.service.gov.uk/payment_links/#payment-links
https://www.payments.service.gov.uk/payment-links/