### PR TITLE
Worldpay docs inaccuracies 

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -7,6 +7,8 @@ weight: 100
 
 Please read this information carefully.
 
+Please read the guidance on what to do [before you switch to live](/switching_to_live/before_you_switch_to_live/#before-you-switch-to-live) first.
+
 Follow these steps to switch your account from ‘test’ to ‘live’. You should
 only do this when you’ve finished [testing with your test
 account](/testing_govuk_pay/#testing-gov-uk-pay), and you’re confident that
@@ -15,8 +17,6 @@ account](/testing_govuk_pay/#testing-gov-uk-pay), and you’re confident that
 This guidance is for services that have integrated
 with the GOV.UK Pay API or which use the [payment
 link](/payment_links/#payment-links) functionality.
-
-Please read the guidance on what to do [before you switch to live](/switching_to_live/before_you_switch_to_live/#before-you-switch-to-live) first.
 
 You can then read about switching to live for:
 

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -34,27 +34,22 @@ If __Switch to Production__ is at the bottom of the left-hand menu, toggle it on
 To set up your profile, you need to copy credentials from your Worldpay account
 into your GOV.UK Pay account.
 
-You will need both your [Worldpay
+You must separately sign in to both your [Worldpay
 account](https://secure.worldpay.com/sso/public/auth/login.html) and your
-[GOV.UK Pay account](https://selfservice.payments.service.gov.uk/login) open
-and signed in, in different web browser tabs.
+[GOV.UK Pay account](https://selfservice.payments.service.gov.uk/login). You
+should have both accounts open, in different web browser tabs.
 
-1. Select __Profile__ in the left-hand menu in your Worldpay account.
+1. In your Worldpay browser tab, select __Profile__ in the left-hand menu. If you
+are prompted to choose a merchant code, select the appropriate one.
 
 1. In your GOV.UK Pay browser tab, go to __My services__ to select the live
 service you want to set up. Select __Settings__, then __Account credentials__,
 then __Edit credentials__.
 
-1. In your Worldpay browser tab, select __Account__ in the left-hand
-menu.
-
-1. From the __Identification__ section, copy the Worldpay __Merchant Code__ into
+1. In Worldpay, copy the Worldpay __Merchant Code__ from __Identification__ into
 the GOV.UK Pay __Merchant ID__ field.
 
-1. Select the checkbox __Enable original username__ and select __save__.
-
-1. Copy the Worldpay __Original XML Username__ into the GOV.UK Pay
-__Username__ field.
+1. Copy the Worldpay __New Username__ into the GOV.UK Pay __Username__ field.
 
 1. Change the Worldpay XML password:
 
@@ -70,30 +65,30 @@ __Username__ field.
 __Account credentials__ page.
 
 1. In your Worldpay browser tab, go to the __Profile__ page. Go to the __Payment service__
-section and set __Capture delay (days)__ to __Off__.
+section and set __Capture delay (days)__ to __0ff__ (not `0`).
 
 ## Set up “Merchant Channel”
 
 In the left-hand menu of [your Worldpay
 account](https://secure.worldpay.com/sso/public/auth/login.html), select
-__Merchant Channel__. Go to the __http Protocol__ row of the __Merchant
-Channels (Production)__ category.
+__Merchant Channel__.
 
-You should see 4 groupings of settings.
+You must edit the content in the _http_ row, under __Protocol__. 
 
-For the first 2, __Merchant Channels (Production)__ and __Merchant Channels (Test)__:
+For __Merchant Channels (Production)__ and __Merchant Channels (Test)__, check
+the following:
 
 1. Under __Active__, select __yes__.
-2. Set __Address__ to
+1. Set __Content__ to __xml__ 
+1. Set __Address__ to
    `https://notifications.payments.service.gov.uk/v1/api/notifications/worldpay`.
-3. Set __Method__ to __POST__.
-4. Set __Client certificate__ to __no__.
-5. Under __Merchant Channels (Production)__ and __Active__, set the __email__ and __shopper
+1. Set __Method__ to __POST__.
+1. Set __Client certificate__ to __no__.
+1. Under __Merchant Channels (Production)__ and __Active__, set the __email__ and __shopper
    email__ protocols to __no__.
 
-For the next 2, also named __Merchant Channels (Production)__ and __Merchant Channels (Test)__:
-
-Check the following in the __http__ row only:
+For __Merchant Channel Events (Production)__ and __Merchant Channel Events
+(Test)__, check the following in the __http__ row only:
 
 __SIGNED_FORM_RECEIVED__
 


### PR DESCRIPTION
### Context
We haven't had access to the user journey for switching to live on Worldpay until now, so there are some inaccuracies in the documentation. It seems like Worldpay may have amended/updated some terminology, as well. Also, we should be recommending __New Username__ above __Original XML Username__. 

### Changes proposed in this pull request
Amends Worldpay STL documentation to reflect actual user journey/Worldpay updates