### PR TITLE
Combines two 'resume payments' sections

### DIFF
--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -289,10 +289,10 @@ format. The following is the start of a typical response:
 }
 ```
 
-The ``state`` array within the JSON lets you know the outcome of the payment:
+The `state` array within the JSON lets you know the outcome of the payment:
 
-+ The ``status`` value describes a stage of the payment journey.
-+ The ``finished`` value indicates if the payment journey is complete or not - that is, if the ``status`` of this payment can change.
++ The `status` value describes a stage of the payment journey.
++ The `finished` value indicates if the payment journey is complete or not - that is, if the ``status`` of this payment can change.
 
 See the [__Making payments__](/making_payments/#making-payments) section for
 more information about how you can integrate your service with GOV.UK Pay.
@@ -301,13 +301,25 @@ more information about how you can integrate your service with GOV.UK Pay.
 
 If your user starts a payment but does not complete it, they can resume that
 incomplete payment. An example of this could be if they use an internet
-browser’s back button during a payment, and then go forward by selecting the
+browser’s ‘back’ button during a payment, and then go forward by selecting 
 links on your website.
 
 If your service uses the resume payment feature, you will:
 
 - minimise the number of expired payments
-- not unnecessarily create new payments
+- reduce the number of unnecessary new payments
+
+When a user resumes a payment, the `next_url` will take them to a screen that
+is appropriate for their payment’s current status. For example, a payment with
+a `started` status will resume at the card details input page. The `next_url`
+is a one-time URL. If a payment has already resumed using a `next_URL`, that
+URL will not be usable again.
+
+A payment cannot resume if it has a status of `success`, `failed`, `cancelled`
+or `error`. If your service tries to resume a payment of this type, the user
+will be sent to your service’s `return_url`. The `return_url` is the URL of a
+page on your service that GOV.UK Pay sends the user to after they have
+completed their payment attempt.
 
 ## Payment expires
 
@@ -324,17 +336,3 @@ An incomplete payment will have a status of `created`, `started` or
 `submitted`. These payment types have a `next_url`. The `next_url` is where
 you should direct the user next in the payment process. You will receive a
 `next_url` every time you query the status of a payment using the API.
-
-### Resuming a payment
-
-When a user resumes a payment, the `next_url` will take them to a screen that
-is appropriate for their payment’s current status. For example, a payment with
-a `started` status will resume at the card details input page. The `next_url`
-is a one-time URL. If a payment has already resumed using a `next_URL`, that
-URL will not be usable again.
-
-A payment cannot resume if it has a status of `success`, `failed`, `cancelled`
-or `error`. If your service tries to resume a payment of this type, the user
-will be sent to your service’s `return_url`. The `return_url` is the URL of a
-page on your service that we send the user to after they have completed their
-payment attempt.


### PR DESCRIPTION
### Context
@tillwirth pointed out that we have two sections on resuming payments, via email. I don't honestly know how this happened, but I've consolidated them in this PR. 

### Changes proposed in this pull request
Consolidation of two sections which contain information about the same subject. 