### PR TITLE
Makes clear reporting is for each service

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -6,7 +6,7 @@ weight: 70
 # Reporting 
 
 You can extract reporting information from GOV.UK Pay manually or via the
-API.
+API, for each service you have set up in GOV.UK Pay. 
 
 You can also read about [refunding payments](/refunding_payments/), including
 how to [search for refunds using the GOV.UK Pay API](/refunding_payments/#search-refunds-with-the-api).


### PR DESCRIPTION
### Context
Makes clear users can have reporting for each service they have set up in GOV.UK Pay 

### Changes proposed in this pull request
Single-line change to reflect above