### PR TITLE
Make bullets/steps uniform

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -13,10 +13,12 @@ GOV.UK Pay test and live accounts are free to create and maintain but your payme
 If you do integrate multiple services, you can treat them separately or as a
 combined single service within GOV.UK Pay and your payment service provider (PSP).
 This gives 3 possible account configurations. These configurations allow you
-to alter 
+to alter:
 
 * which bank accounts payments go to
+
 * the description that appear on your end users’ bank statements.
+
 * who has access to each service and which permissions they have for each service
 
 As an example, take 2 services called ‘parking permits’ and ‘parking fines’:
@@ -67,9 +69,13 @@ tool](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
 page to change:
 
 * 3D Secure settings
+
 * the card types you accept
+
 * email notifications settings
+
 * billing address settings
+
 * account credentials
 
 You can also change the name of a service, including how it appears on payment
@@ -81,6 +87,7 @@ service name you want to change.
 Within each gateway account for the PSP, you can edit:
 
 * what appears on the end user’s bank statement
+
 * which of your bank accounts your revenue goes to
 
 You should contact your PSP to find out more.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -16,8 +16,9 @@ standard HTTP error response codes.
 
 For full details of each API action, see the API browser:
 
-- <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general" target="blank">General functions</a> [external link]
-- <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id" target="blank">Payment ID functions</a> [external link]
+* <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general" target="blank">General functions</a> [external link]
+
+* <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id" target="blank">Payment ID functions</a> [external link]
 
 You can also use the interactive <a
 href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2//"
@@ -102,11 +103,15 @@ A successful response includes ``status`` and ``finished`` values:
 
 The GOV.UK Pay uses standard HTTP response code conventions:
 
-- 100 codes are informational
-- 200 codes indicate success
-- 300 codes indicate a redirection
-- 400 codes indicate a client-side error
-- 500 codes indicate a server-side error
+* 100 codes are informational
+
+* 200 codes indicate success
+
+* 300 codes indicate a redirection
+
+* 400 codes indicate a client-side error
+
+* 500 codes indicate a server-side error
 
 Common status codes are:
 
@@ -200,7 +205,9 @@ Pay admin tool or directly using the API.
 #### Use the admin tool
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
+
 2. Select __Transactions__.
+
 3. Use the __Payment status__ dropdown to find payments with error statuses. For example, “Declined”.
 
 #### Use the API

--- a/source/contribute/index.html.md.erb
+++ b/source/contribute/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 150
 
 GOV.UK Pay’s main application code is public and freely available under an MIT License and the GOV.UK Pay team [codes in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). You can [find us on GitHub](https://github.com/alphagov?q=pay-).
 
->If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you. Please email us at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+> If you’d like to speak to us about writing a developer library for GOV.UK Pay, we’d love to hear from you. Please email us at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
 ## Open-source components on GOV.UK Pay
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -11,10 +11,15 @@ This guidance is for technical architects or developers planning to integrate
 their service with the GOV.UK Pay API. It describes:
 
 * the requirements for your service’s backend
+
 * what data you need to store and why
+
 * typical data flows for using the GOV.UK Pay API in an integration
+
 * when to release services to users
+
 * making sure that all payments are processed
+
 * integrating with finance and accounting systems (see also [__Reporting__](/reporting))
 
 The following diagram shows a typical high-level architecture with a GOV.UK
@@ -27,13 +32,19 @@ Pay integration:
 Your service backend is server-side software. You should build this to:
 
 * make a call to the GOV.UK Pay API to start the payment journey
+
 * store information about user payment journeys in your datastore
+
 * redirect the user to the `next_url` provided by GOV.UK Pay, where the user
 will [enter their payment information and confirm their payment](/payment_flow/#making-a-payment)
+
 * receive users’ requests when they are redirected back to your service via
 the `return_url`, where the user will return [after completing payment](/payment_flow/#making-a-payment)
+
 * identify the returning user via the session
+
 * make a call to the GOV.UK Pay API to determine the outcome of the payment
+
 * display information about the outcome of the payment and next steps to
 the user
 
@@ -42,9 +53,13 @@ the user
 You will likely need some kind of server-side datastore to record payment information for each payment journey. You should store:
 
 * an ID or primary key
+
 * the service the user requested
+
 * the GOV.UK Pay `paymentId`
+
 * the status of the payment
+
 * the date and time the payment was started
 
 ## Finance and accounting systems
@@ -108,6 +123,7 @@ There are 2 failure cases which affect the design of your integration with
 GOV.UK Pay:
 
 * user abandons their payment journey before completing it
+
 * user completes their payment successfully, but their network connection is
 interrupted before they return to your service
 
@@ -118,6 +134,7 @@ possible to your user, so you would check the payment outcome when your
 However, in the failure cases, users will never visit the `return_url`. Instead, you should either:
 
 * make sure your service team can manually check payment outcomes in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login)
+
 * use an automatic mop-up job (recommended)
 
 ### Have your service team manually check the payment outcome
@@ -136,6 +153,7 @@ and automatically. A mop-up job is a background process which checks the outcome
 In order to use a mop-up job, you need:
 
 * a datastore which keeps track of incomplete payment journeys
+
 * a server-side process which periodically checks the datastore for incomplete payment journeys, and queries the GOV.UK Pay API to determine the outcome
 
 The following UML sequence diagram shows an example of an incomplete payment journey, and how a mop-up job would clean it up:
@@ -148,5 +166,3 @@ Your mop-up job should run frequently, for example every half an hour. It should
 
 The Ministry of Justice has a citizen-facing public site for [sending money to
 prisoners](https://github.com/ministryofjustice/money-to-prisoners-send-money).
-
-

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -51,12 +51,12 @@ your ``return_url`` as parameters.
 To match up a returning user with their payment, there are two recommended
 methods:
 
-+ use a secure cookie containing the Payment ID from GOV.UK Pay, issued by
+* use a secure cookie containing the Payment ID from GOV.UK Pay, issued by
 your service when the payment is created (before sending the user to
 ``next_url``). Users will not be able to decrypt a secure cookie, so a
 fraudster could not alter the payment ID and intercept other users’ payments.
 
-+ create a secure random ID (such as a UUID) and include this as part of the
+* create a secure random ID (such as a UUID) and include this as part of the
 ``return_url``, using a different ``return_url`` for each payment. Since a
 securely generated UUID is not guessable, fraudsters will not be able to
 intercept users’ payments.
@@ -68,10 +68,13 @@ datastore mapped to the payment ID just after you create a payment.
 
  A user directed to the return URL could have:
 
- - paid successfully
- - not paid because their card was rejected or they clicked cancel
- - not paid because your service (via the API) cancelled the payment in progress
- - not paid because of a technical error
+ * paid successfully
+
+ * not paid because their card was rejected or they clicked cancel
+
+ * not paid because your service (via the API) cancelled the payment in progress
+
+ * not paid because of a technical error
 
 Your service should use the API to check the payment status when the user
 reaches the return URL, and provide an appropriate response based on the final
@@ -106,9 +109,10 @@ A `204` response indicates success. Any other response indicates an error.
 
 To test this with our API Explorer:
 
-* 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
+1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
    target="blank">the API Explorer</a> (link opens in new window).
-* 2. Under __Resource__, select __{Payment Id}__. Under __Action__, select
+
+2. Under __Resource__, select __{Payment Id}__. Under __Action__, select
 __Search payments__.
 
 ### Find out if you can cancel a payment

--- a/source/optional_features/corporate_card_surcharges/index.html.md.erb
+++ b/source/optional_features/corporate_card_surcharges/index.html.md.erb
@@ -18,8 +18,11 @@ You can set a different surcharge for each of the following 4
 corporate card types:
 
 * non-prepaid credit cards
+
 * non-prepaid debit cards
+
 * prepaid credit cards
+
 * prepaid debit cards
 
 In a payment journey, when a user enters a card number the GOV.UK Pay

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -12,7 +12,9 @@ team](/support_contact_and_more_information/#contact-us) to request
 customisation for the following features:
 
 * the logo displayed in the left-hand side of the top banner
+
 * the background and border colour of the top banner
+
 * the branding of your payment confirmation email
 
 ### Banner logo
@@ -21,8 +23,11 @@ You should provide an image of your desired custom banner logo [to GOV.UK Pay
 directly](/support_contact_and_more_information/#contact-us). Your image should be:
 
 * in PNG or SVG format
+
 * at least 2x the size of the image that will be displayed on-screen
+
 * cropped to leave minimal whitespace around the logo
+
 * compressed (optimised for web)
 
 ### Banner background and border colour
@@ -31,4 +36,3 @@ You can make a request for custom colours [to GOV.UK Pay
 directly](/support_contact_and_more_information/#contact-us).
 
 Colours are customised using hexadecimal representations.
-

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -44,6 +44,7 @@ If a payment is available for capture, you can see its capture URL in
 GOV.UK Pay API responses such as:
 
 * `GET /v1/payments/<PAYMENT-ID>`
+
 * `GET /v1/payments`
 
 The `"__links"` object will contain:`

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -8,7 +8,11 @@ weight: 130
 GOV.UK Pay supports some optional features which need configuration:
 
 * [Custom branding](/optional_features/custom_branding/#custom-branding-of-payment-pages) of payment pages
+
 * [Welsh language](/optional_features/welsh_language/#welsh-language-payment-pages) of payment pages
+
 * [Delayed capture](/optional_features/delayed_capture/#delayed-capture) of payments
+
 * [Corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate_card_surcharges) added to payments
+
 * [Using your own payment failure pages](/optional_features/use_your_own_error_pages) for your service

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -14,8 +14,11 @@ GOV.UK Pay payment failure pages.
 Terminal, unsuccessful payment states are:
 
 * payment declined
+
 * payment cancelled
+
 * payment expired
+
 * error (for example, technical error)
 
 If you use this feature, GOV.UK Pay will immediately redirect the user to the
@@ -48,5 +51,3 @@ expired, they will be returned to the service.
 You may want to read about [what happens when a user does not complete
 their payment
 journey](/making_payments/#when-a-user-does-not-complete-their-payment-journey).
-
-

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -45,12 +45,17 @@ back to your service.
 
 A final state means that the payment:
 
-+ succeeds
-+ fails because it is declined
-+ fails because the user chooses to cancel
-+ fails due to a technical error
-+ fails because it is cancelled by your service
-+ expires - users have 90 minutes to complete a payment once it is created
+* succeeds
+
+* fails because it is declined
+
+* fails because the user chooses to cancel
+
+* fails due to a technical error
+
+* fails because it is cancelled by your service
+ 
+* expires - users have 90 minutes to complete a payment once it is created
 
 When the user arrives back at your service, you can use the API to check the
 status of the transaction and show them an appropriate message.
@@ -186,18 +191,22 @@ user then decides whether or not to complete their payment:
 If the user decides to complete the payment, they select __Confirm__. They
 will then:
 
-- receive a confirmation email, if you have chosen to send these using GOV.UK Pay
-- be redirected to your `return_url`, page which will then send the user to your payment confirmation page
+* receive a confirmation email, if you have chosen to send these using GOV.UK Pay
+
+* be redirected to your `return_url`, page which will then send the user to your payment confirmation page
 
 ### Confirmation email
 
 If you have set up confirmation emails, the user will receive a payment
 confirmation email containing:
 
-- a payment reference number
-- the date of payment
-- who the payment was to
-- the total payment amount
+* a payment reference number
+
+* the date of payment
+
+* who the payment was made to
+
+* the total payment amount
 
 You can add a custom paragraph to a payment confirmation email at the [email
 notifications
@@ -213,11 +222,15 @@ notifications.
 
 The confirmation page is hosted by your service and should:
 
-- confirm that payments have been received successfully
-- contain a reference number, which should be short
-- have a clear payment summary, showing the amount and description
-- clearly state what is going to happen next - this will be different for each service
-- if applicable, let the user know they will receive a receipt email (using GOV.UK Notify or GOV.UK Pay)
+* confirm that payments have been received successfully
+
+* contain a reference number, which should be short
+
+* have a clear payment summary, showing the amount and description
+
+* clearly state what is going to happen next - this will be different for each service
+
+* if applicable, let the user know they will receive a receipt email (using GOV.UK Notify or GOV.UK Pay)
 
 Users have different ways of recording this confirmation information. This can
 include screenshots, prints, PDF receipts to download, and writing down the
@@ -231,17 +244,21 @@ System](https://www.gov.uk/service-manual/design/confirmation-pages).
 
 The payment can fail at any point in the process due to:
 
-+ the user cancelling the payment
-+ the payment being declined
-+ your service cancelling the payment
-+ a technical error
+* the user cancelling the payment
+
+* the payment being declined
+
+* your service cancelling the payment
+
+* a technical error
 
 If the payment fails, the user will see a GOV.UK Pay error page, which
-includes a __Continue__ button. When a user selects this, your service
-should show them a page that confirms that the payment failed. This should either:
+includes a __Continue__ button. When a user selects this, your service should
+show them a page that confirms that the payment failed. This should either:
 
-- offer the user a chance to try the payment again by starting a new payment with GOV.UK Pay, or using another method that your service provides
-- advise the user of an alternative course of action
+* offer the user a chance to try the payment again by starting a new payment with GOV.UK Pay, or using another method that your service provides
+
+* advise the user of an alternative course of action
 
 The following image is an example failure page:
 
@@ -258,9 +275,11 @@ initial request.
 The `return_url` should specify a page on your service. When the user visits
 the `return_url`, your service should:
 
-- match the returning user with their payment (with a secure cookie, or a secure random ID string included in the `return_url`)
-- check the status of the payment using an API call
-- display an appropriate final page, hosted by your service
+* match the returning user with their payment (with a secure cookie, or a secure random ID string included in the `return_url`)
+
+* check the status of the payment using an API call
+
+* display an appropriate final page, hosted by your service
 
 The [__Making payments__](/making_payments/#making-payments) section contains
 more details about how to match users to payments.
@@ -291,8 +310,9 @@ format. The following is the start of a typical response:
 
 The `state` array within the JSON lets you know the outcome of the payment:
 
-+ The `status` value describes a stage of the payment journey.
-+ The `finished` value indicates if the payment journey is complete or not - that is, if the ``status`` of this payment can change.
+* `status` describes a stage of the payment journey
+
+* `finished` indicates if the payment journey is complete or not - that is, if the `status` of this payment can change
 
 See the [__Making payments__](/making_payments/#making-payments) section for
 more information about how you can integrate your service with GOV.UK Pay.
@@ -306,8 +326,9 @@ links on your website.
 
 If your service uses the resume payment feature, you will:
 
-- minimise the number of expired payments
-- reduce the number of unnecessary new payments
+* minimise the number of expired payments
+
+* reduce the number of unnecessary new payments
 
 When a user resumes a payment, the `next_url` will take them to a screen that
 is appropriate for their payment’s current status. For example, a payment with

--- a/source/payment_links/index.html.md.erb
+++ b/source/payment_links/index.html.md.erb
@@ -5,12 +5,16 @@ weight: 45
 
 # Payment links
 
-You may want to use payment links rather than integrate with the GOV.UK Pay API if your service:
+You may want to use payment links rather than integrate with the GOV.UK Pay
+API if your service:
 
-- is non-digital and uses paper applications to process payments
-- is non-digital and has low transaction volumes
-- asks users for payment by sending email or letters
-- does not have a development team that can integrate your service with GOV.UK Pay
+* is non-digital and uses paper applications to process payments
 
-You can read more about payment links on [the product page](https://www.payments.service.gov.uk/payment-links/).
+* is non-digital and has low transaction volumes
 
+* asks users for payment by sending email or letters
+
+* does not have a development team that can integrate your service with GOV.UK Pay
+
+You can read more about payment links on [the product
+page](https://www.payments.service.gov.uk/payment-links/).

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -51,8 +51,11 @@ in JSON format, and standard HTTP error response codes. The platform API
 allows you to:
 
 * begin and complete payments
+
 * view the event history for individual payments
+
 * view transactions and refunds within a specified time period
+
 * issue full or partial refunds
 
 When you've received a test account, follow these instructions to get started
@@ -83,6 +86,7 @@ Explorer</a> [external link] with your API key.
 
 1. Sign in to the API Explorer and select __Add API Key__.<br/><br/>
    ![](/images/pay-add-api-key.png) <br/><br/>
+
 2.  In the pop-up, enter the following values:
 
   * For __API Key__, enter your test API key. You do not need to add the
@@ -107,6 +111,7 @@ payment using GOV.UK Pay.
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
    target="blank">the API Explorer</a> [external link]
+
 2. Under __Resource__, select __General__. Under __Action__, select <a
    href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment"
    target="blank">__Create new payment__</a> [external link]. Select
@@ -152,6 +157,7 @@ enter it to simulate a payment in the test environment. For the other required
 details, enter some test information which should have:
 
   * an expiry date that is in the future and in the format MM/YYYY
+
   * a valid postcode
 
 Submit the payment.

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -28,9 +28,11 @@ possible.
 
 Refunds can have 3 states:
 
-`"submitted"`
-`"success"`
-`"error"`
+* `"submitted"`
+
+* `"success"`
+
+* `"error"`
 
 ## Payment refund status
 
@@ -243,6 +245,7 @@ responsibility of the service to provide an alternative refund method.
 You can use the GOV.UK Pay API to:
 
 * get information about a single refund
+
 * generate a list of refunds matching search criteria
 
 ### Get information about a single refund
@@ -253,7 +256,9 @@ The JSON response body to this API call contains a `"refunds"` object. If the
 refund exists, the `"status"` field will contain one of:
 
 * `"submitted"`
+
 * `"success"`
+
 * `"error"`
 
 ### Generate a list of refunds (search refunds)
@@ -270,6 +275,7 @@ An example search request:
 You can use the following query parameters to filter refunds by date:
 
 * `from_date` - the start date for payments to be searched, inclusive
+
 * `to_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [ISO
@@ -282,6 +288,7 @@ These take inputs based on a subset of [ISO
 You can use the following query parameters for pagination:
 
 * `display_size` - default, and maximum, is `500`
+
 * `page` - default is `1`
 
 These must be a positive integer. For example, for the following search:
@@ -295,5 +302,3 @@ If there were 1543 refunds in the response, you could paginate this as follows:
 /v1/refunds?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display_size=500&page=2`
 
 This would return refunds 501-1000.
-
-

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -44,6 +44,7 @@ lead to significant cost savings for your organisation.
 You can use the GOV.UK Pay API to:
 
 * get information about a single payment
+
 * generate a list of payments matching search criteria
 
 ## Get information about a single payment
@@ -52,7 +53,9 @@ You can use the GOV.UK Pay API to:
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
    target="blank">the API Explorer</a> [external link].
+
 2. Under __Resource__, select __{Payment Id}__.
+
 3. Under __Action__, select __Find payment by ID__.
 
 If the payment exists, the JSON response body to this
@@ -97,7 +100,9 @@ have entered when making a payment:
 
 1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
    target="blank">the API Explorer</a> [external link].
+
 2. Under __Resource__, select __General__.
+
 3. Under __Action__, select __Search payments__.
 
 ### Search criteria
@@ -110,11 +115,17 @@ An example search request:
 Some of the query parameters you can use to search for payments are:
 
 * `reference`
+
 * `email`
+
 * `state`
+
 * `card_brand`
+
 * `first_digits_card_number`
+
 * `last_digits_card_number`
+
 * `cardholder_name`
 
 If you search for a specific payment, all criteria you use must match.
@@ -127,6 +138,7 @@ If your request has no query parameters, the API will return all payments.
 You can use the following query parameters to filter payments by date:
 
 * `from_date` - the start date for payments to be searched, inclusive
+
 * `to_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [ISO
@@ -138,6 +150,7 @@ For example, a valid input would be `2015-08-13T12:35:00Z`.
 You can use the following query parameters for pagination:
 
 * `display-size` - default, and maximum, is `500`
+
 * `page` - default is `1`
 
 These must be a positive integer. For example, for the following search:
@@ -151,9 +164,3 @@ If there were 1543 payments in the response, you could paginate this as follows:
 /v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display-size=500&page=2`
 
 This would return payments 501-1000.
-
-
-
-
-
-

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -32,8 +32,11 @@ source code repositories.
 Follow these steps to revoke your API key immediately if you believe it has been accidentally shared or compromised:
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login)
+
 2. Select the correct services in the [My services](https://selfservice.payments.service.gov.uk/my-services) section
+
 3. Navigate to the [API keys](https://selfservice.payments.service.gov.uk/api-keys) page in the Settings section.
+
 4. Revoke all compromised API keys
 
 <br>
@@ -50,12 +53,17 @@ service manager.
 
 To further secure your live developer keys:
 
- - periodically rotate the keys that are used for live payments
- - you should consider rotating keys that are used for live payments after staff members leave that had access to those keys
- - avoid embedding your developer keys in any of your code - this only increases the risk that they will be discovered (instead store your keys inside your configuration files)
- - avoid storing your API keys in your application source tree (even when you’re not making your source code publicly available)
- - revoke your developer keys when they’re no longer required (this limits the number of entry points into your account)
- - have a leavers’ process, so that a developer’s API key is revoked when they leave
+ * periodically rotate the keys that are used for live payments
+
+ * you should consider rotating keys that are used for live payments after staff members leave that had access to those keys
+
+ * avoid embedding your developer keys in any of your code - this only increases the risk that they will be discovered (instead store your keys inside your configuration files)
+
+ * avoid storing your API keys in your application source tree (even when you’re not making your source code publicly available)
+
+ * revoke your developer keys when they’re no longer required (this limits the number of entry points into your account)
+
+ * have a leavers’ process, so that a developer’s API key is revoked when they leave
 
 ## Securing your integration with GOV.UK Pay
 
@@ -84,6 +92,7 @@ by MID by:
 
 * agreeing with your acquiring bank to allocate an unique MID for each
 separate payment channel you have in place
+
 * reporting your PCI DSS compliance status for each of these unique MIDs to
 your acquiring bank
 

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -29,8 +29,8 @@ In-hours support is from Monday-Friday 9:30am-5:30pm and covers all ticket prior
 
 Out-of-hours support covers P1 support tickets only, during:
 
-- Monday-Friday 5:30pm-9:30am
-- Saturday-Sunday and bank holidays 24x7
+* Monday-Friday 5:30pm-9:30am
+* Saturday-Sunday and bank holidays 24x7
 
 ## Contact us
 

--- a/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
+++ b/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
@@ -8,8 +8,11 @@ weight: 99
 Before you start taking live payments, you should:
 
 * have a signed MOU or contract with GOV.UK Pay
+
 * [provide organisation information](#provide-organisation-information) to GOV.UK Pay
+
 * request a [live GOV.UK Pay account](#request-a-live-gov-uk-pay-account)
+
 * make sure that the right people on your
 team [know how to report an emergency](#emergency-contact-details)
 
@@ -26,10 +29,14 @@ to GOV.UK Pay.
 
 1. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login).
+
 1. Select __My services__.
+
 1. For the test account you want to make live, select __Organisation
    details__.
+
 1. Complete the __Name__ and __Address__ fields.
+
 1. Select __Save__.
 
 > Make sure the organisation is the entity that has a contract with the
@@ -39,9 +46,12 @@ to GOV.UK Pay.
 
 1. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login).
+
 1. Select __My services__.
+
 1. For the test account you want to make live, select __Manage team members__
    on the dashboard.
+
 1. Copy the full page URL, for example   `https://selfservice.payments.service.gov.uk/service/23f0eb425a9569988b99b5bb641a541d`.
 
 Send the GOV.UK Pay team the page URL, your service name, and what type of PSP
@@ -74,6 +84,3 @@ When you sign up for GOV.UK Pay, the team will give you emergency contact
 details. You can use these to reach the appropriate support team in case of an
 urgent problem. For example, if you suspect that fraudulent transactions are
 being made on your account.
-
-
-

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -21,13 +21,17 @@ link](/payment_links/#payment-links) functionality.
 You can then read about switching to live for:
 
 * [ePDQ](/switching_to_live/set_up_a_live_epdq_account) accounts
+
 * [Smartpay](/switching_to_live/set_up_a_live_smartpay_account) accounts
+
 * [Worldpay](/switching_to_live/set_up_a_live_worldpay_account) accounts
 
 ## The differences between test and live accounts
 
 The key differences are:
 
-- return URLs for live services using GOV.UK Pay must use HTTPS, but you [can use HTTP for return URLs with test accounts](https://docs.payments.service.gov.uk/security/#https)
-- 3D Secure is not part of the payment journey on test accounts
-- response times of test accounts do not match live accounts, because live accounts are subject to response times of payment service providers
+* return URLs for live services using GOV.UK Pay must use HTTPS, but you [can use HTTP for return URLs with test accounts](https://docs.payments.service.gov.uk/security/#https)
+
+* 3D Secure is not part of the payment journey on test accounts
+
+* response times of test accounts do not match live accounts, because live accounts are subject to response times of payment service providers

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -24,14 +24,17 @@ new payment methods__. Select __Add__ next to all relevant payment methods.
 
 On the __Contract data__ tab:
 
-1. specify whether you have signed a contract for distance selling with an acquiring bank
-2. complete the __Affiliation number (UID/Merch ID/VP number)__ field
-3. select __Submit__
+1. Specify whether you have signed a contract for distance selling with an acquiring bank
+
+2. Complete the __Affiliation number (UID/Merch ID/VP number)__ field
+
+3. Select __Submit__
 
 On the __PM Activation__ tab:
 
-1. select __Yes__ for __Activation__
-2. select __Submit__
+1. Select __Yes__ for __Activation__
+
+2. Select __Submit__
 
 ## Set up account security parameters
 
@@ -43,7 +46,9 @@ __Configuration__.
 
 1. On the __Technical Information__ page, select the __Global security
    parameters__ tab.
+
 1. For the __Hash algorithm__, choose __SHA-512__.
+
 1. For the __Character encoding__, choose __UTF-8__ and select __Save__.
 
 ### Set up checks for “e-Commerce & Alias Gateway”
@@ -54,9 +59,12 @@ __Configuration__.
 
 1. On the __Technical information__ page, select the __Data and origin
    verification__ tab.
+
 1. Go to the __Checks for e-Commerce & Alias Gateway__ section.
+
 1. Leave the following field blank: __URL of the merchant page containing the payment form that will
    call the page: orderstandard.asp__.
+
 1. Enter a strong SHA-IN passphrase in plaintext. Do not use a hash. You will
    need to copy this passphrase into the GOV.UK Pay account credentials page
    later.
@@ -64,10 +72,11 @@ __Configuration__.
     > A strong passphrase has at least 16 characters, contains at least 4 different characters, at least one letter (a-z), and at least one number (0-9) or symbol (&, @, #, !, etc.). You cannot use ^, {, }, [, ], “, ‘, |, <, or >.
 
 1. Go to the __Checks for Barclaycard Direct Link__ section.
+
 1. Leave the __IP address__ blank.
+
 1. Enter the same SHA-IN passphrase as in the __Checks for e-Commerce & Alias
 Gateway__ section and select __Save__.
-
 
 ## Set up notification settings
 
@@ -78,15 +87,21 @@ site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index), go to
 __Configuration__.
 
 1. On the __Technical information__ page, select __Transaction feedback__.
+
 1. Go to __e-Commerce__ and the __Direct HTTP server-to-server request__
    section.
+
 1. Leave __Timing of the request__ on the default __No request__ setting.
+
 1. Leave the following fields blank:
+
 <br>__If the payment’s status is “accepted”, “on hold” or “uncertain”__</br>
 <br>__If the payment’s status is “cancelled by the client” or “too many rejections by the acquirer”__ </br>
 
 1. Set the __Request method__ to __POST__.
+
 1. Go to the __e-Commerce__ then __Dynamic e-Commerce parameters__ section.
+
 1. Check if “PAYIDSUB” is included in the __Selected__ box. If it is not, find it
    in the __Available__ box and select __>__ to add it.
 
@@ -96,16 +111,21 @@ __Configuration__.
 
 1. Go to __All transaction submission modes__ and the __Security for request
    parameters__ section.
+
 1. Enter a strong SHA-OUT passphrase in plain text. Do not use a hash. You will
    need to copy this passphrase into the GOV.UK Pay account credentials page
    later.
+
 1. Leave the __Basic Authentication Credentials__ field blank.
+
 1. Set __Timing of the request__ to: <br> __For each offline status change
    (payment, cancellation, etc.)__</br>
+
 1. In the __URL on which the merchant wishes to receive a deferred HTTP request,
 should the status of a transaction change offline__ field, enter:
 <br> `https://notifications.payments.service.gov.uk/v1/api/notifications/epdq`
 </br>
+
 1. Select __Save__.
 
 ## Set up an API user
@@ -113,20 +133,30 @@ should the status of a transaction change offline__ field, enter:
 ### Add a user manager
 
 1. Go to __Configuration__ then __Account__.
+
 1. Go to the __Your options__ tab.
+
 1. Under the __Available options__ sub-tab, there is a list of IDs with
    __Activate__ options.
+
 1. Activate one of the __User Manager__ options.
+
 1. Select __Accept__ on the __General Conditions__ screen.
+
 1. Sign out and then sign back in again.
 
 ### Create an API user
 
 1. On the __Users__ page, select __New User__.
+
 1. Complete the __UserID__ and __User’s name__ fields.
+
 1. Complete the __Email address__ field. This should contain the email address you want to receive notifications.
+
 1. In the __Profile__ field, select __Admin__.
+
 1. Check the __Special user for API (no access to admin.)__ option.
+
 1. Enter your own password and select __Create__.
 
 > Store the API user’s username and password securely. You will need to copy them into the GOV.UK Pay account credentials page later.
@@ -137,6 +167,7 @@ In your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login):
 
 1. Go to __My services__ and select the live service you want to set up.
+
 1. Go to __Settings__ then __Account credentials__ then __Edit credentials__.
 
 1. Complete the following fields:
@@ -152,15 +183,19 @@ In your [GOV.UK Pay
 
 1. Contact your ePDQ account manager to confirm the cards you want to
    accept are set up.
+
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this. Make sure you use a live API key, not a test
    one. Use [payment links](/payment_links) if your service is not yet connected
    to GOV.UK Pay.
+
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
+
 4. Go to the [__Transactions__
    page](https://selfservice.payments.service.gov.uk/transactions) and check
    your test transaction is in the list of transactions.
+
 5. Select the test transaction and check if you can refund it.
 
 > The refund option may take up to 20 minutes to appear after submitting the transaction.
@@ -178,4 +213,3 @@ Secure__ and then __turn 3D Secure on__.
 3D Secure should be enabled by default on the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index). To check
 this, go to __Configuration__ then  __Payment methods__ and select __3D Secure__.
-

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -23,13 +23,16 @@ the organisation name at the top of the page to view all merchant accounts.
 ### Add new user
 
 1. Select __Settings__ and then __Users__.
+
 1. Select __Add new user__.
+
 1. Select __Web Service__ as the user type.
+
 1. Complete both the __Password__ fields.
+
 1. Leave the __Client Certificate (DN)__ field blank.
 
->  You will use this username and password on the GOV.UK Pay admin tool to
->  [set up your account credentials](#set-up-credentials-on-gov-uk-pay) later.
+>  You will use this username and password on the GOV.UK Pay admin tool to [set up your account credentials](#set-up-credentials-on-gov-uk-pay) later.
 
 ### Generate client encryption key
 
@@ -42,7 +45,9 @@ Under __Roles and Associated Accounts__, select __Roles__ and enable the
 following roles:
 
   * API PCI Payments role
+
   * Merchant PAL Webservice role
+
   * Merchant Recurring role
 
 > Contact Smartpay if any of these roles are not available.
@@ -67,23 +72,30 @@ Complete all the fields on the __Standard Notification settings__ page.
 
 Complete the fields in the __Transport__ page as follows:
 
-- __URL__: `https://notifications.payments.service.gov.uk/v1/api/notifications/smartpay`
-- __SSL Version__: TLSv1.2
-- __Active__: Checked
-- __Accept expired__:  Leave unchecked
-- __Accept self-signed__:  Leave unchecked
-- __Accept untrusted Root certificates__:  Leave unchecked
-- __Service version__: 1
-- __Method__: JSON
-- __Populate SOAP Action header__: Leave unchecked
+* __URL__: `https://notifications.payments.service.gov.uk/v1/api/notifications/smartpay`
+
+* __SSL Version__: TLSv1.2
+
+* __Active__: Checked
+
+* __Accept expired__:  Leave unchecked
+
+* __Accept self-signed__:  Leave unchecked
+
+* __Accept untrusted Root certificates__:  Leave unchecked
+
+* __Service version__: 1
+
+* __Method__: JSON
+
+* __Populate SOAP Action header__: Leave unchecked
 
 ### Authentication
 
 Enter a unique username and password. The password must be at least 10
 characters long.
 
-> You will use this username and password to set
-> up your notification credentials on the GOV.UK Pay admin tool later.
+> You will use this username and password to set up your notification credentials on the GOV.UK Pay admin tool later.
 
 Leave all other settings to their defaults and select __Save configuration__.
 
@@ -91,8 +103,10 @@ Leave all other settings to their defaults and select __Save configuration__.
 
 1. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/login).
+
 1. Go to __My services__ and select the Smartpay live service you want to
    set up.
+
 1. Go to __Settings__ then __Account credentials__.
 
 ### Set up account credentials
@@ -101,34 +115,41 @@ Under __Your Smartpay credentials__, select __Edit credentials__ .
 
 Complete the following fields on this page:
 
-* **Merchant code**
-* **Username**
-* **Password**
+* __Merchant code__
 
-> Your merchant code should be for Smartpay, and you should have a username and
-> password from [adding a new user](#add-new-user).
+* __Username__
+
+* __Password__
+
+> Your merchant code should be for Smartpay, and you should have a username and password from [adding a new user](#add-new-user).
 
 ### Set up notification credentials
 
 1. Under __Your Smartpay notification credentials__, select __Edit
    notification credentials__.
+
 1. Complete the __Username__ and __Password__ fields on this page using the
    username and password described in [the Authentication section](#authentication).
+
 1. Select __Save credentials__ to go back to the __Account credentials__ page.
 
 ## Test your configuration
 
 1. Contact your Smartpay account manager to confirm the cards you want to
    accept are set up.
+
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this. Make sure you use a live API key, not a test
    one. Use [payment links](/payment_links) if your service is not yet connected
    to GOV.UK Pay.
+
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
+
 4. Go to the [__Transactions__
    page](https://selfservice.payments.service.gov.uk/transactions) and check
    your test transaction is in the list of transactions.
+
 5. Select the test transaction and check if you can refund it.
 
 > The refund option may take up to 20 minutes to appear after submitting the transaction.
@@ -146,4 +167,3 @@ Select __Settings__, then __3D Secure__ and then __Turn on 3D Secure__.
 
 Barclaycard is responsible for setting up 3D Secure payment authentication
 for your Smartpay account. You do not need to set anything manually.
-

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -67,7 +67,9 @@ the __Save Profile__ button at the bottom of the page)
     > If you're setting up another GOV.UK Pay service using the same Worldpay
     merchant code, you should not need to change your XML password again. If
     you do change it in this situation, you will need to update your other
-    services with the new XML password.  <br></br>
+    services with the new XML password. <br></br>
+
+    <br>
 
 1. Enter the Worldpay XML password into the GOV.UK Pay __Password__ field.
 
@@ -89,16 +91,23 @@ For __Merchant Channels (Production)__ and __Merchant Channels (Test)__, check
 the following:
 
 1. Under __Active__, select __yes__.
+
 1. Set __Content__ to __xml__
+
 1. Set __Address__ to
    `https://notifications.payments.service.gov.uk/v1/api/notifications/worldpay`.
+
 1. Set __Method__ to __POST__.
+
 1. Set __Client certificate__ to __no__.
+
 1. Set the __email__ and __shopper
    email__ protocols to __no__.
 
 For __Merchant Channel Events (Production)__ and __Merchant Channel Events
 (Test)__, check the following in the __http__ row only:
+
+<br>
 
 __SIGNED_FORM_RECEIVED__
 
@@ -152,16 +161,21 @@ __REVOKED__
 
 1. Contact your Worldpay account manager to confirm the cards you want to
    accept are set up. Make sure you only select [card types](https://selfservice.payments.service.gov.uk/card-types/summary) within GOV.UK Pay that are also enabled in your Worldpay account.
+
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this. Make sure you use a live API key, not a test
    one. Use [payment links](/payment_links) if your service is not yet connected
    to GOV.UK Pay.
+
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
+
 4. Go to the [__Transactions__
    page](https://selfservice.payments.service.gov.uk/transactions) and check
    your test transaction is in the list of transactions.
+
 5. Select the test transaction and check if you can refund it.
+
 6. Delete the payments link you created to make the test payment.
 
 > The refund option may take up to 20 minutes to appear after submitting the transaction.
@@ -178,5 +192,3 @@ When this is available, sign in to your [GOV.UK Pay
 account](https://selfservice.payments.service.gov.uk/login). Go to __My
 services__ to select the live service you want to set up. Select __Settings__,
 then __3D Secure__ and then select __Turn 3D Secure on__.
-
-

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -17,9 +17,11 @@ Real card numbers will not work.
 
 You should also:
 
- - only use your test account, not your live account
- - make sure that test calls to the GOV.UK Pay API succeed with [200 codes](/api_reference/#http-status-codes)
- - [test the whole user journey](/#test-your-service-with-your-users) from your service to the payment service provider
+ * only use your test account, not your live account
+
+ * make sure that test calls to the GOV.UK Pay API succeed with [200 codes](/api_reference/#http-status-codes)
+
+ * [test the whole user journey](/#test-your-service-with-your-users) from your service to the payment service provider
 
 #### HTTP with test accounts
 
@@ -105,7 +107,9 @@ other details. For example, expiry dates must be in the future.
 Refer to the [Worldpay documentation](http://support.worldpay.com/support/kb/gg/corporate-gateway-guide/content/reference/testvalues.htm#Test) [external link].
 
 ### Barclays ePDQ test card numbers
+
 Refer to the [ePDQ __Get Started__ guide](https://support.epdq.co.uk/en/products/onboarding) [external link] and select __What credit cards can I use for testing?__
 
 ### Barclays SmartPay test card numbers
+
 Refer to the [SmartPay TestCards page](https://docs.adyen.com/developers/test-cards/test-card-numbers) [external link].

--- a/source/troubleshooting/index.html.md.erb
+++ b/source/troubleshooting/index.html.md.erb
@@ -22,12 +22,17 @@ This section explains how to troubleshoot common problems.
 
 Possible reasons why your call may be rejected include:
 
-+ sending a POST call with an empty body where content in the body is expected
-+ the use of invalid characters such as ``<``, ``>``, ``|``, ``"`` or backslashes
-+ the ``return_url`` you provide is not ``https://``
-+ there are URLs inside the ``reference`` or ``description`` you provide
-+ you have not included a ``Content-Type: application/json`` header
-+ you’ve included an ``Accept`` header but with something other than ``application/json``
+* sending a POST call with an empty body where content in the body is expected
+
+* the use of invalid characters such as ``<``, ``>``, ``|``, ``"`` or backslashes
+
+* the ``return_url`` you provide is not ``https://``
+
+* there are URLs inside the ``reference`` or ``description`` you provide
+
+* you have not included a ``Content-Type: application/json`` header
+
+* you’ve included an ``Accept`` header but with something other than ``application/json``
 
 ## The code examples in the documentation do not work
 


### PR DESCRIPTION
### Context
The bullet points and numbered steps in the docs aren't currently uniform. In the Markdown itself, we use "+", "-", "*"

Some bullets have spaces and some don't. I think it's easiest (and clearest) if we just have spaces everywhere. 

### Changes proposed in this pull request
Makes all bullets use "*"

Adds spaces between all numbered steps and bullets

Other very few, very minor edits I spotted along the way 

### Guidance to review
Would be good to have someone review this properly to assess whether my suggested changes make sense, and to make sure I haven't broken up any bullets/steps