### PR TITLE
Billing address note 

### DIFF
--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -35,6 +35,14 @@ When an end user needs to make a payment, your service makes an API call to crea
 
 The end user enters their payment details (for example, credit/debit card details and billing address) on the GOV.UK Pay pages. GOV.UK Pay verifies the payment with the underlying PSP. 
 
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    If you do not collect billing address information, the GOV.UK Pay API will not return address fields in response to GET requests
+  </strong>
+</div>
+
 After the transaction reaches a final state, the end user is then redirected back to your service.
 
 A final state means that the payment:


### PR DESCRIPTION
### Context
We should include that if you opt not to collect billing address, then the billing address fields will not be returned in public API when doing a GET request.

### Changes proposed in this pull request
Adds warning text about billing address: if not set, address fields will not be returned in public API when doing a GET request

### Guidance to review
https://govukpaytest.cloudapps.digital/payment_flow/#overview

We also had this note in the Trello card but I'm not sure about including this:

> we might also want to point out that if you switch on/off collecting billing address, it can take up to 45 minutes for the change to be seen on the payment pages due to caching 