### PR TITLE
Remove trailing whitespace in all index.html.md.erb files

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -1,41 +1,41 @@
 ---
-title: Account structure 
+title: Account structure
 weight: 95
 ---
 
-# Account structure 
+# Account structure
 
-Before you read this section, you may find it useful to read the [‘Reporting’ section](/reporting/#reporting). 
+Before you read this section, you may find it useful to read the [‘Reporting’ section](/reporting/#reporting).
 
-GOV.UK Pay does not limit how many services you can integrate with it. 
+GOV.UK Pay does not limit how many services you can integrate with it.
 
 If you do integrate multiple services, you can treat them separately or as a
 combined single service within GOV.UK and your payment service provider (PSP).
 This gives 3 possible account configurations. These configurations allow you
 to alter which bank accounts payments go to, and the names of services that
-appear on your end users’ bank statements. 
+appear on your end users’ bank statements.
 
-As an example, take 2 services called ‘parking permits’ and ‘parking fines’: 
+As an example, take 2 services called ‘parking permits’ and ‘parking fines’:
 
 ### Type 1 (GOV.UK Pay separate, PSP separate)
 
 ![``”``](images/accountstructure_1.png)
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
-both GOV.UK Pay and the PSP. 
+both GOV.UK Pay and the PSP.
 
 In this setup, payments to services can go to separate bank accounts because
-each service has a PSP account. 
+each service has a PSP account.
 
 ### Type 2 (GOV.UK Pay combined, PSP combined)
 
 ![``”``](images/accountstructure_2.png)
 
 ‘Parking permits’ and ‘Parking fines’ are considered a single combined
-service by GOV.UK Pay and the PSP. 
+service by GOV.UK Pay and the PSP.
 
 You may want to use this configuration if you want to simplify the
-administration of multiple services in GOV.UK Pay. For example, if you do not need reporting at an individual service level. The services will appear in the same transactions list and CSV file. You may find it useful to use unique reference numbers to separate payments clearly, for example “parkingfine_1234” and “parkingpermit_1234”. 
+administration of multiple services in GOV.UK Pay. For example, if you do not need reporting at an individual service level. The services will appear in the same transactions list and CSV file. You may find it useful to use unique reference numbers to separate payments clearly, for example “parkingfine_1234” and “parkingpermit_1234”.
 
 In this configuration, payments to services must go to the same bank account because
 they are a single service in the PSP. It is not possible to support multiple PSP accounts in a single GOV.UK Pay service.
@@ -45,38 +45,36 @@ they are a single service in the PSP. It is not possible to support multiple PSP
 ![``”``](images/accountstructure_3.png)
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
-GOV.UK Pay and as a single combined service in the PSP. 
+GOV.UK Pay and as a single combined service in the PSP.
 
 You may want to use this configuration if you want to administrate multiple
-services individually in GOV.UK Pay. For example, if you want separate reporting for each service, or different service names on the payment pages. 
+services individually in GOV.UK Pay. For example, if you want separate reporting for each service, or different service names on the payment pages.
 
 In this configuration, payments to services must go to the same bank account because
-they are a single service in the PSP. 
+they are a single service in the PSP.
 
-## Editing GOV.UK Pay services 
+## Editing GOV.UK Pay services
 
-Each service defined in GOV.UK Pay has its own API key. 
+Each service defined in GOV.UK Pay has its own API key.
 
 Sign in to [the GOV.UK Pay admin
 site](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
-page to change: 
+page to change:
 
-* account credentials 
-* 3D Secure settings 
-* the card types you accept 
-* email notifications settings 
+* account credentials
+* 3D Secure settings
+* the card types you accept
+* email notifications settings
 
 You can also change the name of a service, including how it appears on payment
 pages. To do this, select __My services__ and then __Edit name__ for the
-service name you want to change.  
+service name you want to change.
 
-## Editing PSP services 
+## Editing PSP services
 
-Within each gateway account for the PSP, you can edit: 
+Within each gateway account for the PSP, you can edit:
 
-* what appears on the end user’s bank statement  
+* what appears on the end user’s bank statement
 * which of your bank accounts your revenue goes to
 
-You should contact your PSP to find out more. 
-
-
+You should contact your PSP to find out more.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: API reference 
+title: API reference
 weight: 60
 ---
 
@@ -16,7 +16,7 @@ standard HTTP error response codes.
 
 For full details of each API action, see the API browser:
 
-- <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general" target="blank">General functions</a> [external link] 
+- <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general" target="blank">General functions</a> [external link]
 - <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id" target="blank">Payment ID functions</a> [external link]
 
 You can also use the interactive <a
@@ -31,7 +31,7 @@ key to avoid generating real payments.
 
 GOV.UK Pay authenticates API calls with [OAuth2 HTTP bearer
 tokens](http://tools.ietf.org/html/rfc6750) [external link]. These are easy to
-use and contain only your API key. 
+use and contain only your API key.
 
 When you make an API call, you need to use an “Authorization” HTTP header to
 provide your API key, with a “Bearer” prefix. For example:
@@ -56,27 +56,27 @@ A successful response includes ``status`` and ``finished`` values:
 <table style="width:100%">
   <tr>
   <th><code>status</code></th>
-  <th>Meaning</th> 
+  <th>Meaning</th>
   <th nowrap><code>finished</code></th>
   </tr>
   <tr>
-    <td> created </td>     
+    <td> created </td>
     <td> Payment created. User has not yet visited <code>next_url</code>. </td>
-    <td> false </td> 
+    <td> false </td>
   </tr>
   <tr>
     <td> started </td>
-    <td> User has visited <code>next_url</code> and is entering payment details. </td> 
+    <td> User has visited <code>next_url</code> and is entering payment details. </td>
     <td> false </td>
   </tr>
   <tr>
     <td> submitted </td>
-    <td> User has submitted payment details but has not yet selected <b>Confirm</b>. Or, user has selected <b>Confirm</b> and the payment is a delayed capture.</td> 
+    <td> User has submitted payment details but has not yet selected <b>Confirm</b>. Or, user has selected <b>Confirm</b> and the payment is a delayed capture.</td>
     <td> false </td>
   </tr>
   <tr>
     <td> success </td>
-    <td> User successfully completed the payment. </td> 
+    <td> User successfully completed the payment. </td>
     <td> true </td>
   </tr>
   <tr>
@@ -195,7 +195,7 @@ Some errors may contain additional fields , such as `field`.
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
 You can see which payments have status-related error codes using the GOV.UK
-Pay admin tool or directly using the API. 
+Pay admin tool or directly using the API.
 
 #### Use the admin tool
 
@@ -240,7 +240,7 @@ For example:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-## Rate limits 
+## Rate limits
 
 POST requests to the GOV.UK Pay API are rate-limited to 15 requests per
 second, for each government service.

--- a/source/contribute/index.html.md.erb
+++ b/source/contribute/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Contribute 
+title: Contribute
 weight: 150
 ---
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,21 +3,21 @@ title: Documentation – GOV.UK Pay
 weight: 10
 ---
 
-# GOV.UK Pay documentation 
+# GOV.UK Pay documentation
 
 Use the left-hand navigation bar to go to different sections of the
 documentation.
 
 You can also read about GOV.UK Pay on the [product
 page](https://www.payments.service.gov.uk/) and the [features
-page](https://www.payments.service.gov.uk/features). 
+page](https://www.payments.service.gov.uk/features).
 
 Please [contact us](/support_contact_and_more_information/#contact-us) if you have any questions or feedback.
 
-## How many services are using GOV.UK Pay? 
+## How many services are using GOV.UK Pay?
 
 You can see how many services are using GOV.UK Pay on [our performance
-dashboard](https://www.gov.uk/performance/govuk-pay). 
+dashboard](https://www.gov.uk/performance/govuk-pay).
 
 ## How much does it cost?
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Making payments 
+title: Making payments
 weight: 70
 ---
 
@@ -30,7 +30,7 @@ publicly, for example as a URL parameter or in an insecure cookie. You should
 store it as a secure cookie or in a database.
 
 You will receive the ``next_url``  to which you should direct the user to
-complete their payment. 
+complete their payment.
 
 ## Tracking the progress of a payment
 
@@ -67,7 +67,7 @@ datastore mapped to the payment ID just after you create a payment.
 ## Accepting returning users
 
  A user directed to the return URL could have:
- 
+
  - paid successfully
  - not paid because their card was rejected or they clicked cancel
  - not paid because your service (via the API) or service manager (via the self-service dashboard) cancelled the payment in progress
@@ -91,7 +91,7 @@ redirected, but just after a set time (eg, an hour).
 
 If a user does not have enough funds in their account to make a payment, the
 current GOV.UK Pay frontend will not let them try again with separate card
-details. They will have to return to the service to retry the payment. 
+details. They will have to return to the service to retry the payment.
 
 ## Cancel a payment that’s in progress
 
@@ -106,12 +106,12 @@ A `204` response indicates success. Any other response indicates an error.
 To test this with our API Explorer:
 
 * 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).  
+   target="blank">the API Explorer</a> (link opens in new window).
 * 2. Under __Resource__, select __{Payment Id}__. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/"
-   target="blank">__Search payments__</a> (link opens in new window). 
+   target="blank">__Search payments__</a> (link opens in new window).
 
-### Find out if you can cancel a payment 
+### Find out if you can cancel a payment
 
 Use a GET request against a single payment to find out if you can cancel it:
 

--- a/source/optional_features/corporate_card_surcharges/index.html.md.erb
+++ b/source/optional_features/corporate_card_surcharges/index.html.md.erb
@@ -1,52 +1,52 @@
 ---
-title: Corporate card surcharges 
+title: Corporate card surcharges
 weight: 134
 ---
 
-# Corporate card surcharges  
+# Corporate card surcharges
 
 GOV.UK Pay supports adding a surcharge when a user pays with a corporate
 credit or debit card. You can [contact GOV.UK Pay
 support](/support_contact_and_more_information/#contact-us) to ask the team to
-set this up for you. 
+set this up for you.
 
 Each surcharge is a flat amount added to a payment. If you’d like to discuss
 adding surcharges as percentages, please [contact
 us](/support_contact_and_more_information/#contact-us).
 
 You can set a different surcharge for each of the following 4
-corporate card types: 
+corporate card types:
 
-* non-prepaid credit cards 
+* non-prepaid credit cards
 * non-prepaid debit cards
 * prepaid credit cards
-* prepaid debit cards 
+* prepaid debit cards
 
 In a payment journey, when a user enters a card number the GOV.UK Pay
 platform checks to determine if it’s one of the 4 corporate card types. If a
-surcharge is applicable, the platform will inform them that a surcharge of a 
-certain amount will be added to the total. 
+surcharge is applicable, the platform will inform them that a surcharge of a
+certain amount will be added to the total.
 
 If the platform cannot determine the exact type of a card being used, it
 will not apply a surcharge.
 
 You can sign in to the [GOV.UK Pay admin
 tool](https://selfservice.payments.service.gov.uk/login) (link opens in new
-window) to see the payment amount and the surcharge amount listed separately. 
+window) to see the payment amount and the surcharge amount listed separately.
 
 If a payment has a surcharge applied, the full amount available for refund
 includes the surcharge. You can also use the [partial refund
 feature](/refunding_payments/#payment-refund-status-and-partial-refunds) to
-only refund the total amount excluding the surcharge. 
+only refund the total amount excluding the surcharge.
 
 If a surcharge is applied to a particular payment, you can see this in API
-response fields:  
+response fields:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-| Response field                   | Meaning                                                                                        
+| Response field                   | Meaning
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `"amount"`                       | Contains the amount in pence, without any surcharge. </br> This field always appears, even if a surcharge is not applicable.|  
+| `"amount"`                       | Contains the amount in pence, without any surcharge. </br> This field always appears, even if a surcharge is not applicable.|
 | `"total_amount"`                 | Contains the total amount in pence, including any surcharge. </br> Only appears if a surcharge is applicable.               |
 | `"corporate_card_surcharge"`     | Contains only the surcharge amount, in pence. </br> Only appears if a surcharge is applicable.                              |
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -28,7 +28,7 @@ directly](/support_contact_and_more_information/#contact-us). Your image should 
 ### Banner background and border colour
 
 You can make a request for custom colours [to GOV.UK Pay
-directly](/support_contact_and_more_information/#contact-us). 
+directly](/support_contact_and_more_information/#contact-us).
 
-Colours are customised using hexadecimal representations. 
+Colours are customised using hexadecimal representations.
 

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -1,16 +1,16 @@
 ---
-title: Delayed capture 
+title: Delayed capture
 weight: 133
 ---
 
-# Delayed capture 
+# Delayed capture
 
 GOV.UK Pay supports the delayed capture of payments.
 
 To use this feature, include `"delayed_capture": true` in the body of a
 [create new
 payment](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment)
-request (link opens in new window). 
+request (link opens in new window).
 
 The user experience matches the current payment flow. Once the user selects
 __Confirm__ on the __Confirm your details__ page, your service can call the
@@ -40,13 +40,13 @@ received and accepted.
 
 ## See the capture URL for a payment
 
-If a payment is available for capture, you can see its capture URL in 
+If a payment is available for capture, you can see its capture URL in
 GOV.UK Pay API responses such as:
 
-* `GET /v1/payments/<PAYMENT-ID>` 
+* `GET /v1/payments/<PAYMENT-ID>`
 * `GET /v1/payments`
 
-The `"__links"` object will contain:` 
+The `"__links"` object will contain:`
 
 ```
 "capture": {

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -1,13 +1,13 @@
 ---
-title: Optional features 
+title: Optional features
 weight: 130
 ---
 
-# Optional features 
+# Optional features
 
-GOV.UK Pay supports some optional features which need configuration: 
+GOV.UK Pay supports some optional features which need configuration:
 
-* [Custom branding](/optional_features/custom_branding/#custom-branding-of-payment-pages) of payment pages 
-* [Welsh language](/optional_features/welsh_language/#welsh-language-payment-pages) of payment pages 
-* [Delayed capture](/optional_features/delayed_capture/#delayed-capture) of payments 
-* [Corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate_card_surcharges) added to payments 
+* [Custom branding](/optional_features/custom_branding/#custom-branding-of-payment-pages) of payment pages
+* [Welsh language](/optional_features/welsh_language/#welsh-language-payment-pages) of payment pages
+* [Delayed capture](/optional_features/delayed_capture/#delayed-capture) of payments
+* [Corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate_card_surcharges) added to payments

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -5,24 +5,24 @@ weight: 132
 
 # Welsh-language payment pages
 
-GOV.UK Pay supports Welsh-language payment pages. 
+GOV.UK Pay supports Welsh-language payment pages.
 
 To use Welsh, you can include `"language": "cy"` in the body of
 a request to create a payment. Users will see Welsh text on the payment
-pages as they complete the [payment flow](/payment_flow).  
+pages as they complete the [payment flow](/payment_flow).
 
 Sign in to your [GOV.UK Pay
 account](https://selfservice.payments.service.gov.uk/login) and use the admin
-tool to add a Welsh service name to your service.  
+tool to add a Welsh service name to your service.
 
 If you add a Welsh service
 name to your service, users will see this on Welsh-language payment pages instead of the
-usual service name.  
+usual service name.
 
 When users make a payment, they will also [see a
 `description`](/payment_flow/#making-a-payment). If you use Welsh-language
 payment pages, you may also want to use Welsh text in the
-`description`.  
+`description`.
 
 GOV.UK Pay does not automatically translate emails into Welsh. Please [contact
 us](/support_contact_and_more_information/#contact-us) if you would like to send Welsh language emails to your users.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -3,7 +3,7 @@ title: Payment flow overview
 weight: 50
 ---
 
-# Payment flow 
+# Payment flow
 
 This section outlines how your service will interact with GOV.UK Pay after integration.
 
@@ -21,7 +21,7 @@ This section outlines how your service will interact with GOV.UK Pay after integ
   </strong>
 </div>
 
-## Overview 
+## Overview
 
 The following diagram shows the payment process for a service that has an
 integration with GOV.UK Pay:
@@ -33,18 +33,18 @@ It also shows the relationship between GOV.UK Pay, payment service providers
 
 When an end user needs to make a payment, your service makes an API call to create a new payment, then redirects the user to the payment pages hosted on GOV.UK Pay.
 
-The end user enters their payment details (for example, credit/debit card details and billing address) on the GOV.UK Pay pages. GOV.UK Pay verifies the payment with the underlying PSP. 
+The end user enters their payment details (for example, credit/debit card details and billing address) on the GOV.UK Pay pages. GOV.UK Pay verifies the payment with the underlying PSP.
 
 After the transaction reaches a final state, the end user is then redirected back to your service.
 
 A final state means that the payment:
 
 + succeeds
-+ fails because it is declined 
++ fails because it is declined
 + fails because the user chooses to cancel
 + fails due to a technical error
 + fails because it is cancelled by your service
-+ fails because it times out - users have 90 minutes to complete a payment once it is created 
++ fails because it times out - users have 90 minutes to complete a payment once it is created
 
 When the user arrives back at your service, you can use the API to check the
 status of the transaction and show them an appropriate message.
@@ -54,7 +54,7 @@ reaching a final state:
 
 ![](images/payment-states.svg)
 
-## Making a payment 
+## Making a payment
 
 The following image represents a page on a service where the end user needs to make a payment:
 
@@ -62,13 +62,13 @@ The following image represents a page on a service where the end user needs to m
 
 > The payment pages are responsive and work on both desktop and mobile.
 
-In your service, this page might be the end of a series of pages you host which allow the user to choose between a variety of possible payments. 
+In your service, this page might be the end of a series of pages you host which allow the user to choose between a variety of possible payments.
 
-This page should make it clear to the user that they are about to pay for your product or service with a clear call to action. For example, a button that says __Pay now__ or __Continue to payment__. The user will then be taken to the GOV.UK Pay pages to complete their transaction. 
+This page should make it clear to the user that they are about to pay for your product or service with a clear call to action. For example, a button that says __Pay now__ or __Continue to payment__. The user will then be taken to the GOV.UK Pay pages to complete their transaction.
 
 The page should include clear information on what is being purchased. You do not need to tell the user that they are being handed over to GOV.UK Pay’s pages to make their payment.
 
-When the user clicks **Continue** in the example page, the service makes a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment" target="blank">Create new payment</a> call to the GOV.UK Pay API (link opens in new window). The body of the call contains information in JSON format. 
+When the user clicks **Continue** in the example page, the service makes a <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment" target="blank">Create new payment</a> call to the GOV.UK Pay API (link opens in new window). The body of the call contains information in JSON format.
 
 For example:
 
@@ -87,7 +87,7 @@ For example:
 + **return_url**: an HTTPS URL on your site that the user will be sent back to once they have completed their payment attempt on GOV.UK Pay (this should not be JSON-encoded as backslashes will not be accepted)
 
 In the example, responses to the __Create new payment__ API call would have
-headers of the form:  
+headers of the form:
 
 ```response
 HTTP/1.1 201 Created
@@ -95,7 +95,7 @@ Content-Type: application/json
 Location: https://publicapi.payments.service.gov.uk/v1/payments/icus7b4umg4b4g5fat4831es5f
 ```
 
-And response bodies would be of the form: 
+And response bodies would be of the form:
 
 ```javascript
 {
@@ -119,7 +119,7 @@ And response bodies would be of the form:
       "href": "https://publicapi.payments.service.gov.uk/secure/bb0a272c-8eaf-468d-b3xf-ae5e000d2231",
       "method": "GET"
     },
- ...}  
+ ...}
 }
 ```
 
@@ -129,7 +129,7 @@ The ``self`` URL (also provided in the Location header of the response) is a uni
 
 The ``next_url`` is the URL where your service should direct the end user next. It points to a payment page hosted by GOV.UK Pay where the user can enter their payment details. This is a one-time URL - after it’s been visited once, it will give an error message.
 
-When your service redirects the user to ``next_url``, they’ll see an __Enter card details__ page similar to the following: 
+When your service redirects the user to ``next_url``, they’ll see an __Enter card details__ page similar to the following:
 
 ![](images/flow-payment-details-page.png)
 
@@ -159,7 +159,7 @@ The user will receive a payment confirmation email containing:
 - who the payment was to
 - the total payment amount
 
-You can add a custom paragraph to a payment confirmation email at the [email notifications page](https://selfservice.payments.service.gov.uk/email-notifications) on the GOV.UK Pay admin site. 
+You can add a custom paragraph to a payment confirmation email at the [email notifications page](https://selfservice.payments.service.gov.uk/email-notifications) on the GOV.UK Pay admin site.
 
 You can further customise using [GOV.UK Notify](https://www.notifications.service.gov.uk/) to set up custom notifications. If you do this, the recommendation is to disable GOV.UK Pay notifications.
 
@@ -197,7 +197,7 @@ The following image is an example failure page:
 
 ## Check the status of a payment
 
-Regardless of the payment outcome, when a payment journey has reached a final state, GOV.UK Pay will return the user to the `return_url` provided in the initial request. 
+Regardless of the payment outcome, when a payment journey has reached a final state, GOV.UK Pay will return the user to the `return_url` provided in the initial request.
 
 The `return_url` should specify a page on your service. When the user visits the `return_url`, your service should:
 
@@ -211,7 +211,7 @@ To check the status of the payment, you must make a <a href="https://gds-payment
 
 The URL to do this is the same as the ``self`` URL provided in the response when the payment was first created.
 
-The response body contains information about the payment encoded in JSON format. The following is the start of a typical response: 
+The response body contains information about the payment encoded in JSON format. The following is the start of a typical response:
 
 ```javascript
 {
@@ -235,7 +235,7 @@ See the [__Making payments__](/making_payments/#making-payments) section for mor
 
 ## Resume a payment
 
-If your user starts a payment but does not complete it, they can resume that incomplete payment. An example of this could be if they click the browser’s back button during a payment, and then go forward by clicking the links on your website. 
+If your user starts a payment but does not complete it, they can resume that incomplete payment. An example of this could be if they click the browser’s back button during a payment, and then go forward by clicking the links on your website.
 
 If your service uses the resume payment feature, you will:
 
@@ -244,7 +244,7 @@ If your service uses the resume payment feature, you will:
 
 ## Payment expires
 
-Payments that are not confirmed and completed after 90 minutes will expire automatically. 
+Payments that are not confirmed and completed after 90 minutes will expire automatically.
 
 If the payment was authorised but incomplete, GOV.UK Pay will send a cancellation to the payment provider. This will raise a [P0020 API error](/api_reference/#api-errors-caused-by-payment-statuses).
 
@@ -256,4 +256,4 @@ An incomplete payment will have a status of `created`, `started` or `submitted`.
 
 When a user resumes a payment, the `next_URL` will take them to a screen that is appropriate for their payment’s current status. For example, a payment with a `started` status will resume at the card details input page. The `next_URL` is a one-time URL. If a payment has already resumed using a `next_URL`, that URL will not be usable again.
 
-A payment cannot resume if it has a status of `success`, `failed`, `cancelled` or `error`. If your service tries to resume a payment of this type, the user will be sent to your service’s `return_url`. The `return_url` is the URL of a page on your service that we send the user to after they have completed their payment attempt.   
+A payment cannot resume if it has a status of `success`, `failed`, `cancelled` or `error`. If your service tries to resume a payment of this type, the user will be sent to your service’s `return_url`. The `return_url` is the URL of a page on your service that we send the user to after they have completed their payment attempt.

--- a/source/payment_links/index.html.md.erb
+++ b/source/payment_links/index.html.md.erb
@@ -3,7 +3,7 @@ title: Payment links
 weight: 45
 ---
 
-# Payment links 
+# Payment links
 
 You may want to use payment links rather than integrate with the GOV.UK Pay API if your service:
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -3,7 +3,7 @@ title: Quick start guide
 weight: 40
 ---
 
-# Quick start guide 
+# Quick start guide
 
 Read this section to learn about what to do to get started with GOV.UK Pay.
 
@@ -13,10 +13,10 @@ Before you start testing GOV.UK Pay, you should:
 
 * read the [__Get started__
 guide](https://www.payments.service.gov.uk/getstarted/) (link opens in new
-window) to decide if GOV.UK Pay is right for your service 
+window) to decide if GOV.UK Pay is right for your service
 
 * sign up for [the GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/create-service/register) 
+tool](https://selfservice.payments.service.gov.uk/create-service/register)
 
 * read the government guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html).
@@ -28,7 +28,7 @@ Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-servic
 for more information. This does not apply if you only use [payment
 links](/payment_links/#payment-links).
 
-## The GOV.UK Pay API 
+## The GOV.UK Pay API
 
 The GOV.UK Pay API is based on REST principles with endpoints returning data
 in JSON format, and standard HTTP error response codes. The platform API
@@ -41,7 +41,7 @@ allows you to:
 
 Once you [have a test account](/before_you_start/#before-you-start), follow
 these instructions to get started with our API Explorer and make a test API
-call. 
+call.
 
 ## Generate API Key for API Explorer
 
@@ -53,16 +53,16 @@ call.
 
 ![](images/pay_9.png)
  <br /><br />Enter a description for your API key: <br /><br />
- 
- 
+
+
 ![](images/DescribeAPIKey+image2.png)
 <br /><br />Your API key will be shown for you to copy:<br /><br /> ![](images/NewKeygenerate+image+3.png)
 
 
-<blockquote>You must store your API keys securely. You must not share 
+<blockquote>You must store your API keys securely. You must not share
 this key in publicly accessible documents or repositories. You must not share
 it with anyone who should not be using the GOV.UK Pay API directly.</blockquote>
- 
+
 [Read the __Security__ section](/security/#security) for more information on how
 to keep your API key safe.
 
@@ -70,18 +70,18 @@ to keep your API key safe.
 
 The quickest way to get started with the API is to use the <a
 href="https://gds-payments.gelato.io/api-explorer/" target="blank">API
-Explorer</a> (link opens in new window) with your API key. 
+Explorer</a> (link opens in new window) with your API key.
 
 1. Sign in to the API Explorer and select __Add API Key__.<br/><br/>
    ![](images/pay-add-api-key.png) <br/><br/>
 2.  In the pop-up, enter the following values:
 
   * For __API Key__, enter your test API key. You do not need to add the
-  "Bearer: " prefix, because the API Explorer adds that automatically.  
-  * For __Label__, enter `Authorization`. 
+  "Bearer: " prefix, because the API Explorer adds that automatically.
+  * For __Label__, enter `Authorization`.
 
 > Do not use an API key from a live account on the GOV.UK Pay admin site. Only
-> use a test API key 
+> use a test API key
 
 ## Make a test API call
 
@@ -90,7 +90,7 @@ a new payment.  This is the same call your service will make when beginning a
 payment using GOV.UK Pay.
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).  
+   target="blank">the API Explorer</a> (link opens in new window).
 2. Under __Resource__, select __General__. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment"
    target="blank">__Create new payment__</a> (link opens in new window) Select
@@ -115,7 +115,7 @@ that the user will be redirected to after they have completed their payment
 
 Services that use test accounts can optionally use HTTP, rather than HTTPS,
 for return URLs. You can read more about this in [the __Security__
-section](/security/#https). 
+section](/security/#https).
 
 1. Select the green __Send Request__ button.
 
@@ -123,11 +123,11 @@ section](/security/#https).
    response with a JSON body, confirming that the payment was created:
 
    ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/pay-api-explorer-response.png)
-   
+
    The JSON includes a ``next_url`` link. This URL is where your service
    should redirect the user for them to make their payment.  <br/><br/>
 
-## Simulate an end-user payment journey 
+## Simulate an end-user payment journey
 
 Go to the ``next_url`` with a browser, and you’ll see the payment screen.
 Choose a mock card number from the [__Testing GOV.UK__
@@ -135,8 +135,8 @@ Pay"](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
 enter it to simulate a payment in the test environment. For the other
 required details, enter some test information which should have:
 
-  * an expiry date that is in the future and in the format MM/YYYY 
-  * a valid postcode 
+  * an expiry date that is in the future and in the format MM/YYYY
+  * a valid postcode
 
 Submit the payment.
 
@@ -144,7 +144,7 @@ Submit the payment.
 
 Go to the [GOV.UK Pay admin
 site](https://selfservice.payments.service.gov.uk/). From the landing page,
-select __Transactions__:  
+select __Transactions__:
 
 ![](images/transaction+list+image+4.png)
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -43,7 +43,7 @@ target="blank">Find payment by ID</a> or <a
 href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general/endpoints/search-payments"
 target="blank">Search payments</a> functions (links open in new window).
 
-The JSON response body will contain a `refund_summary` object. For example, 
+The JSON response body will contain a `refund_summary` object. For example,
 for a completed £50 payment with no previous refunds:
 
 ```javascript
@@ -69,7 +69,7 @@ target="blank">Get all refunds for a payment</a> (link opens in new window)
 API call to get information about partial refunds.
 
 As another example, this is the JSON response body for a completed £90 payment
-with a previous refund of £30: 
+with a previous refund of £30:
 
 ```javascript
   "refund_summary": {
@@ -112,7 +112,7 @@ the error code returned is P0604, with an HTTP status of 412.
 
 You must include any [corporate card
 surcharges](/optional_features/corporate_card_surcharges/#corporate-card-surcharges)
-in the ``refund_amount_available`` value. 
+in the ``refund_amount_available`` value.
 
 ## Refunding with the API
 
@@ -171,7 +171,7 @@ account with the PSP does not have enough funds to cover the refund.
 Each refund has a processing status indicated by a "status" value that is
 returned in response to a successful request to a ``/refunds/`` endpoint.
 
-For example, the response body for a refund would include: 
+For example, the response body for a refund would include:
 
 ```javascript
 {
@@ -203,7 +203,7 @@ target="blank">Find payment refund by ID</a> (link opens in new window) to
 check the processing status of the refund until it changes to either
 ``success`` or ``error``.
 
-It will typically take 30 minutes for the status to change. You should not  
+It will typically take 30 minutes for the status to change. You should not
 check the status more than once every 5 minutes.
 
 In the event of an error, GOV.UK Pay will not currently provide any more
@@ -223,7 +223,7 @@ transactions. For example:
 ![](images/transaction+list+image+4.png)
 
 In this list, you can select an individual payment to see details of that
-payment, including any previous refunds. 
+payment, including any previous refunds.
 
 For a successful payment with no previous refunds, you can use the red
 **Refund payment** button to carry out a full or partial payment.
@@ -247,7 +247,7 @@ new card with the refund. If this attempt fails, or the customer does not have
 a new card, the refund will have to be made using another channel (eg bank
 transfer or cheque).
 
-## Search refunds with the API  
+## Search refunds with the API
 
 You can use the GOV.UK Pay API to:
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -1,12 +1,12 @@
 ---
-title: Reporting 
+title: Reporting
 weight: 70
 ---
 
-# Reporting 
+# Reporting
 
 You can extract reporting information from GOV.UK Pay manually or via the
-API, for each service you have set up in GOV.UK Pay. 
+API, for each service you have set up in GOV.UK Pay.
 
 You can also read about [refunding payments](/refunding_payments/), including
 how to [search for refunds using the GOV.UK Pay API](/refunding_payments/#search-refunds-with-the-api).
@@ -15,22 +15,22 @@ how to [search for refunds using the GOV.UK Pay API](/refunding_payments/#search
 
 You can use your [GOV.UK Pay admin
 account](https://selfservice.payments.service.gov.uk/login) to export
-transaction information in a CSV file. 
+transaction information in a CSV file.
 
 1. For the account you want reporting information for, select __Transactions__
 in the __Dashboard__ page.
 
-2. Filter transactions using the available search criteria. 
+2. Filter transactions using the available search criteria.
 
-3. Select __Download all transaction details as a CSV file__. 
+3. Select __Download all transaction details as a CSV file__.
 
 The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page. You can process CSV files using
 spreadsheet software and edit the contents you do not need.
 
-## Reporting via the GOV.UK Pay API 
+## Reporting via the GOV.UK Pay API
 
 Before reading this section, you should be familiar with the ‘[Making
-payments](/making_payments)’ section. 
+payments](/making_payments)’ section.
 
 You can get data from the GOV.UK Pay API in a format suitable for automatic
 processing. For example, you could develop software to query the GOV.UK Pay
@@ -41,22 +41,22 @@ lead to significant cost savings for your organisation.
 You can use the GOV.UK Pay API to:
 
 * get information about a single payment
-* generate a list of payments matching search criteria  
+* generate a list of payments matching search criteria
 
 ## Get information about a single payment
 
 `GET /v1/payments/paymentId`
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).  
-2. Under __Resource__, select __{Payment Id}__. 
+   target="blank">the API Explorer</a> (link opens in new window).
+2. Under __Resource__, select __{Payment Id}__.
 3. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/"
-   target="blank">__Find payment by ID__</a> (link opens in new window). 
-   
+   target="blank">__Find payment by ID__</a> (link opens in new window).
+
 If the payment exists, the JSON response body to this
 API call contains a `"state"` field. You can use this information when
-designing a service.  
+designing a service.
 
 For example, the response for a successful payment contains:
 
@@ -73,7 +73,7 @@ through your service.
 For a valid request, the JSON response body to this API call also contains
 other useful information. For example, if a user has gone far enough in their
 payment journey, the `"card_details"` section contains information that they
-have entered when making a payment: 
+have entered when making a payment:
 
 ```
   "card_details": {
@@ -90,45 +90,45 @@ have entered when making a payment:
     },
 ```
 
-## Generate a list of payments (search payments) 
+## Generate a list of payments (search payments)
 
 `GET /v1/payments`
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).  
-2. Under __Resource__, select __General__. 
+   target="blank">the API Explorer</a> (link opens in new window).
+2. Under __Resource__, select __General__.
 3. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/"
-   target="blank">__Search payments__</a> (link opens in new window). 
+   target="blank">__Search payments__</a> (link opens in new window).
 
-### Search criteria 
+### Search criteria
 
 An example search request:
 
 `GET
 /v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&reference=12345&state=success`
 
-Some of the query parameters you can use to search for payments are: 
+Some of the query parameters you can use to search for payments are:
 
 * `reference`
 * `email`
-* `state` 
-* `card_brand` 
+* `state`
+* `card_brand`
 * `first_digits_card_number`
 * `last_digits_card_number`
 * `cardholder_name`
 
 If you search for a specific payment, all criteria you use must match.
-Otherwise, that payment will not be returned in the results. 
+Otherwise, that payment will not be returned in the results.
 
-If your request has no query parameters, the API will return all payments. 
+If your request has no query parameters, the API will return all payments.
 
 #### Filter by date
 
 You can use the following query parameters to filter payments by date:
 
-* `from_date` - the start date for payments to be searched, inclusive 
-* `to_date` - the end date for payments to be searched, exclusive 
+* `from_date` - the start date for payments to be searched, inclusive
+* `to_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [ISO
 8601](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
@@ -137,9 +137,9 @@ These take inputs based on a subset of [ISO
 
 #### Pagination
 
-You can use the following query parameters for pagination: 
+You can use the following query parameters for pagination:
 
-* `display-size` - default, and maximum, is `500` 
+* `display-size` - default, and maximum, is `500`
 * `page` - default is `1`
 
 These must be a positive integer. For example, for the following search:

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Security 
+title: Security
 weight: 140
 ---
 
@@ -90,7 +90,7 @@ Your service manager may also be asked to supply extra evidence on your internal
 GOV.UK Pay follows [government HTTPS security guidelines](https://www.gov.uk/service-manual/domain-names/https.html). The Hypertext Transfer Protocol Secure (HTTPS), which involves the Transport Layer Security  (TLS) protocol is used by the platform to authenticate servers / clients and to provide secure connections.
 
 You must use HTTPS for all direct communication between your service and
-GOV.UK Pay. 
+GOV.UK Pay.
 
 Return URLs for live services using GOV.UK Pay must use HTTPS, but [you can use HTTP for return
 URLs with test accounts](/testing_govuk_pay/#testing-gov-uk-pay).

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -1,14 +1,14 @@
 ---
-title: Support, contact and more information 
+title: Support, contact and more information
 weight: 160
 ---
 
 # Support
 
 You can subscribe to our public status page for updates [on the status of our
-system](https://payments.statuspage.io/). 
+system](https://payments.statuspage.io/).
 
-## Incident severity 
+## Incident severity
 
 GOV.UK Pay incident severities are defined as follows:
 
@@ -25,29 +25,29 @@ GOV.UK Pay incident severities are defined as follows:
 
 ## Hours of service
 
-In-hours support is from Monday-Friday 9:30am-5:30pm and covers all ticket priorities (P1-4). 
+In-hours support is from Monday-Friday 9:30am-5:30pm and covers all ticket priorities (P1-4).
 
 Out-of-hours support covers P1 support tickets only, during:
 
 - Monday-Friday 5:30pm-9:30am
 - Saturday-Sunday and bank holidays 24x7
 
-## Contact us 
+## Contact us
 
-If you raise a support request, the GOV.UK Pay team will contact you using the 
-Zendesk ticketing system. 
+If you raise a support request, the GOV.UK Pay team will contact you using the
+Zendesk ticketing system.
 
 ### P1 support queries (critical incidents)
 
 For P1 support requests, you will receive instructions from us when you
-sign on as a partner. 
+sign on as a partner.
 
-### P2-P4 support queries (non-critical incidents) 
+### P2-P4 support queries (non-critical incidents)
 
 For all non-P1 support requests, contact us via email at
 [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-### General feedback 
+### General feedback
 
-If you have any feedback or questions, please email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). 
+If you have any feedback or questions, please email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 

--- a/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
+++ b/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
@@ -1,14 +1,14 @@
 ---
-title: Switching to live 
+title: Switching to live
 weight: 99
 ---
 
-# Before you switch to live 
+# Before you switch to live
 
-Before you start taking live payments, you should: 
+Before you start taking live payments, you should:
 
 * have a signed MOU or contract with GOV.UK Pay
-* [provide organisation information](#provide-organisation-information) to GOV.UK Pay 
+* [provide organisation information](#provide-organisation-information) to GOV.UK Pay
 * request a [live GOV.UK Pay account](#request-a-live-gov-uk-pay-account)
 * make sure that the right people on your
 team [know how to report an emergency](#emergency-contact-details)
@@ -16,7 +16,7 @@ team [know how to report an emergency](#emergency-contact-details)
 GOV.UK Pay currently supports live gateways for the PSPs
 [ePDQ](/switching_to_live/set_up_a_live_epdq_account),
 [Smartpay](/switching_to_live/set_up_a_live_smartpay_account) and
-[Worldpay](/switching_to_live/set_up_a_live_worldpay_account).  
+[Worldpay](/switching_to_live/set_up_a_live_worldpay_account).
 
 ## Provide organisation information
 
@@ -28,9 +28,9 @@ to GOV.UK Pay.
    account](https://selfservice.payments.service.gov.uk/login).
 1. Select __My services__.
 1. For the test account you want to make live, select __Organisation
-   details__. 
+   details__.
 1. Complete the __Name__ and __Address__ fields.
-1. Select __Save__. 
+1. Select __Save__.
 
 > Make sure the organisation is the entity that has a contract with the
 > payment service provider.
@@ -41,7 +41,7 @@ to GOV.UK Pay.
    account](https://selfservice.payments.service.gov.uk/login).
 1. Select __My services__.
 1. For the test account you want to make live, select __Manage team members__
-   on the dashboard. 
+   on the dashboard.
 1. Copy the full page URL, for example   `https://selfservice.payments.service.gov.uk/service/23f0eb425a9569988b99b5bb641a541d`.
 
 Send the GOV.UK Pay team the page URL, your service name, and what type of PSP
@@ -59,7 +59,7 @@ Before you switch to live, you may find it helpful to read about the [support
 the GOV.UK Pay team provides](/support_contact_and_more_information/#support).
 
 While GOV.UK Pay is in beta, our team can provide hands-on support to you as you
-make your service live if you require it. 
+make your service live if you require it.
 
 ### Emergency contact details
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Switching to live 
+title: Switching to live
 weight: 100
 ---
 
@@ -18,13 +18,13 @@ link](/payment_links/#payment-links) functionality.
 
 Please read the guidance on what to do [before you switch to live](/switching_to_live/before_you_switch_to_live/#before-you-switch-to-live) first.
 
-You can then read about switching to live for: 
+You can then read about switching to live for:
 
 * [ePDQ](/switching_to_live/set_up_a_live_epdq_account) accounts
 * [Smartpay](/switching_to_live/set_up_a_live_smartpay_account) accounts
-* [Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts 
+* [Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts
 
-## The differences between test and live accounts 
+## The differences between test and live accounts
 
 The key differences are:
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Switching to live 
+title: Switching to live
 weight: 100
 ---
 
@@ -13,7 +13,7 @@ You should follow these instructions in order.
 
 You can also read about setting up live
 [Smartpay](/switching_to_live/set_up_a_live_smartpay_account) and
-[Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts. 
+[Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts.
 
 ## Add payment methods to your account
 
@@ -23,13 +23,13 @@ landing page, go to __Configuration__ then __Payment methods__ and select __Choo
 new payment methods__. Select __Add__ next to all relevant payment methods.
 
 On the __Contract data__ tab:
-    
-1. specify whether you have signed a contract for distance selling with an acquiring bank 
-2. complete the __Affiliation number (UID/Merch ID/VP number)__ field 
+
+1. specify whether you have signed a contract for distance selling with an acquiring bank
+2. complete the __Affiliation number (UID/Merch ID/VP number)__ field
 3. select __Submit__
 
 On the __PM Activation__ tab:
-    
+
 1. select __Yes__ for __Activation__
 2. select __Submit__
 
@@ -39,7 +39,7 @@ On the __PM Activation__ tab:
 
 On the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index), go to
-__Configuration__. 
+__Configuration__.
 
 1. On the __Technical Information__ page, select the __Global security
    parameters__ tab.
@@ -50,7 +50,7 @@ __Configuration__.
 
 On the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index), go to
-__Configuration__. 
+__Configuration__.
 
 1. On the __Technical information__ page, select the __Data and origin
    verification__ tab.
@@ -75,7 +75,7 @@ Gateway__ section and select __Save__.
 
 On the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index), go to
-__Configuration__. 
+__Configuration__.
 
 1. On the __Technical information__ page, select __Transaction feedback__.
 1. Go to __e-Commerce__ and the __Direct HTTP server-to-server request__
@@ -105,7 +105,7 @@ __Configuration__.
 1. In the __URL on which the merchant wishes to receive a deferred HTTP request,
 should the status of a transaction change offline__ field, enter:
 <br> `https://notifications.payments.service.gov.uk/v1/api/notifications/epdq`
-</br> 
+</br>
 1. Select __Save__.
 
 ## Set up an API user
@@ -115,7 +115,7 @@ should the status of a transaction change offline__ field, enter:
 1. Go to __Configuration__ then __Account__.
 1. Go to the __Your options__ tab.
 1. Under the __Available options__ sub-tab, there is a list of IDs with
-   __Activate__ options. 
+   __Activate__ options.
 1. Activate one of the __User Manager__ options.
 1. Select __Accept__ on the __General Conditions__ screen.
 1. Sign out and then sign back in again.
@@ -125,7 +125,7 @@ should the status of a transaction change offline__ field, enter:
 1. On the __Users__ page, select __New User__.
 1. Complete the __UserID__ and __User’s name__ fields.
 1. Complete the __Email address__ field. This should contain the email address you want to receive notifications.
-1. In the __Profile__ field, select __Admin__.  
+1. In the __Profile__ field, select __Admin__.
 1. Check the __Special user for API (no access to admin.)__ option.
 1. Enter your own password and select __Create__.
 
@@ -146,7 +146,7 @@ In your [GOV.UK Pay
   <br> __SHA-IN passphrase__ - described in [__Set up account security parameters__](#set-up-account-security-parameters)</br>
   <br> __SHA-OUT passphrase__ - described in [__Set up notification settings__](#set-up-notification-settings)</br>
 
-1. Select __Save credentials__.  
+1. Select __Save credentials__.
 
 ## Test your configuration
 
@@ -154,7 +154,7 @@ In your [GOV.UK Pay
    accept are set up.
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this, or use [payment
-   links](/payment_links) if your service is not yet connected to GOV.UK Pay. 
+   links](/payment_links) if your service is not yet connected to GOV.UK Pay.
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
 4. Go to the [__Transactions__
@@ -164,12 +164,12 @@ In your [GOV.UK Pay
 
 > The refund option may take up to 20 minutes to appear after submitting the transaction.
 
-## Set up 3D Secure 
+## Set up 3D Secure
 
 To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay
 self-service admin site](https://selfservice.payments.service.gov.uk/). Go to
 __My services__ to select the live service you want to set up. Select
-__Settings__, then __3D Secure__ and then __turn 3D Secure on__. 
+__Settings__, then __3D Secure__ and then __turn 3D Secure on__.
 
 3D Secure should be enabled by default on the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index). To check

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Switching to live 
+title: Switching to live
 weight: 100
 ---
 
@@ -13,19 +13,19 @@ You should follow these instructions in order.
 
 You can also read about setting up live
 [ePDQ](/switching_to_live/set_up_a_live_epdq_account) and
-[Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts. 
+[Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts.
 
 ## Configure your user profile on Smartpay
 
 Sign in to Smartpay and select the correct merchant account. You can select
-the organisation name at the top of the page to view all merchant accounts. 
+the organisation name at the top of the page to view all merchant accounts.
 
 ### Add new user
 
 1. Select __Settings__ and then __Users__.
 1. Select __Add new user__.
 1. Select __Web Service__ as the user type.
-1. Complete both the __Password__ fields. 
+1. Complete both the __Password__ fields.
 1. Leave the __Client Certificate (DN)__ field blank.
 
 >  You will use this username and password on the GOV.UK Pay admin site to
@@ -46,14 +46,14 @@ Select __Accounts__ and enable your merchant account, then select __Save__.
 
 ### Generate client encryption key
 
-Under __Easy Encryption__, select __Generate__. Leave the other options 
+Under __Easy Encryption__, select __Generate__. Leave the other options
 as their defaults.
 
 ### Edit allowed user IP range
 
-Set the __IP address__ to `0.0.0.1`. Leave the other options 
+Set the __IP address__ to `0.0.0.1`. Leave the other options
 as their defaults.
-    
+
 ## Configure server communication on Smartpay
 
 Select __Settings__ and then __Server Communication__.
@@ -63,17 +63,17 @@ __Standard Notification__ row.
 
 Complete all the fields on the __Standard Notification settings__ page.
 
-### Set up “Transport” 
+### Set up “Transport”
 
 Complete the fields in the __Transport__ page as follows:
 
 - __URL__: `https://notifications.payments.service.gov.uk/v1/api/notifications/smartpay`
-- __SSL Version__: TLSv1.2 
-- __Active__: Checked 
-- __Accept expired__:  Leave unchecked 
-- __Accept self-signed__:  Leave unchecked 
-- __Accept untrusted Root certificates__:  Leave unchecked 
-- __Service version__: 1 
+- __SSL Version__: TLSv1.2
+- __Active__: Checked
+- __Accept expired__:  Leave unchecked
+- __Accept self-signed__:  Leave unchecked
+- __Accept untrusted Root certificates__:  Leave unchecked
+- __Service version__: 1
 - __Method__: JSON
 - __Populate SOAP Action header__: Leave unchecked
 
@@ -111,7 +111,7 @@ Complete the following fields on this page:
 ### Set up notification credentials
 
 1. Under __Your Smartpay notification credentials__, select __Edit
-   notification credentials__. 
+   notification credentials__.
 1. Complete the __Username__ and __Password__ fields on this page using the
    username and password described in [the Authentication section](#authentication).
 1. Select __Save credentials__ to go back to the __Account credentials__ page.
@@ -122,7 +122,7 @@ Complete the following fields on this page:
    accept are set up.
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this, or use [payment
-   links](/payment_links) if your service is not yet connected to GOV.UK Pay. 
+   links](/payment_links) if your service is not yet connected to GOV.UK Pay.
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
 4. Go to the [__Transactions__
@@ -132,13 +132,13 @@ Complete the following fields on this page:
 
 > The refund option may take up to 20 minutes to appear after submitting the transaction.
 
-## Set up 3D Secure 
+## Set up 3D Secure
 
 To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay
-self-service admin site](https://selfservice.payments.service.gov.uk/). 
+self-service admin site](https://selfservice.payments.service.gov.uk/).
 
-Go to __My services__ to select the live service you want to set up. 
-Select __Settings__, then __3D Secure__ and then __Turn on 3D Secure__. 
+Go to __My services__ to select the live service you want to set up.
+Select __Settings__, then __3D Secure__ and then __Turn on 3D Secure__.
 
 Barclaycard is responsible for setting up 3D Secure payment authentication
 for your Smartpay account. You do not need to set anything manually.

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Switching to live 
+title: Switching to live
 weight: 100
 ---
 
@@ -32,12 +32,12 @@ If __Switch to Production__ is at the bottom of the left-hand menu, toggle it on
 ## Set up your profile
 
 To set up your profile, you need to copy credentials from your Worldpay account
-into your GOV.UK Pay account. 
+into your GOV.UK Pay account.
 
 You will need both your [Worldpay
 account](https://secure.worldpay.com/sso/public/auth/login.html) and your
 [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/login) open
-and signed in, in different web browser tabs.  
+and signed in, in different web browser tabs.
 
 1. Select __Profile__ in the left-hand menu in your Worldpay account.
 
@@ -46,12 +46,12 @@ service you want to set up. Select __Settings__, then __Account credentials__,
 then __Edit credentials__.
 
 1. In your Worldpay browser tab, select __Account__ in the left-hand
-menu. 
+menu.
 
 1. From the __Identification__ section, copy the Worldpay __Merchant Code__ into
 the GOV.UK Pay __Merchant ID__ field.
 
-1. Select the checkbox __Enable original username__ and select __save__. 
+1. Select the checkbox __Enable original username__ and select __save__.
 
 1. Copy the Worldpay __Original XML Username__ into the GOV.UK Pay
 __Username__ field.
@@ -60,7 +60,7 @@ __Username__ field.
 
     <br> select the pencil icon next to __XML Password__ </br>
     <br> change the password and select __Add new Password__ </br>
-    <br> select __OK__ to go back to the __Profile__ page </br> 
+    <br> select __OK__ to go back to the __Profile__ page </br>
     <br> select the pencil icon again, then __Complete__ then __OK__ </br>
     <br><br>
 
@@ -79,9 +79,9 @@ account](https://secure.worldpay.com/sso/public/auth/login.html), select
 __Merchant Channel__. Go to the __http Protocol__ row of the __Merchant
 Channels (Production)__ category.
 
-You should see 4 groupings of settings. 
+You should see 4 groupings of settings.
 
-For the first 2, __Merchant Channels (Production)__ and __Merchant Channels (Test)__: 
+For the first 2, __Merchant Channels (Production)__ and __Merchant Channels (Test)__:
 
 1. Under __Active__, select __yes__.
 2. Set __Address__ to
@@ -91,7 +91,7 @@ For the first 2, __Merchant Channels (Production)__ and __Merchant Channels (Tes
 5. Under __Merchant Channels (Production)__ and __Active__, set the __email__ and __shopper
    email__ protocols to __no__.
 
-For the next 2, also named __Merchant Channels (Production)__ and __Merchant Channels (Test)__: 
+For the next 2, also named __Merchant Channels (Production)__ and __Merchant Channels (Test)__:
 
 Check the following in the __http__ row only:
 
@@ -149,7 +149,7 @@ __REVOKED__
    accept are set up.
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this, or use [payment
-   links](/payment_links) if your service is not yet connected to GOV.UK Pay. 
+   links](/payment_links) if your service is not yet connected to GOV.UK Pay.
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
 4. Go to the [__Transactions__
@@ -165,8 +165,8 @@ Ask your Worldpay account manager to configure your merchant code to enable 3D
 Secure for all payments.
 
 When this is available, sign in to your [GOV.UK Pay
-account](https://selfservice.payments.service.gov.uk/login). Go to __My 
+account](https://selfservice.payments.service.gov.uk/login). Go to __My
 services__ to select the live service you want to set up. Select __Settings__,
-then __3D Secure__ and then select __Turn 3D Secure on__. 
+then __3D Secure__ and then select __Turn 3D Secure on__.
 
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -24,7 +24,7 @@ You can [try the payment experience as a
 user](https://selfservice.payments.service.gov.uk/make-a-demo-payment), and
 then view the completed payment as a GOV.UK Pay administrator.
 
-### Test your service with your users 
+### Test your service with your users
 
 You can [create a reusable
 link](https://selfservice.payments.service.gov.uk/test-with-your-users) to

--- a/source/troubleshooting/index.html.md.erb
+++ b/source/troubleshooting/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting 
+title: Troubleshooting
 weight: 110
 ---
 

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Versioning 
+title: Versioning
 weight: 130
 ---
 


### PR DESCRIPTION
### Context
There are a lot of trailing whitespaces in index.html.md.erb files we use to render our docs. This isn't good practice even though it's not actually important as far as Middleman's rendering is concerned, because it may be awkward for some people navigating through the docs in future when making edits using Git.

### Changes proposed in this pull request
Rids all docs files of whitespace.

### Guidance to review
I've tested and built this locally and can't see any changes as far as the user is concerned. If I've missed something we can revert this commit.

Apologies for having to remake https://github.com/alphagov/pay-tech-docs/pull/214—I'd rather not have to add an extra merge commit