### PR TITLE
Corrections  for "cancel" and "try again "

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -70,7 +70,7 @@ datastore mapped to the payment ID just after you create a payment.
 
  - paid successfully
  - not paid because their card was rejected or they clicked cancel
- - not paid because your service (via the API) or service manager (via the self-service dashboard) cancelled the payment in progress
+ - not paid because your service (via the API) cancelled the payment in progress
  - not paid because of a technical error
 
 Your service should use the API to check the payment status when the user
@@ -85,13 +85,14 @@ your service.
 
 You can still check on the status of these payments by making a GET request
 using the Location Header or Self Link, the same way you would if they were
-redirected, but just after a set time (eg, an hour).
+redirected, but just after a set time (eg, two hours).
 
 >Note: GOV.UK Pay will expire incomplete payments after 90 minutes, but you should expect an occasional success or failure if the user experienced problems right at the moment of the redirect.
 
 If a user does not have enough funds in their account to make a payment, the
 current GOV.UK Pay frontend will not let them try again with separate card
-details. They will have to return to the service to retry the payment.
+details. They will be redirected to your service but you can offer them the option to try again. 
+That option would require your service to start a new payment. 
 
 ## Cancel a payment that’s in progress
 


### PR DESCRIPTION
- We currently don't allow staff users to cancel a payment that's in progress via the admin tool

- payments expire after 90 min, so it's better to recommend 2 hours rather than 1 hour 

- services can offer users the option to try again. That would involve creating a completely new payment.


