### PR TITLE
Calls out need to sign up for API explorer in QS guide

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -5,8 +5,6 @@ weight: 40
 
 # Quick start guide
 
-<br>
-
 <style>
 .govuk-warning-text{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:16px;font-size:1rem;line-height:1.25;color:#0b0c0c;position:relative;margin-bottom:20px;padding:10px 0}@media print{.govuk-warning-text{font-family:sans-serif}}@media (min-width:40.0625em){.govuk-warning-text{font-size:19px;font-size:1.1875rem;line-height:1.31579}}@media print{.govuk-warning-text{font-size:14pt;line-height:1.15;color:#000}}@media (min-width:40.0625em){.govuk-warning-text{margin-bottom:30px}}.govuk-warning-text__assistive{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;border:0!important;white-space:nowrap!important}.govuk-warning-text__icon{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;display:inline-block;position:absolute;top:50%;left:0;min-width:32px;min-height:29px;margin-top:-20px;padding-top:3px;border:3px solid #0b0c0c;border-radius:50%;color:#fff;background:#0b0c0c;font-size:1.6em;line-height:29px;text-align:center;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}@media print{.govuk-warning-text__icon{font-family:sans-serif}}.govuk-warning-text__text{display:block;margin-left:-15px;padding-left:65px}
 </style>
@@ -29,11 +27,14 @@ Before you start using GOV.UK Pay, you should:
 guide](https://www.payments.service.gov.uk/getstarted/) to decide if GOV.UK
 Pay is right for your service
 
-* sign up for [the GOV.UK Pay admin
+* sign up to the [GOV.UK Pay admin
 site](https://selfservice.payments.service.gov.uk/create-service/register)
 
 * read the GOV.UK Service Manual guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html)
+
+* sign up to the [API
+explorer](https://gds-payments.gelato.io/) if you want to use it to test the API
 
 If you want to build a technical integration between your service and the
 GOV.UK Pay API, your service team should have the necessary skills. You can


### PR DESCRIPTION
### Context
An easy addition to call out the need to sign up for the API explorer as part of the QS guide

### Changes proposed in this pull request
Adds a line and a link to Gelato