### PR TITLE
Add a note explaining that payment links are only available on live accounts

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -31,3 +31,4 @@ The key differences are:
 - return URLs for live services using GOV.UK Pay must use HTTPS, but you [can use HTTP for return URLs with test accounts](https://docs.payments.service.gov.uk/security/#https)
 - 3D Secure is not part of the payment journey on test accounts
 - response times of test accounts do not match live accounts, because live accounts are subject to response times of payment service providers
+- the payment links feature is only available for live accounts


### PR DESCRIPTION
### Context
We sometimes get queries about why the payment links feature isn't visible. This is because the options don't show up for non-live accounts.

### Changes proposed in this pull request
Add payment links to the list of differences between live and non-live accounts

### Guidance to review
Make sure my statement is actually true