### PR TITLE
Adds Maestro

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -232,6 +232,7 @@ For example:
 | visa             | CREDIT | Visa             |
 | master-card      | DEBIT  | Mastercard       |
 | master-card      | CREDIT | Mastercard       |
+| maestro          | DEBIT  | Maestro          |
 | american-express | CREDIT | American Express |
 | diners-club      | CREDIT | Diners Club      |
 | discover         | CREDIT | Discover         |


### PR DESCRIPTION
### Context
@tillwirth pointed out via email that we lack 'Maestro' in https://docs.payments.service.gov.uk/api_reference/#card-types

### Changes proposed in this pull request
Adds Maestro to list of cards in API reference section

### Guidance to review
This isn't my area of expertise so I don't know that my proposed edit at time of writing is correct, so I'm opening this as a pointer that this change is needed as much as anything
