### PR TITLE
Style amendments to 'Security' section

### DIFF
--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -5,22 +5,44 @@ weight: 140
 
 # Security
 
+<style>
+.govuk-warning-text{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:16px;font-size:1rem;line-height:1.25;color:#0b0c0c;position:relative;margin-bottom:20px;padding:10px 0}@media print{.govuk-warning-text{font-family:sans-serif}}@media (min-width:40.0625em){.govuk-warning-text{font-size:19px;font-size:1.1875rem;line-height:1.31579}}@media print{.govuk-warning-text{font-size:14pt;line-height:1.15;color:#000}}@media (min-width:40.0625em){.govuk-warning-text{margin-bottom:30px}}.govuk-warning-text__assistive{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;border:0!important;white-space:nowrap!important}.govuk-warning-text__icon{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;display:inline-block;position:absolute;top:50%;left:0;min-width:32px;min-height:29px;margin-top:-20px;padding-top:3px;border:3px solid #0b0c0c;border-radius:50%;color:#fff;background:#0b0c0c;font-size:1.6em;line-height:29px;text-align:center;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}@media print{.govuk-warning-text__icon{font-family:sans-serif}}.govuk-warning-text__text{display:block;margin-left:-15px;padding-left:65px}
+</style>
+
 ## Reporting vulnerabilities
 
-If you believe GOV.UK Pay security has been breached, contact us immediately at [govuk-pay-support@digital.cabinet-office.gov.uk] (mailto:govuk-pay-support@digital.cabinet-office.gov.uk). If you are a live user and the suspected breach is severe, consider using the urgent contact details provided to your service manager.
+If you believe GOV.UK Pay security has been breached, contact us immediately
+at [govuk-pay-support@digital.cabinet-office.gov.uk]
+(mailto:govuk-pay-support@digital.cabinet-office.gov.uk). If you are a live
+user and the suspected breach is severe, consider using the urgent contact
+details provided to your service manager.
 
 Please do not disclose the suspected breach publicly until it has been fixed.
 
 ## Securing your developer keys
 
-GOV.UK Pay will let you create as many API keys as you want.
+GOV.UK Pay allows you to create as many API keys as you want.
 
-We suggest letting all your developers experiment with their own test keys in the test environment, but keys for real integrations should only be shared with the minimum number of people necessary. This is because these keys can be used to create and manipulate payments. Do not commit these keys to public source code repositories.
+We recommend allowing all your developers experiment with their own test keys in
+the test environment, but keys for real integrations should only be shared
+with the minimum number of people necessary. This is because these keys can be
+used to create and manipulate payments. Do not commit these keys to public
+source code repositories.
 
-Revoke your key immediately using the self-service site if you believe it has been accidentally shared or compromised.
+Revoke your key immediately using the GOV.UK admin tool if you believe it has
+been accidentally shared or compromised.
 
-> If you believe your key has been used to make fraudulent payments, contact the GOV.UK support team using the urgent contact methods provided to your service manager.
+<br>
 
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+If you believe your key has been used to make fraudulent payments, contact
+the GOV.UK support team using the urgent contact methods provided to your
+service manager.
+  </strong>
+</div>
 
 To further secure your live developer keys:
 
@@ -31,40 +53,66 @@ To further secure your live developer keys:
 
 ## Securing your integration with GOV.UK Pay
 
-Make sure you’ve fully tested your integration with GOV.UK Pay. When doing so, take care not to use any real card numbers. Read our testing section for more details.
+Make sure you’ve fully tested your integration with GOV.UK Pay. When doing so,
+take care not to use any real card numbers. Read the
+[__Testing__](/testing_govuk_pay) section for more details.
 
 ## Securing user information
 
-GOV.UK Pay does not store full card numbers or CVV data for security reasons. This means you will not be able to search for transactions using card numbers.
+GOV.UK Pay does not store full card numbers or CVV data for security reasons.
+This means you will not be able to search for transactions using card numbers.
 
 ## Payment Card Industry (PCI) compliance
 
-Anyone involved with the processing, transmission, or storage of cardholder data must comply with the [Payment Card Industry Data Security Standards](https://www.pcisecuritystandards.org/) (PCI DSS) [external link]. GOV.UK Pay is certified as fully compliant as a Level 1 Service Provider with PCI DSS version 3.2. All GOV.UK Pay partners must be compliant with PCI DSS, and must validate their compliance annually.
+Anyone involved with the processing, transmission, or storage of cardholder
+data must comply with the [Payment Card Industry Data Security
+Standards](https://www.pcisecuritystandards.org/) (PCI DSS) [external link].
+GOV.UK Pay is certified as fully compliant as a Level 1 Service Provider with
+PCI DSS version 3.2. All GOV.UK Pay partners must be compliant with PCI DSS,
+and must validate their compliance annually.
 
 ### Use your Merchant ID to report PCI DSS compliance
 
-A merchant ID is a unique number that identifies you to your payment processor and acquiring bank. The recommended approach is to report PCI DSS compliance by MID by:
+A merchant ID is a unique number that identifies you to your payment processor
+and acquiring bank. The recommended approach is to report PCI DSS compliance
+by MID by:
 
-- agreeing with your acquiring bank to allocate an unique MID for each separate payment channel you have in place
-- reporting your PCI DSS compliance status for each of these unique MIDs to your acquiring bank
+* agreeing with your acquiring bank to allocate an unique MID for each
+separate payment channel you have in place
+* reporting your PCI DSS compliance status for each of these unique MIDs to
+your acquiring bank
 
-If you have one MID that encompasses multiple payment channels, the compliance requirements will be more complex for that MID. Check the PCI DSS for more information.
+If you have one MID that encompasses multiple payment channels, the compliance
+requirements will be more complex for that MID. You should check [the PCI
+DSS](https://www.pcisecuritystandards.org/) [external link] for more
+information.
 
 ### Determine your PCI DSS compliance requirements
 
-Your requirements depend on the number of transactions that you process as a merchant per scheme (Visa, MasterCard) per year. For example, if you process 4 million transactions with Visa and 3 million with MasterCard, the “Fewer than 6 million transactions per year” category still applies despite the fact that the total number of transactions is larger than 6 million. Your merchant level should be confirmed with your acquiring bank.
+Your requirements depend on the number of transactions that you process as a
+merchant per scheme (Visa, MasterCard) per year. For example, if you process 4
+million transactions with Visa and 3 million with MasterCard, the “Fewer than
+6 million transactions per year” category still applies despite the fact that
+the total number of transactions is larger than 6 million. Your merchant level
+should be confirmed with your acquiring bank.
 
 ### Assessing your compliance requirements
 
 #### Process fewer than 6 million transactions per year
 
-If you process fewer than 6 million transactions per scheme per year, you may be able to self-assess by completing one of the PCI DSS Self-Assessment Questionnaire (SAQ); this is a self-assessment tool to assess security for cardholder data.
+If you process fewer than 6 million transactions per scheme per year, you may
+be able to self-assess by completing one of the [PCI DSS Self-Assessment
+Questionnaires (SAQs)](https://www.pcisecuritystandards.org/document_library)
+[external link].  This is a self-assessment tool to assess security for
+cardholder data.
 
-When using GOV.UK Pay, the SAQ A questionnaire should apply. You should be eligible to complete the SAQ A questionnaire if you fulfil all the eligibility criteria and comply with SAQ A requirements 2, 8, 9 and 12:
-
-- the SAQ A questionnaire can be found in the [PCI documents library](https://www.pcisecuritystandards.org/document_library) [external link]
-- more detailed information on meeting requirements 2 and 8 can be found in [this article](https://pcissc.secure.force.com/faq/articles/Frequently_Asked_Question/How-do-PCI-DSS-Requirements-2-and-8-apply-to-SAQ-A-merchants) [external link]
-- more detailed information on the eligibility criteria can be found in the table below
+When using GOV.UK Pay, the SAQ A questionnaire should apply. You should be
+eligible to complete the SAQ A questionnaire if you fulfil all the eligibility
+criteria and comply with SAQ A requirements 2, 8, 9 and 12. You can read [more
+about
+this](https://pcissc.secure.force.com/faq/articles/Frequently_Asked_Question/How-do-PCI-DSS-Requirements-2-and-8-apply-to-SAQ-A-merchants)
+[external link]. You can also read more detailed information on the
+eligibility criteria in the following table:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
@@ -81,13 +129,25 @@ When using GOV.UK Pay, the SAQ A questionnaire should apply. You should be eligi
 
 #### Process more than 6 million transactions per year
 
-If you process more than 6 million transactions per scheme per year, you will need to undertake a formal on-site security assessment by a PCI DSS Qualified Security Assessor (QSA). It may be possible to be assessed against only the SAQ A requirements but this should be discussed with your own PCI DSS compliance team and your acquiring bank. More information on this can be found at the [PCI Security Standards Council website](https://www.pcisecuritystandards.org) [external link].
+If you process more than 6 million transactions per scheme per year, you will
+need to undertake a formal on-site security assessment by a PCI DSS Qualified
+Security Assessor (QSA). It may be possible to be assessed against only the
+SAQ A requirements but this should be discussed with your own PCI DSS
+compliance team and your acquiring bank. More information on this can be found
+at the [PCI Security Standards Council
+website](https://www.pcisecuritystandards.org) [external link].
 
-Your service manager may also be asked to supply extra evidence on your internal security protocols, and you may have to undertake security awareness training to ensure you are qualified to handle credit card data.
+Your service manager may also be asked to supply extra evidence on your
+internal security protocols, and you may have to undertake security awareness
+training to ensure you are qualified to handle credit card data.
 
 ## HTTPS
 
-GOV.UK Pay follows [government HTTPS security guidelines](https://www.gov.uk/service-manual/domain-names/https.html). The Hypertext Transfer Protocol Secure (HTTPS), which involves the Transport Layer Security  (TLS) protocol is used by the platform to authenticate servers / clients and to provide secure connections.
+GOV.UK Pay follows [government HTTPS security
+guidelines](https://www.gov.uk/service-manual/domain-names/https.html). The
+Hypertext Transfer Protocol Secure (HTTPS), which involves the Transport Layer
+Security  (TLS) protocol is used by the platform to authenticate servers /
+clients and to provide secure connections.
 
 You must use HTTPS for all direct communication between your service and
 GOV.UK Pay.


### PR DESCRIPTION
### Context
The 'Security' section breaks style in some places and lacks a warning symbol where a blockquote is used 

### Changes proposed in this pull request
Amendments to the 'Security' section so that it's tonally consistent with the newer version of the Pay documentation, and does not break GOV.UK style 

### Guidance for review
Note for reviewer: I've left my own review comments to be addressed by SME before merge