### PR TITLE
adjusts note about optional features

### DIFF
--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 130
 
 # Optional features 
 
-GOV.UK Pay supports the following optional features: 
+GOV.UK Pay supports some optional features which need configuration: 
 
 * [Custom branding](/optional_features/custom_branding/#custom-branding-of-payment-pages) of payment pages 
 * [Welsh language](/optional_features/welsh_language/#welsh-language-payment-pages) of payment pages 


### PR DESCRIPTION
### Context
The optional features list in the tech docs isn't an exhaustive list of Pay's optional features, but the current line of text implies that inadvertently 

### Changes proposed in this pull request
☝️ suggestion to amend this 
