### PR TITLE
State that the amount is a number

### DIFF
--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -102,7 +102,7 @@ For example:
 }
 ```
 
-`amount`: The amount in pence - in the example, the payment is for £145.
+`amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type.
 
 `reference`: The reference number you wish to associate with this payment. The
 format is variable: if you have an existing format, you can keep using it with

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -102,7 +102,7 @@ For example:
 }
 ```
 
-`amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type.
+`amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type rather than a string.
 
 `reference`: The reference number you wish to associate with this payment. The
 format is variable: if you have an existing format, you can keep using it with


### PR DESCRIPTION
### Context

HMPO feedback on the documentation states that it would be useful to say that a Number is required for the parameter "amount" when Posting to the /payments endpoint.

### Changes proposed in this pull request

Add statement to the Payment flow overview section that the amount parameter is a number data type.

### Guidance to review

This is a small change based on HMPO feedback and just needs review and approval from a Pay approved reviewer.