### PR TITLE
Change notes about 90min expiry to 48h in delayed capture 

### DIFF
--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -30,7 +30,7 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 90 minutes of the
+Your service must send the delayed capture request within 48 hours of the
 payment creation, regardless of how long the user takes to complete the
 payment flow. Otherwise, it will expire.
 


### PR DESCRIPTION
### Context
The delayed capture should reflect a 48 hour expiry 

### Changes proposed in this pull request
Change to reflect above need 
