### PR TITLE
Adds correct images path to avoid 404s

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -19,7 +19,7 @@ As an example, take 2 services called ‘parking permits’ and ‘parking fines
 
 ### Type 1 (GOV.UK Pay separate, PSP separate)
 
-![``”``](images/accountstructure_1.png)
+![``”``](/images/accountstructure_1.png)
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
 both GOV.UK Pay and the PSP.
@@ -29,7 +29,7 @@ each service has a PSP account.
 
 ### Type 2 (GOV.UK Pay combined, PSP combined)
 
-![``”``](images/accountstructure_2.png)
+![``”``](/images/accountstructure_2.png)
 
 ‘Parking permits’ and ‘Parking fines’ are considered a single combined
 service by GOV.UK Pay and the PSP.
@@ -42,7 +42,7 @@ they are a single service in the PSP. It is not possible to support multiple PSP
 
 ### Type 3 (GOV.UK Pay separate, PSP combined)
 
-![``”``](images/accountstructure_3.png)
+![``”``](/images/accountstructure_3.png)
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
 GOV.UK Pay and as a single combined service in the PSP.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -45,7 +45,7 @@ Authorization: Bearer <YOUR-API-KEY-HERE>
 The following diagram gives an overview of the payment status lifecycle and the
 possible outcomes, excluding for delayed capture payments:
 
-![](images/payment-states.svg)
+![](/images/payment-states.svg)
 
 You can check the status of a payment using the <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -58,7 +58,7 @@ status of the transaction and show them an appropriate message.
 The following diagram illustrates the states a payment can pass through before
 reaching a final state:
 
-![](images/payment-states.svg)
+![](/images/payment-states.svg)
 
 ## Making a payment
 
@@ -67,7 +67,7 @@ between a variety of possible payments. At the end of this, you may have a
 page where the end user needs to make a payment. The following image shows an
 example: 
 
-![](images/flow-service-pay-page.png)
+![](/images/flow-service-pay-page.png)
 
 This page should make it clear to the user that they are about to pay for your
 product or service, with a clear call to action. For example a button that
@@ -162,7 +162,7 @@ it will give an error message.
 When your service redirects the user to `next_url`, they’ll see an __Enter
 card details__ page similar to the following image:
 
-![](images/flow-payment-details-page.png)
+![](/images/flow-payment-details-page.png)
 
 This page shows the `description` as well as the amount the end user has to
 pay, making it clear what they’re paying for.
@@ -179,7 +179,7 @@ If the details are valid and the payment is approved by the PSP, the user is
 then taken to a payment confirmation page, still hosted by GOV.UK Pay. The
 user then decides whether or not to complete their payment:
 
-![](images/flow-payment-confirm-page.png)
+![](/images/flow-payment-confirm-page.png)
 
 If the user decides to complete the payment, they select __Confirm__. They
 will then:
@@ -243,7 +243,7 @@ should show them a page that confirms that the payment failed. This should eithe
 
 The following image is an example failure page:
 
-![](images/flow-payment-declined.png)
+![](/images/flow-payment-declined.png)
 
 ## Check the status of a payment
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -64,11 +64,11 @@ with our API Explorer and make a test API call.
 
 2. From the landing page, select __API key__, then __Generate a new key__.
 
-![](images/pay_9.png)
+![](/images/pay_9.png)
  <br /><br />Enter a description for your API key: <br /><br />
 
-![](images/DescribeAPIKey+image2.png)
-<br /><br />Your API key will be shown for you to copy:<br /><br /> ![](images/NewKeygenerate+image+3.png)
+![](/images/DescribeAPIKey+image2.png)
+<br /><br />Your API key will be shown for you to copy:<br /><br /> ![](/images/NewKeygenerate+image+3.png)
 
 [Read the __Security__ section](/security/#security) for more information on how
 to keep your API key safe.
@@ -80,7 +80,7 @@ href="https://gds-payments.gelato.io/api-explorer/" target="blank">API
 Explorer</a> [external link] with your API key.
 
 1. Sign in to the API Explorer and select __Add API Key__.<br/><br/>
-   ![](images/pay-add-api-key.png) <br/><br/>
+   ![](/images/pay-add-api-key.png) <br/><br/>
 2.  In the pop-up, enter the following values:
 
   * For __API Key__, enter your test API key. You do not need to add the
@@ -160,6 +160,6 @@ Go to the [GOV.UK Pay admin
 site](https://selfservice.payments.service.gov.uk/). From the landing page,
 select __Transactions__:
 
-![](images/transaction+list+image+4.png)
+![](/images/transaction+list+image+4.png)
 
 Enter search criteria to find transactions using the available filters.

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -220,7 +220,7 @@ issue refunds.
 Go to the __Transactions__ section of your accoun page to see a list of
 transactions. For example:
 
-![](images/transaction+list+image+4.png)
+![](/images/transaction+list+image+4.png)
 
 In this list, you can select an individual payment to see details of that
 payment, including any previous refunds.
@@ -228,7 +228,7 @@ payment, including any previous refunds.
 For a successful payment with no previous refunds, you can use the red
 **Refund payment** button to carry out a full or partial payment.
 
-![](images/refund-payment-button.png)
+![](/images/refund-payment-button.png)
 
 ## Refund notifications
 


### PR DESCRIPTION
### Context
Most of our images 404 at the moment in the docs if actually selected/clicked on; this is because they're not pointing to the correct path 

### Changes proposed in this pull request
Point images (where wrong) to correct path 
