### PR TITLE
Style amendments across docs

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -58,7 +58,7 @@ they are a single service in the PSP.
 Each service defined in GOV.UK Pay has its own API key.
 
 Sign in to [the GOV.UK Pay admin
-site](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
+tool](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
 page to change:
 
 * account credentials

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -200,7 +200,7 @@ Pay admin tool or directly using the API.
 #### Use the admin tool
 
 1. Sign in to the [GOV.UK Pay admin
-site](https://selfservice.payments.service.gov.uk/) (link opens in new window).
+tool](https://selfservice.payments.service.gov.uk/).
 2. Select _Transactions_.
 3. Select a payment with a `"failed"`, `"cancelled"` or `"error"` status.
 

--- a/source/contribute/index.html.md.erb
+++ b/source/contribute/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 150
 
 GOV.UK Pay’s main application code is public and freely available under an MIT License and the GOV.UK Pay team [codes in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). You can [find us on GitHub](https://github.com/alphagov?q=pay-).
 
->If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you. Please email us at [mailto:govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+>If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you. Please email us at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
 ## Open-source components on GOV.UK Pay
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -37,7 +37,7 @@ complete their payment.
 You can track the progress of a payment while the user is on GOV.UK Pay using
 the <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
-target="blank">Find payment by ID</a> call (link opens in new window).
+target="blank">Find payment by ID</a> call [external link].
 
 NOTE: The status of the payment will go through several phases until it either
 succeeds or fails. See the [API reference
@@ -106,10 +106,10 @@ A `204` response indicates success. Any other response indicates an error.
 To test this with our API Explorer:
 
 * 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).
+   target="blank">the API Explorer</a> [external link].
 * 2. Under __Resource__, select __{Payment Id}__. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/"
-   target="blank">__Search payments__</a> (link opens in new window).
+   target="blank">__Search payments__</a> [external link].
 
 ### Find out if you can cancel a payment
 

--- a/source/optional_features/corporate_card_surcharges/index.html.md.erb
+++ b/source/optional_features/corporate_card_surcharges/index.html.md.erb
@@ -31,8 +31,8 @@ If the platform cannot determine the exact type of a card being used, it
 will not apply a surcharge.
 
 You can sign in to the [GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/login) (link opens in new
-window) to see the payment amount and the surcharge amount listed separately.
+tool](https://selfservice.payments.service.gov.uk/login) to see the payment
+amount and the surcharge amount listed separately.
 
 If a payment has a surcharge applied, the full amount available for refund
 includes the surcharge. You can also use the [partial refund

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -10,7 +10,7 @@ GOV.UK Pay supports the delayed capture of payments.
 To use this feature, include `"delayed_capture": true` in the body of a
 [create new
 payment](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment)
-request (link opens in new window).
+request [external link].
 
 The user experience matches the current payment flow. Once the user selects
 __Confirm__ on the __Confirm your details__ page, your service can call the

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -104,7 +104,7 @@ variable: if you have an existing format, you can keep using it with GOV.UK
 Pay (maximum 255 characters, and must not contain URLs).
 
 `description`: A human-readable description of the payment. This will be shown to the end
-user on the payment pages and to your staff on the GOV.UK Pay admin site
+user on the payment pages and to your staff on the GOV.UK Pay admin tool
 (maximum 255 characters, and must not contain URLs).
 
 `return_url`: A HTTPS URL on your site that the user will be sent back to once they have
@@ -200,7 +200,7 @@ confirmation email containing:
 You can add a custom paragraph to a payment confirmation email at the [email
 notifications
 page](https://selfservice.payments.service.gov.uk/email-notifications) on the
-GOV.UK Pay admin site.
+GOV.UK Pay admin tool.
 
 You can further customise using [GOV.UK
 Notify](https://www.notifications.service.gov.uk/) to set up custom
@@ -263,7 +263,7 @@ more details about how to match users to payments.
 
 To check the status of a payment, you must make a <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
-target="blank">Find payment by ID</a> API call (link opens in new window),
+target="blank">Find payment by ID</a> API call [external link],
 using the `payment_id` of the payment as the parameter.
 
 The URL to do this is the same as the `self` URL provided in the response

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -9,6 +9,8 @@ weight: 40
 .govuk-warning-text{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:16px;font-size:1rem;line-height:1.25;color:#0b0c0c;position:relative;margin-bottom:20px;padding:10px 0}@media print{.govuk-warning-text{font-family:sans-serif}}@media (min-width:40.0625em){.govuk-warning-text{font-size:19px;font-size:1.1875rem;line-height:1.31579}}@media print{.govuk-warning-text{font-size:14pt;line-height:1.15;color:#000}}@media (min-width:40.0625em){.govuk-warning-text{margin-bottom:30px}}.govuk-warning-text__assistive{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;border:0!important;white-space:nowrap!important}.govuk-warning-text__icon{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;display:inline-block;position:absolute;top:50%;left:0;min-width:32px;min-height:29px;margin-top:-20px;padding-top:3px;border:3px solid #0b0c0c;border-radius:50%;color:#fff;background:#0b0c0c;font-size:1.6em;line-height:29px;text-align:center;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}@media print{.govuk-warning-text__icon{font-family:sans-serif}}.govuk-warning-text__text{display:block;margin-left:-15px;padding-left:65px}
 </style>
 
+<br>
+
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
@@ -27,14 +29,13 @@ Before you start using GOV.UK Pay, you should:
 guide](https://www.payments.service.gov.uk/getstarted/) to decide if GOV.UK
 Pay is right for your service
 
-* sign up to the [GOV.UK Pay admin
-site](https://selfservice.payments.service.gov.uk/create-service/register)
+* sign up to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/create-service/register)
 
 * read the GOV.UK Service Manual guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html)
 
 * sign up to the [API
-explorer](https://gds-payments.gelato.io/) if you want to use it to test the API
+explorer](https://gds-payments.gelato.io/) [external link] if you want to use it to test the API
 
 If you want to build a technical integration between your service and the
 GOV.UK Pay API, your service team should have the necessary skills. You can
@@ -60,7 +61,7 @@ with our API Explorer and make a test API call.
 ## Generate API Key for API Explorer
 
 1. Sign in to the [GOV.UK Pay admin
-   site](https://selfservice.payments.service.gov.uk/) with the test
+   tool](https://selfservice.payments.service.gov.uk/) with the test
    account login details you received.
 
 2. From the landing page, select __API key__, then __Generate a new key__.
@@ -94,7 +95,7 @@ Explorer</a> [external link] with your API key.
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    Do not use an API key from a live account on the GOV.UK Pay admin site. Only use a test API key
+    Do not use an API key from a live account on the GOV.UK Pay admin tool. Only use a test API key.
   </strong>
 </div>
 
@@ -145,20 +146,20 @@ section](/security/#https).
 ## Simulate an end-user payment journey
 
 Go to the ``next_url`` with a browser, and you’ll see the payment screen.
-Choose a mock card number from the [__Testing GOV.UK__
-Pay](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
-enter it to simulate a payment in the test environment. For the other
-required details, enter some test information which should have:
+Choose a mock card number from the [__Testing GOV.UK
+Pay__](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
+enter it to simulate a payment in the test environment. For the other required
+details, enter some test information which should have:
 
   * an expiry date that is in the future and in the format MM/YYYY
   * a valid postcode
 
 Submit the payment.
 
-## View transactions at GOV.UK Pay admin site
+## View transactions at GOV.UK Pay admin tool
 
 Go to the [GOV.UK Pay admin
-site](https://selfservice.payments.service.gov.uk/). From the landing page,
+tool](https://selfservice.payments.service.gov.uk/). From the landing page,
 select __Transactions__:
 
 ![](/images/transaction+list+image+4.png)

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -38,7 +38,7 @@ You can find out the refund status of a payment with the GOV.UK Pay API using th
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
 target="blank">Find payment by ID</a> or <a
 href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general/endpoints/search-payments"
-target="blank">Search payments</a> functions (links open in new window).
+target="blank">Search payments</a> functions [external link].
 
 The JSON response body will contain a `refund_summary` object. For example,
 for a completed £50 payment with no previous refunds:
@@ -64,7 +64,7 @@ be greater than the original payment.
 
 You can use the <a
 href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id/endpoints/get-all-refunds-for-a-payment"
-target="blank">Get all refunds for a payment</a> (link opens in new window)
+target="blank">Get all refunds for a payment</a> [external link].
 API call to get information about partial refunds.
 
 As another example, this is the JSON response body for a completed £90 payment
@@ -160,7 +160,7 @@ window) will return an error code and a description of what it means. (A
 refund attempt that fails like this with an error code is not assigned a
 `refundId` and is not available using <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id"
-target="blank">Find payment refund by ID</a> (link opens in new window)).
+target="blank">Find payment refund by ID</a> [external link].
 
 If a refund is accepted by GOV.UK Pay, it may still go on to fail at the PSP.
 This may happen if the card involved is cancelled or has expired, or if your
@@ -196,7 +196,7 @@ go directly to `success`.
 
 To manage refunds in live environments, you must use <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id"
-target="blank">Find payment refund by ID</a> (link opens in new window) to
+target="blank">Find payment refund by ID</a> [external link] to
 check the processing status of the refund, until it changes to either
 `success` or `error`.
 
@@ -211,7 +211,7 @@ information required about why a refund failed.
 ## Refunding from the GOV.UK Pay admin tool
 
 You can use the [GOV.UK Pay admin
-site](https://selfservice.payments.service.gov.uk) to view transactions and
+tool](https://selfservice.payments.service.gov.uk) to view transactions and
 issue refunds.
 
 Go to the __Transactions__ section to see a list of transactions. For example,
@@ -274,7 +274,7 @@ You can use the following query parameters to filter refunds by date:
 
 These take inputs based on a subset of [ISO
 8601](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
-(link opens in new window).  For example, a valid input would be
+[external link].  For example, a valid input would be
 `2015-08-13T12:35:00Z`.
 
 #### Pagination

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -29,8 +29,8 @@ spreadsheet software and edit the contents you do not need.
 
 ## Reporting via the GOV.UK Pay API
 
-Before reading this section, you should be familiar with the ‘[Making
-payments](/making_payments)’ section.
+Before reading this section, you should be familiar with the [__Making
+payments__](/making_payments) section.
 
 You can get data from the GOV.UK Pay API in a format suitable for automatic
 processing. For example, you could develop software to query the GOV.UK Pay
@@ -48,11 +48,11 @@ You can use the GOV.UK Pay API to:
 `GET /v1/payments/paymentId`
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).
+   target="blank">the API Explorer</a> [external link].
 2. Under __Resource__, select __{Payment Id}__.
 3. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/"
-   target="blank">__Find payment by ID__</a> (link opens in new window).
+   target="blank">__Find payment by ID__</a> [external link].
 
 If the payment exists, the JSON response body to this
 API call contains a `"state"` field. You can use this information when
@@ -95,11 +95,11 @@ have entered when making a payment:
 `GET /v1/payments`
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).
+   target="blank">the API Explorer</a> [external link].
 2. Under __Resource__, select __General__.
 3. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/"
-   target="blank">__Search payments__</a> (link opens in new window).
+   target="blank">__Search payments__</a> [external link].
 
 ### Search criteria
 
@@ -131,9 +131,8 @@ You can use the following query parameters to filter payments by date:
 * `to_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [ISO
-8601](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
-(link opens in new window).  For example, a valid input would be
-`2015-08-13T12:35:00Z`.
+8601](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+For example, a valid input would be `2015-08-13T12:35:00Z`.
 
 #### Pagination
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -170,10 +170,10 @@ should open it in a separate browser tab to avoid confusion.
 
 ## Set up 3D Secure
 
-To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay
-self-service admin site](https://selfservice.payments.service.gov.uk/). Go to
-__My services__ to select the live service you want to set up. Select
-__Settings__, then __3D Secure__ and then __turn 3D Secure on__.
+To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay admin
+tool](https://selfservice.payments.service.gov.uk/). Go to __My services__ to
+select the live service you want to set up. Select __Settings__, then __3D
+Secure__ and then __turn 3D Secure on__.
 
 3D Secure should be enabled by default on the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index). To check

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -28,7 +28,7 @@ the organisation name at the top of the page to view all merchant accounts.
 1. Complete both the __Password__ fields.
 1. Leave the __Client Certificate (DN)__ field blank.
 
->  You will use this username and password on the GOV.UK Pay admin site to
+>  You will use this username and password on the GOV.UK Pay admin tool to
 >  [set up your account credentials](#set-up-credentials-on-gov-uk-pay) later.
 
 ### Generate client encryption key
@@ -83,7 +83,7 @@ Enter a unique username and password. The password must be at least 10
 characters long.
 
 > You will use this username and password to set
-> up your notification credentials on the GOV.UK Pay admin site later.
+> up your notification credentials on the GOV.UK Pay admin tool later.
 
 Leave all other settings to their defaults and select __Save configuration__.
 
@@ -138,8 +138,8 @@ should open it in a separate browser tab to avoid confusion.
 
 ## Set up 3D Secure
 
-To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay
-self-service admin site](https://selfservice.payments.service.gov.uk/).
+To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay admin
+tool](https://selfservice.payments.service.gov.uk/).
 
 Go to __My services__ to select the live service you want to set up.
 Select __Settings__, then __3D Secure__ and then __Turn on 3D Secure__.

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -103,7 +103,7 @@ other details. For example, expiry dates must be in the future.
 Refer to the [Worldpay documentation](http://support.worldpay.com/support/kb/gg/corporate-gateway-guide/content/reference/testvalues.htm#Test) [external link].
 
 ### Barclays ePDQ test card numbers
-Refer to the [ePDQ __Get Started__ guide](https://support.epdq.co.uk/en/products/onboarding) [external link] and select __What credit cards can I use for testing?__.
+Refer to the [ePDQ __Get Started__ guide](https://support.epdq.co.uk/en/products/onboarding) [external link] and select __What credit cards can I use for testing?__
 
 ### Barclays SmartPay test card numbers
 Refer to the [SmartPay TestCards page](https://docs.adyen.com/developers/test-cards/test-card-numbers) [external link].

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -5,8 +5,8 @@ weight: 130
 
 # Versioning
 
-You can use [our API explorer](https://gds-payments.gelato.io/) to use the
-latest version of our API.
+You can use [our API explorer](https://gds-payments.gelato.io/) [external
+link] to use the latest version of our API.
 
 If you want to update to our latest API, make sure you test your code before
 committing to the change.


### PR DESCRIPTION
### Context
Before I leave the project, I'm going through everything to make sure I've not left any broken links/inconsistencies etc.

### Changes proposed in this pull request
* introduces a break between the 'Quick start guide' title and the warning that appears about storing API keys securely
* uses the term "admin *tool*" throughout (rather than "admin site") 
* uses bold formatting for interface text rather than quotes, e.g. linking to other sections 
* adds "[external link]" where appropriate
* small style edits, e.g. missing full stops

### Guidance for review
This excludes changes made to the **Security** section in https://github.com/alphagov/pay-tech-docs/pull/234 and the **Making payments** section in https://github.com/alphagov/pay-tech-docs/pull/222