### PR TITLE
Rogue parenthesis (multiple times)

### DIFF
--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -272,7 +272,7 @@ refund exists, the `"status"` field will contain one of:
 An example search request:
 
 `GET
-/v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z)`
+/v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z`
 
 #### Filter by date
 
@@ -294,12 +294,12 @@ You can use the following query parameters for pagination:
 These must be a positive integer. For example, for the following search:
 
 `GET
-/v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z)`
+/v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z`
 
 If there were 1543 refunds in the response, you could paginate this as follows:
 
 `GET
-/v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display-size=500&page=2)`
+/v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display-size=500&page=2`
 
 This would return refunds 501-1000.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -106,7 +106,7 @@ have entered when making a payment:
 An example search request:
 
 `GET
-/v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&reference=12345&state=success)`
+/v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&reference=12345&state=success`
 
 Some of the query parameters you can use to search for payments are: 
 
@@ -143,12 +143,12 @@ You can use the following query parameters for pagination:
 These must be a positive integer. For example, for the following search:
 
 `GET
-/v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z)`
+/v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z`
 
 If there were 1543 payments in the response, you could paginate this as follows:
 
 `GET
-/v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display-size=500&page=2)`
+/v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display-size=500&page=2`
 
 This would return payments 501-1000.
 


### PR DESCRIPTION
### Context
The same rogue parenthesis appears in the reporting and refunding API call examples 

### Changes proposed in this pull request
Removes rogue ")" from examples where appropriate