### PR TITLE
Minor improvements to 'Switching to live' section

### DIFF
--- a/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
+++ b/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
@@ -1,12 +1,13 @@
 ---
 title: Switching to live 
-weight: 100
+weight: 99
 ---
 
 # Before you switch to live 
 
 Before you start taking live payments, you should: 
 
+* have a signed MOU or contract with GOV.UK Pay
 * [provide organisation information](#provide-organisation-information) to GOV.UK Pay 
 * request a [live GOV.UK Pay account](#request-a-live-gov-uk-pay-account)
 * make sure that the right people on your


### PR DESCRIPTION
### Context
The engagement team reported that a user got confused about needing a contract before switching to live, so we should add a line about that. Also, currently, the 'Before you switch to live' link is appearing quite far down in the left-hand nav rather than near the top. 

### Changes proposed in this pull request
Fix appearance of 'Before you switch to live' in left-hand nav, and adds line about needing contract. 