### PR TITLE
Adds note to 'Account structure' section to indicate no limit on services

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -7,9 +7,13 @@ weight: 95
 
 Before you read this section, you may find it useful to read the [‘Reporting’ section](/reporting/#reporting). 
 
-If you have integrated multiple services, you can treat them separately or as
-a combined single service within GOV.UK and your payment service provider
-(PSP). This gives 3 possible account configurations. These configurations allow you to alter which bank accounts payments go to, and the names of services that appear on your end users’ bank statements. 
+GOV.UK Pay does not limit how many services you can integrate with it. 
+
+If you do integrate multiple services, you can treat them separately or as a
+combined single service within GOV.UK and your payment service provider (PSP).
+This gives 3 possible account configurations. These configurations allow you
+to alter which bank accounts payments go to, and the names of services that
+appear on your end users’ bank statements. 
 
 As an example, take 2 services called ‘parking permits’ and ‘parking fines’: 
 
@@ -73,6 +77,6 @@ Within each gateway account for the PSP, you can edit:
 * what appears on the end user’s bank statement  
 * which of your bank accounts your revenue goes to
 
-Contact your PSP to find out more. 
+You should contact your PSP to find out more. 
 
 


### PR DESCRIPTION
### Context
We get some tickets asking if there's a process involved to having more services 

### Changes proposed in this pull request
Adds note to 'Account structure' section about unlimited service allowance. We might want to add a note elsewhere, e.g. the Switching to live section, as well? 