### PR TITLE
Erroneous double quote in QS guide section

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -145,7 +145,7 @@ section](/security/#https).
 
 Go to the ``next_url`` with a browser, and you’ll see the payment screen.
 Choose a mock card number from the [__Testing GOV.UK__
-Pay"](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
+Pay](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
 enter it to simulate a payment in the test environment. For the other
 required details, enter some test information which should have:
 


### PR DESCRIPTION
### Context
![image](https://user-images.githubusercontent.com/32935794/49653900-30dc8c80-fa2e-11e8-8864-31394f28ff11.png)


### Changes proposed in this pull request
Fix for image
