### PR TITLE
Section title conventions, curlification, placeholders

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -23,7 +23,7 @@ You can also use the interactive <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2//"
 target="blank">API explorer</a> [external link] to try API calls and view responses.
 
-See the ["Quick start guide"](/quick_start_guide/#quick-start-guide) section
+See the [__Quick start guide__](/quick_start_guide/#quick-start-guide) section
 to read how to set up the API explorer. Make sure you enter your test API
 key to avoid generating real payments.
 
@@ -33,8 +33,8 @@ GOV.UK Pay authenticates API calls with [OAuth2 HTTP bearer
 tokens](http://tools.ietf.org/html/rfc6750) [external link]. These are easy to
 use and contain only your API key. 
 
-When you make an API call, you need to use an "Authorization" HTTP header to
-provide your API key, with a "Bearer" prefix. For example:
+When you make an API call, you need to use an “Authorization” HTTP header to
+provide your API key, with a “Bearer” prefix. For example:
 
 ```text
 Authorization: Bearer <YOUR-API-KEY-HERE>
@@ -202,11 +202,11 @@ Pay admin tool or directly using the API.
 1. Sign in to the [GOV.UK Pay admin
 site](https://selfservice.payments.service.gov.uk/) (link opens in new window).
 2. Select _Transactions_.
-3. Select a payment with a "failed", "cancelled" or "error" status.
+3. Select a payment with a `"failed"`, `"cancelled"` or `"error"` status.
 
 #### Use the API
 
-You can use the API to examine the `state` object in a payment's API response.
+You can use the API to examine the `state` object in a payment’s API response.
 
 For example:
 
@@ -248,8 +248,8 @@ second, for each government service.
 GET requests are also rate-limited, but at a very high level. In the future,
 we will publish an official rate limit for GET requests.
 
-If you exceed the rate limit, this will return HTTP status code "429" (Too
-many requests) and error code P0900. After a second, you'll be able to retry
+If you exceed the rate limit, this will return HTTP status code “429” (Too
+many requests) and error code P0900. After a second, you’ll be able to retry
 your attempt in a reasonable way. For example, using exponential backoff.
 
 Please [contact

--- a/source/contribute/index.html.md.erb
+++ b/source/contribute/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 150
 
 # Contribute
 
-GOV.UK Pay's main application code is public and freely available under an MIT License and the GOV.UK Pay team [codes in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). You can [find us on GitHub](https://github.com/alphagov?q=pay-).
+GOV.UK Pay’s main application code is public and freely available under an MIT License and the GOV.UK Pay team [codes in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). You can [find us on GitHub](https://github.com/alphagov?q=pay-).
 
 >If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you. Please email us at [mailto:govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -22,4 +22,4 @@ dashboard](https://www.gov.uk/performance/govuk-pay).
 ## How much does it cost?
 
 There is no charge to use GOV.UK Pay. You will still need to pay your payment
-service provider's (PSP's) transaction fees.
+service provider’s (PSP’s) transaction fees.

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -54,14 +54,14 @@ methods:
 + use a secure cookie containing the Payment ID from GOV.UK Pay, issued by
 your service when the payment is created (before sending the user to
 ``next_url``). Users will not be able to decrypt a secure cookie, so a
-fraudster could not alter the payment ID and intercept other users' payments.
+fraudster could not alter the payment ID and intercept other users’ payments.
 
 + create a secure random ID (such as a UUID) and include this as part of the
 ``return_url``, using a different ``return_url`` for each payment. Since a
 securely generated UUID is not guessable, fraudsters will not be able to
 intercept users’ payments.
 
->Note: If you create an ID yourself, you'll likely need to store this in a
+>Note: If you create an ID yourself, you’ll likely need to store this in a
 datastore mapped to the payment ID just after you create a payment.
 
 ## Accepting returning users
@@ -93,9 +93,9 @@ If a user does not have enough funds in their account to make a payment, the
 current GOV.UK Pay frontend will not let them try again with separate card
 details. They will have to return to the service to retry the payment. 
 
-## Cancel a payment that's in progress
+## Cancel a payment that’s in progress
 
-Users can click a link on the payment page to cancel a payment that's in
+Users can click a link on the payment page to cancel a payment that’s in
 progress. Alternatively, a service can make the following API call for a given
 `paymentId`:
 

--- a/source/optional_features/corporate_card_surcharges/index.html.md.erb
+++ b/source/optional_features/corporate_card_surcharges/index.html.md.erb
@@ -10,7 +10,7 @@ credit or debit card. You can [contact GOV.UK Pay
 support](/support_contact_and_more_information/#contact-us) to ask the team to
 set this up for you. 
 
-Each surcharge is a flat amount added to a payment. If you'd like to discuss
+Each surcharge is a flat amount added to a payment. If you’d like to discuss
 adding surcharges as percentages, please [contact
 us](/support_contact_and_more_information/#contact-us).
 

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -35,7 +35,7 @@ payment creation, regardless of how long the user takes to complete the
 payment flow. Otherwise, it will expire.
 
 If your service has enabled payment receipt emails, GOV.UK Pay will send a
-payment receipt email to the user once your service's capture request is
+payment receipt email to the user once your service’s capture request is
 received and accepted.
 
 ## See the capture URL for a payment

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -64,7 +64,7 @@ The following image represents a page on a service where the end user needs to m
 
 In your service, this page might be the end of a series of pages you host which allow the user to choose between a variety of possible payments. 
 
-This page should make it clear to the user that they are about to pay for your product or service with a clear call to action. For example, a button that says “Pay now” or “Continue to payment”. The user will then be taken to the GOV.UK Pay pages to complete their transaction. 
+This page should make it clear to the user that they are about to pay for your product or service with a clear call to action. For example, a button that says __Pay now__ or __Continue to payment__. The user will then be taken to the GOV.UK Pay pages to complete their transaction. 
 
 The page should include clear information on what is being purchased. You do not need to tell the user that they are being handed over to GOV.UK Pay’s pages to make their payment.
 
@@ -127,13 +127,13 @@ The start of the response confirms the properties of the attempted payment.
 
 The ``self`` URL (also provided in the Location header of the response) is a unique identifier for the payment. It can be used to retrieve its status details in future.
 
-The ``next_url`` is the URL where your service should direct the end user next. It points to a payment page hosted by GOV.UK Pay where the user can enter their payment details. This is a one-time URL - after it's been visited once, it will give an error message.
+The ``next_url`` is the URL where your service should direct the end user next. It points to a payment page hosted by GOV.UK Pay where the user can enter their payment details. This is a one-time URL - after it’s been visited once, it will give an error message.
 
-When your service redirects the user to ``next_url``, they'll see an __Enter card details__ page similar to the following: 
+When your service redirects the user to ``next_url``, they’ll see an __Enter card details__ page similar to the following: 
 
 ![](images/flow-payment-details-page.png)
 
-This page shows the ``description`` as well as the amount the end user has to pay, making it clear what they're paying for.
+This page shows the ``description`` as well as the amount the end user has to pay, making it clear what they’re paying for.
 
 The user enters their payment details and clicks **Continue**.
 
@@ -205,7 +205,7 @@ The `return_url` should specify a page on your service. When the user visits the
 - check the status of the payment using an API call
 - display an appropriate final page (hosted by your service)
 
-The "[Making payments](/making_payments/#making-payments)" section contains more details about how to match the user to the payment.
+The [__Making payments__](/making_payments/#making-payments) section contains more details about how to match the user to the payment.
 
 To check the status of the payment, you must make a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id" target="blank">Find payment by ID</a> API call (link opens in new window), using the ``payment_id`` of the payment as the parameter.
 
@@ -231,11 +231,11 @@ The ``state`` array within the JSON lets you know the outcome of the payment:
 + The ``status`` value describes a stage of the payment journey.
 + The ``finished`` value indicates if the payment journey is complete or not - that is, if the ``status`` of this payment can change.
 
-See the ["Making payments"](/making_payments/#making-payments) section for more information about how you can integrate your service with GOV.UK Pay.
+See the [__Making payments__](/making_payments/#making-payments) section for more information about how you can integrate your service with GOV.UK Pay.
 
 ## Resume a payment
 
-If your user starts a payment but does not complete it, they can resume that incomplete payment. An example of this could be if they click the browser's back button during a payment, and then go forward by clicking the links on your website. 
+If your user starts a payment but does not complete it, they can resume that incomplete payment. An example of this could be if they click the browser’s back button during a payment, and then go forward by clicking the links on your website. 
 
 If your service uses the resume payment feature, you will:
 
@@ -254,6 +254,6 @@ An incomplete payment will have a status of `created`, `started` or `submitted`.
 
 ### Resuming a payment
 
-When a user resumes a payment, the `next_URL` will take them to a screen that is appropriate for their payment's current status. For example, a payment with a `started` status will resume at the card details input page. The `next_URL` is a one-time URL. If a payment has already resumed using a `next_URL`, that URL will not be usable again.
+When a user resumes a payment, the `next_URL` will take them to a screen that is appropriate for their payment’s current status. For example, a payment with a `started` status will resume at the card details input page. The `next_URL` is a one-time URL. If a payment has already resumed using a `next_URL`, that URL will not be usable again.
 
-A payment cannot resume if it has a status of `success`, `failed`, `cancelled` or `error`. If your service tries to resume a payment of this type, the user will be sent to your service's `return_url`. The `return_url` is the URL of a page on your service that we send the user to after they have completed their payment attempt.   
+A payment cannot resume if it has a status of `success`, `failed`, `cancelled` or `error`. If your service tries to resume a payment of this type, the user will be sent to your service’s `return_url`. The `return_url` is the URL of a page on your service that we send the user to after they have completed their payment attempt.   

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -11,7 +11,7 @@ Read this section to learn about what to do to get started with GOV.UK Pay.
 
 Before you start testing GOV.UK Pay, you should:
 
-* read the ["Get started"
+* read the [__Get started__
 guide](https://www.payments.service.gov.uk/getstarted/) (link opens in new
 window) to decide if GOV.UK Pay is right for your service 
 
@@ -63,7 +63,7 @@ call.
 this key in publicly accessible documents or repositories. You must not share
 it with anyone who should not be using the GOV.UK Pay API directly.</blockquote>
  
-[Read the "Security" section](/security/#security) for more information on how
+[Read the __Security__ section](/security/#security) for more information on how
 to keep your API key safe.
 
 ## API Explorer setup
@@ -114,7 +114,7 @@ that the user will be redirected to after they have completed their payment
 ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/pay-api-explorer-createpay.png)
 
 Services that use test accounts can optionally use HTTP, rather than HTTPS,
-for return URLs. You can read more about this in [the "Security"
+for return URLs. You can read more about this in [the __Security__
 section](/security/#https). 
 
 1. Select the green __Send Request__ button.
@@ -129,8 +129,8 @@ section](/security/#https).
 
 ## Simulate an end-user payment journey 
 
-Go to the ``next_url`` with a browser, and you'll see the payment screen.
-Choose a mock card number from the ["Testing GOV.UK
+Go to the ``next_url`` with a browser, and you’ll see the payment screen.
+Choose a mock card number from the [__Testing GOV.UK__
 Pay"](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
 enter it to simulate a payment in the test environment. For the other
 required details, enter some test information which should have:

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -19,7 +19,7 @@ Each payment has a refund status which can take one of the following values:
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | pending               | The payment is potentially refundable, but is not ready to be refunded yet.                                                                                                        |
 | unavailable           | It is not possible to refund the payment: for example, the payment failed.                                                                                                         |
-| available             | It's possible to initiate a refund. Note that this does not mean that the full original value of the payment is available to refund: there may have been previous partial refunds. |
+| available             | It’s possible to initiate a refund. Note that this does not mean that the full original value of the payment is available to refund: there may have been previous partial refunds. |
 | full                  | The original value of the payment has been fully refunded, so it is not possible to refund any more.                                                                               |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
@@ -88,7 +88,7 @@ be available for refund at the time your refund request is made.
 
 The purpose of this is to prevent accidentally processing a partial refund
 more than once, by rejecting requests where your `refund_amount_available`
-does not match the real amount that's available to be refunded.
+does not match the real amount that’s available to be refunded.
 
 For example, a payment is made for £5, but later the user requires a £2
 refund. Your system for processing refunds submits a request for a £2 refund
@@ -101,7 +101,7 @@ In the same scenario, if you had specified the ``refund_amount_available`` as
 £5. The first request still succeeds, leaving £3 available to be refunded.
 When the accidental duplicate request comes in, it has a
 ``refund_amount_available`` of £5, even though only £3 is available, so GOV.UK
-Pay can tell that it's a stale request, and it is rejected.
+Pay can tell that it’s a stale request, and it is rejected.
 
 We recommend that your service tracks the expected refund amount available and
 submits a ``refund_amount_available`` value whenever you request a refund via
@@ -262,8 +262,8 @@ The JSON response body to this API call contains a `"refunds"` object. If the
 refund exists, the `"status"` field will contain one of:
 
 * `"submitted"`
-* `”success”`
-* `”error”`
+* `"success"`
+* `"error"`
 
 ### Generate a list of refunds (search refunds)
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -27,7 +27,7 @@ To further secure your live developer keys:
  - avoid embedding your developer keys in any of your code - this only increases the risk that they will be discovered (instead store your keys inside your configuration files)
  - avoid storing your API keys in your application source tree (even when you’re not making your source code publicly available)
  - revoke your developer keys when they’re no longer required (this limits the number of entry points into your account)
- - have a leavers’ process, so that a developer's API key is revoked when they leave
+ - have a leavers’ process, so that a developer’s API key is revoked when they leave
 
 ## Securing your integration with GOV.UK Pay
 
@@ -52,7 +52,7 @@ If you have one MID that encompasses multiple payment channels, the compliance r
 
 ### Determine your PCI DSS compliance requirements
 
-Your requirements depend on the number of transactions that you process as a merchant per scheme (Visa, MasterCard) per year. For example, if you process 4 million transactions with Visa and 3 million with MasterCard, the "Fewer than 6 million transactions per year" category still applies despite the fact that the total number of transactions is larger than 6 million. Your merchant level should be confirmed with your acquiring bank.
+Your requirements depend on the number of transactions that you process as a merchant per scheme (Visa, MasterCard) per year. For example, if you process 4 million transactions with Visa and 3 million with MasterCard, the “Fewer than 6 million transactions per year” category still applies despite the fact that the total number of transactions is larger than 6 million. Your merchant level should be confirmed with your acquiring bank.
 
 ### Assessing your compliance requirements
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -46,7 +46,7 @@ __Configuration__.
 1. For the __Hash algorithm__, choose __SHA-512__.
 1. For the __Character encoding__, choose __UTF-8__ and select __Save__.
 
-### Set up checks for "e-Commerce & Alias Gateway"
+### Set up checks for “e-Commerce & Alias Gateway”
 
 On the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index), go to
@@ -82,12 +82,12 @@ __Configuration__.
    section.
 1. Leave __Timing of the request__ on the default __No request__ setting.
 1. Leave the following fields blank: 
-<br>__If the payment's status is "accepted", "on hold" or "uncertain"__</br> 
-<br>__If the payment's status is "cancelled by the client" or "too many rejections by the acquirer"__ </br>
+<br>__If the payment’s status is “accepted”, “on hold” or “uncertain”__</br> 
+<br>__If the payment’s status is “cancelled by the client” or “too many rejections by the acquirer”__ </br>
 
 1. Set the __Request method__ to __POST__.
 1. Go to the __e-Commerce__ then __Dynamic e-Commerce parameters__ section.
-1. Check if "PAYIDSUB" is included in the __Selected__ box. If it is not, find it
+1. Check if “PAYIDSUB” is included in the __Selected__ box. If it is not, find it
    in the __Available__ box and select __>__ to add it. 
 
 ### Set up security for request parameters
@@ -143,8 +143,8 @@ In your [GOV.UK Pay
   <br> __PSP ID__ - enter your PSP ID for ePDQ</br>
   <br> __Username__ enter the API user’s username</br>
   <br> __Password__ - enter the API user’s password</br> 
-  <br> __SHA-IN passphrase__ - described in ["Set up account security parameters"](#set-up-account-security-parameters)</br>
-  <br> __SHA-OUT passphrase__ - described in ["Set up notification settings"](#set-up-notification-settings)</br>
+  <br> __SHA-IN passphrase__ - described in [__Set up account security parameters__](#set-up-account-security-parameters)</br>
+  <br> __SHA-OUT passphrase__ - described in [__Set up notification settings__](#set-up-notification-settings)</br>
 
 1. Select __Save credentials__.  
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -63,7 +63,7 @@ __Standard Notification__ row.
 
 Complete all the fields on the __Standard Notification settings__ page.
 
-### Set up "Transport" 
+### Set up “Transport” 
 
 Complete the fields in the __Transport__ page as follows:
 

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -9,7 +9,7 @@ Please read the guidance on what to do [before you switch to
 live](/switching_to_live/before_you_switch_to_live/#before-you-switch-to-live)
 first.
 
-Worldpay uses the term 'production' for live accounts.
+Worldpay uses the term “production” for live accounts.
 
 You should follow these instructions in order.
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -15,7 +15,7 @@ When testing, you’ll need to ensure:
  - you’ve tested the user journey from your service to the payments platform using end-to-end/smoke tests
 
 Services testing with test accounts can optionally use HTTP (rather than HTTPS)
-for return URLs. You can read more about this in [the "Security"
+for return URLs. You can read more about this in [the __Security__
 section](/security/#https). 
 
 ### Make a demo payment
@@ -44,9 +44,9 @@ If you experience any problems when testing, please email us at [govuk-pay-suppo
 
 ## Mock card numbers for testing purposes
 
-When you're testing your integration, you must not use real card numbers. Use the below test numbers.
+When you’re testing your integration, you must not use real card numbers. Use the below test numbers.
 
-When you're using these card numbers, you can enter any valid value for the other details (name, expiry date, card security code etc). For example, it does not matter what expiry date you enter, but it must be in the future.
+When you’re using these card numbers, you can enter any valid value for the other details (name, expiry date, card security code etc). For example, it does not matter what expiry date you enter, but it must be in the future.
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 

--- a/source/troubleshooting/index.html.md.erb
+++ b/source/troubleshooting/index.html.md.erb
@@ -27,18 +27,18 @@ Possible reasons why your call may be rejected include:
 + the ``return_url`` you provide is not ``https://``
 + there are URLs inside the ``reference`` or ``description`` you provide
 + you have not included a ``Content-Type: application/json`` header
-+ you've included an ``Accept`` header but with something other than ``application/json``
++ you’ve included an ``Accept`` header but with something other than ``application/json``
 
 ## The code examples in the documentation do not work
 
-**Problem**: The "Example Request" code snippets in the API documentation always cause the request to fail with a "401 unauthorized" error.
+**Problem**: The “Example Request” code snippets in the API documentation always cause the request to fail with a `"401 unauthorized"` error.
 
-**Fix**: Remember that you must send the API key with "Bearer " in front of it (not including the quotation marks.) This is not made clear in the code examples due to a technical limitation.
+**Fix**: You must send the API key with `"Bearer " in front of it (not including the quotation marks.) This is not made clear in the code examples due to a technical limitation.
 
 If the code example includes a line like this:
 
 ```ruby
-request["authorization"] = 'YOUR API KEY HERE'
+request["authorization"] = '<YOUR-API-KEY-HERE>'
 ```
 
-remember that you must actually use "Bearer <YOUR API KEY>" as the value.
+You must use `"Bearer <YOUR-API-KEY-HERE>"` as the value.

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -15,7 +15,7 @@ When we add new properties to the JSON responses, the GOV.UK Pay API version
 number will not change. You should develop your service to ignore properties
 it does not understand.
 
-We'll release new and dated versions of the public API if we remove JSON
+We’ll release new and dated versions of the public API if we remove JSON
 values in a backwards-incompatible manner.
 
 Our version number will be updated in the URL when there is a release. All


### PR DESCRIPTION


### Context
We should use proper conventions for section title links (bold), curly quotes rather than straight ones to match other Pay content where appropriate (not in API responses), and set a placeholder convention

### Changes proposed in this pull request
Uses __bold__ for section title links, curly quotes (” and ‘ rather than " and ') and sets placeholder convention `<THIS-IS-A-PLACEHOLDER>`