### PR TITLE
Removes FAQ format from landing page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -14,12 +14,12 @@ page](https://www.payments.service.gov.uk/features).
 
 Please [contact us](/support_contact_and_more_information/#contact-us) if you have any questions or feedback.
 
-## How many services are using GOV.UK Pay?
+## Services using GOV.UK Pay
 
 You can see how many services are using GOV.UK Pay on [our performance
 dashboard](https://www.gov.uk/performance/govuk-pay).
 
-## How much does it cost?
+## How much it costs
 
 There is no charge to use GOV.UK Pay. You will still need to pay your payment
 service provider’s (PSP’s) transaction fees.


### PR DESCRIPTION
### Context
We shouldn't use FAQs anywhere on GOV.UK

### Changes proposed in this pull request
Removes FAQ and changes to different, statement-based format