### PR TITLE
Amendment to 'Switching to live' Smartpay docs re. generating encryption key before saving roles/accounts configuration

### DIFF
--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -31,6 +31,11 @@ the organisation name at the top of the page to view all merchant accounts.
 >  You will use this username and password on the GOV.UK Pay admin site to
 >  [set up your account credentials](#set-up-credentials-on-gov-uk-pay) later.
 
+### Generate client encryption key
+
+Under __Easy Encryption__, select __Generate__. Leave the other options
+as their defaults.
+
 ### Enable roles and accounts
 
 Under __Roles and Associated Accounts__, select __Roles__ and enable the
@@ -43,11 +48,6 @@ following roles:
 > Contact Smartpay if any of these roles are not available.
 
 Select __Accounts__ and enable your merchant account, then select __Save__.
-
-### Generate client encryption key
-
-Under __Easy Encryption__, select __Generate__. Leave the other options
-as their defaults.
 
 ### Edit allowed user IP range
 


### PR DESCRIPTION
### Context
Per feedback from FCO, we need to amend the order of information in our Smartpay switching to live docs: we should direct users to generate an encryption key BEFORE saving roles/accounts configuration

### Changes proposed in this pull request
Switches section on using encryption key and section on saving configuration around, so that encryption comes first

### Guidance to review
ZenDesk ticket 3483808