### PR TITLE
Changes 'Switch service' to 'My services'

### DIFF
--- a/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
+++ b/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
@@ -26,7 +26,7 @@ to GOV.UK Pay.
 
 1. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login).
-1. Select __Switch service__.
+1. Select __My services__.
 1. For the test account you want to make live, select __Organisation
    details__. 
 1. Complete the __Name__ and __Address__ fields.
@@ -39,7 +39,7 @@ to GOV.UK Pay.
 
 1. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login).
-1. Select __Switch service__.
+1. Select __My services__.
 1. For the test account you want to make live, select __Manage team members__
    on the dashboard. 
 1. Copy the full page URL, for example   `https://selfservice.payments.service.gov.uk/service/23f0eb425a9569988b99b5bb641a541d`.
@@ -50,7 +50,7 @@ account you want to make live. You can email the team at
 
 The GOV.UK Pay team will change your account to live within one business day.
 
-When your account is live, it will appear in the __Switch service__ page
+When your account is live, it will appear in the __My services__ page
 labelled as a __Live card account__.
 
 ## Support

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -136,7 +136,7 @@ should the status of a transaction change offline__ field, enter:
 In your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login):
 
-1. Go to __Switch service__ and select the live service you want to set up.
+1. Go to __My services__ and select the live service you want to set up.
 1. Go to __Settings__ then __Account credentials__ then __Edit credentials__.
 
 1. Complete the following fields:
@@ -168,7 +168,7 @@ In your [GOV.UK Pay
 
 To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay
 self-service admin site](https://selfservice.payments.service.gov.uk/). Go to
-__Switch service__ to select the live service you want to set up. Select
+__My services__ to select the live service you want to set up. Select
 __Settings__, then __3D Secure__ and then __turn 3D Secure on__. 
 
 3D Secure should be enabled by default on the [ePDQ admin

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -91,7 +91,7 @@ Leave all other settings to their defaults and select __Save configuration__.
 
 1. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login).
-1. Go to __Switch service__ and select the Smartpay live service you want to
+1. Go to __My services__ and select the Smartpay live service you want to
    set up.
 1. Go to __Settings__ then __Account credentials__.
 
@@ -137,7 +137,7 @@ Complete the following fields on this page:
 To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay
 self-service admin site](https://selfservice.payments.service.gov.uk/). 
 
-Go to __Switch service__ to select the live service you want to set up. 
+Go to __My services__ to select the live service you want to set up. 
 Select __Settings__, then __3D Secure__ and then __Turn on 3D Secure__. 
 
 Barclaycard is responsible for setting up 3D Secure payment authentication

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -41,9 +41,9 @@ and signed in, in different web browser tabs.
 
 1. Select __Profile__ in the left-hand menu in your Worldpay account.
 
-1. In your GOV.UK Pay browser tab, go to __Switch
-service__ to select the live service you want to set up. Select __Settings__,
-then __Account credentials__, then __Edit credentials__.
+1. In your GOV.UK Pay browser tab, go to __My services__ to select the live
+service you want to set up. Select __Settings__, then __Account credentials__,
+then __Edit credentials__.
 
 1. In your Worldpay browser tab, go to the __Profile__ page, then select
 __Identification__. 
@@ -162,8 +162,8 @@ Ask your Worldpay account manager to configure your merchant code to enable 3D
 Secure for all payments.
 
 When this is available, sign in to your [GOV.UK Pay
-account](https://selfservice.payments.service.gov.uk/login). Go to __Switch
-service__ to select the live service you want to set up. Select __Settings__,
+account](https://selfservice.payments.service.gov.uk/login). Go to __My 
+services__ to select the live service you want to set up. Select __Settings__,
 then __3D Secure__ and then select __Turn 3D Secure on__. 
 
 


### PR DESCRIPTION
### Context
The documentation for 'Switching to live' currently directs people to use the old 'Switch service' pattern in the banner for the self-service tool; this has been changed to 'My services'. This was highlighted in https://govuk.zendesk.com/agent/tickets/3441245

### Changes proposed in this pull request
Changes in the relevant section of the docs to reflect the new state. I can't see any other sections of the docs where this needs changing but please let me know if you find any. 