### PR TITLE
Amend description re. payment status failure in admin tool 

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -201,8 +201,8 @@ Pay admin tool or directly using the API.
 
 1. Sign in to the [GOV.UK Pay admin
 site](https://selfservice.payments.service.gov.uk/) (link opens in new window).
-2. Select _Transactions_.
-3. Select a payment with a `"failed"`, `"cancelled"` or `"error"` status.
+2. Select __Transactions__.
+3. Use the __Payment status__ dropdown to find payments with error statuses. For example, “Declined”.
 
 #### Use the API
 


### PR DESCRIPTION
### Context
@tillwirth wrote via email:

> The following section/statement is no longer accurate: 
> https://docs.payments.service.gov.uk/api_reference/#use-the-admin-tool
> "Select a payment with a "failed", "cancelled" or "error" status."
> We have replaced the "failed" state with "new" states that only exist in the admin tool but not the  API: Declined and Timed Out. We may have also combined the "user cancelled" and "system cancelled" into one "cancelled" state in the admin tool but I'm not sure about that. 

I confirmed that the "cancelled" statuses are indeed consolidated in the self-service tool 

### Changes proposed in this pull request
Suggested edit to account for the above