### PR TITLE
Change docs to reflect new Slate instance rather than Gelato

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -14,19 +14,13 @@ determines if actions are treated as test payments, or processed as real payment
 The API is based on REST principles. It returns data in JSON format, and uses
 standard HTTP error response codes.
 
-For full details of each API action, see the API browser:
-
-* <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general" target="blank">General functions</a> [external link]
-
-* <a href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id" target="blank">Payment ID functions</a> [external link]
-
-You can also use the interactive <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2//"
-target="blank">API explorer</a> [external link] to try API calls and view responses.
+For full details of each API action, see the <a
+href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
+browser</a> [external link].
 
 See the [__Quick start guide__](/quick_start_guide/#quick-start-guide) section
-to read how to set up the API explorer. Make sure you enter your test API
-key to avoid generating real payments.
+to read how to get started with the API quickly. Make sure you enter your test
+API key to avoid generating real payments.
 
 ## Authentication
 
@@ -49,7 +43,7 @@ possible outcomes, excluding for delayed capture payments:
 ![](/images/payment-states.svg)
 
 You can check the status of a payment using the <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
+href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
 target="blank">Find payment by ID</a> API call [external link].
 
 A successful response includes ``status`` and ``finished`` values:

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -77,9 +77,10 @@ You can read more in the [__Reporting__](/reporting) and
 ## The GOV.UK Pay API
 
 The GOV.UK Pay API offers a set of operations to conduct and report on
-payments. See the [__API reference__](/api_reference) section
-of this documentation for more information or use the interactive [API
-explorer](https://gds-payments.gelato.io/api-explorer/) [external link].
+payments. See the [__API reference__](/api_reference) section of this
+documentation for more information or use the <a
+href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
+browser</a> [external link].
 
 ## When to release your service to users
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -14,9 +14,10 @@ The call to create a payment with the GOV.UK Pay API is:
 
 `POST  /v1/payments`
 
-You can test this with [our API
-explorer](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2//)
-[external link].
+Refer to the <a
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
+target="blank">GOV.UK Pay API browser</a> [external link] for more
+information.
 
 The response to the ‘Create new payment’ API call will include the URL for the
 payment. You can get this from either:
@@ -59,9 +60,9 @@ You must not expose the URL with the `paymentId` or the `next_url` publicly, for
 
 ## Track the progress of a payment
 
-You can track the progress of a payment using
-the <a href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
-target="blank">Find payment by ID</a> call [external link]
+You can track the progress of a payment using the <a
+href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
+target="blank">Find payment by ID</a> call [external link].
 
 The status of the payment will pass through several states until it either
 succeeds or fails. See the [“API reference”
@@ -135,13 +136,8 @@ progress. Alternatively, a service can make the following API call for a given
 
 A `204` response indicates success. Any other response indicates an error.
 
-To test this with the GOV.UK Pay API Explorer [external links]:
-
-1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> (link opens in new window).
-
-2. Under __Resource__, select __{Payment Id}__. Under __Action__, select
-__Search payments__.
+See <a href="https://govukpay-api-browser.cloudapps.digital/#cancelpayment"
+target="blank">API browser</a> [external link] for more details.
 
 ### Find out if you can cancel a payment
 

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -7,15 +7,16 @@ weight: 133
 
 GOV.UK Pay supports the delayed capture of payments.
 
-To use this feature, include `"delayed_capture": true` in the body of a
-[create new
-payment](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment)
-request [external link].
+To use this feature, include `"delayed_capture": true` in the body of a <a
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
+target="blank">Create new payment</a> request [external link]. 
 
 The user experience matches the current payment flow. Once the user selects
 __Confirm__ on the __Confirm your details__ page, your service can call the
 `POST /v1/payments/{paymentId}/capture` endpoint to send a delayed capture
-request.
+request. Refer to the <a
+href="https://govukpay-api-browser.cloudapps.digital/#capturepayment"
+target="blank">API browser</a> [external link] for more information.
 
 There are 4 possible responses:
 
@@ -41,9 +42,9 @@ received and accepted.
 ## See the capture URL for a payment
 
 If a payment is available for capture, you can see its capture URL in
-GOV.UK Pay API responses such as:
+responses to API calls. For example:
 
-* `GET /v1/payments/<PAYMENT-ID>`
+* `GET /v1/payments/{paymentID}`
 
 * `GET /v1/payments`
 

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -32,10 +32,9 @@ knows the [state of a payment](/payment_flow/#check-the-status-of-a-payment), it
 example if a user's payment expires, you may want your service to return the
 user to the start of their payment journey.
 
-You can experiment with querying payments using [our
-interactive API
-explorer](https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2//)
-[external link].
+Refer to the GOV.UK Pay <a
+href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
+browser</a> [external link] for more information on using the API.
 
 In very rare cases, GOV.UK Pay is unable to redirect payments. You should
 [contact us](/support_contact_and_more_information/#contact-us) if this

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -54,7 +54,7 @@ A final state means that the payment:
 * fails due to a technical error
 
 * fails because it is cancelled by your service
- 
+
 * expires - users have 90 minutes to complete a payment once it is created
 
 When the user arrives back at your service, you can use the API to check the
@@ -87,7 +87,7 @@ pages to make their payment.
 
 In the example page, when the user selects __Continue__, the service makes a
 <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment"
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
 target="blank">Create new payment</a> call to the GOV.UK Pay API [external
 link]. The body of the call is returned in JSON.
 
@@ -285,7 +285,7 @@ The [__Making payments__](/making_payments/#making-payments) section contains
 more details about how to match users to payments.
 
 To check the status of a payment, you must make a <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
+href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
 target="blank">Find payment by ID</a> API call [external link],
 using the `payment_id` of the payment as the parameter.
 
@@ -321,7 +321,7 @@ more information about how you can integrate your service with GOV.UK Pay.
 
 If your user starts a payment but does not complete it, they can resume that
 incomplete payment. An example of this could be if they use an internet
-browser’s ‘back’ button during a payment, and then go forward by selecting 
+browser’s ‘back’ button during a payment, and then go forward by selecting
 links on your website.
 
 If your service uses the resume payment feature, you will:

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -93,6 +93,8 @@ to keep your API key safe.
 
 You can make test API calls to GOV.UK Pay with your test API key. 
 
+You can use API testing tools such as <a href="https://www.getpostman.com/" target="blank">Postman</a> [external link] or <a href="https://www.soapui.org/" target="blank">SoapUI</a> [external link] to make test API calls.
+
 This section shows an example API call and request body, to make a new payment
 for a passport application:
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -93,7 +93,7 @@ to keep your API key safe.
 
 You can make test API calls to GOV.UK Pay with your test API key. 
 
-You can use API testing tools such as <a href="https://www.getpostman.com/" target="blank">Postman</a> [external link] or <a href="https://www.soapui.org/" target="blank">SoapUI</a> [external link] to make test API calls.
+You can use API testing tools such as <a href="https://www.getpostman.com/" target="_blank">Postman</a> [external link] or <a href="https://insomnia.rest/" target="_blank">Insomnia REST</a> [external link] to make test API calls.
 
 This section shows an example API call and request body, to make a new payment
 for a passport application:

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -34,8 +34,7 @@ Pay is right for your service
 * read the GOV.UK Service Manual guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html)
 
-* sign up to the [API
-explorer](https://gds-payments.gelato.io/) [external link] if you want to use it to test the API
+* visit our <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a> [external link]
 
 If you want to build a technical integration between your service and the
 GOV.UK Pay API, your service team should have the necessary skills. You can
@@ -59,9 +58,11 @@ allows you to:
 * issue full or partial refunds
 
 When you've received a test account, follow these instructions to get started
-with our API Explorer and make a test API call.
+with our API and make a test API call.
 
-## Generate API Key for API Explorer
+## Test the API 
+
+### Generate a test API key
 
 1. Sign in to the [GOV.UK Pay admin
    tool](https://selfservice.payments.service.gov.uk/) with the test
@@ -78,21 +79,6 @@ with our API Explorer and make a test API call.
 [Read the __Security__ section](/security/#security) for more information on how
 to keep your API key safe.
 
-## API Explorer setup
-
-The quickest way to get started with the API is to use the <a
-href="https://gds-payments.gelato.io/api-explorer/" target="blank">API
-Explorer</a> [external link] with your API key.
-
-1. Sign in to the API Explorer and select __Add API Key__.<br/><br/>
-   ![](/images/pay-add-api-key.png) <br/><br/>
-
-2.  In the pop-up, enter the following values:
-
-  * For __API Key__, enter your test API key. You do not need to add the
-  `"Bearer:"` prefix, because the API Explorer adds that automatically.
-  * For __Label__, enter `Authorization`.
-
 <br>
 
 <div class="govuk-warning-text">
@@ -103,20 +89,14 @@ Explorer</a> [external link] with your API key.
   </strong>
 </div>
 
-## Make a test API call
+### Make a test API call
 
-This section describes how to make a test API call to GOV.UK Pay, by creating
-a new payment.  This is the same call your service will make when beginning a
-payment using GOV.UK Pay.
+You can make test API calls to GOV.UK Pay with your test API key. 
 
-1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> [external link]
+This section shows an example API call and request body, to make a new payment
+for a passport application:
 
-2. Under __Resource__, select __General__. Under __Action__, select <a
-   href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/general/create-new-payment"
-   target="blank">__Create new payment__</a> [external link]. Select
-   the __Body__ tab down to see an example JSON body that you would send when
-   creating a payment.
+```POST /v1/payments```
 
 ```javascript
 {
@@ -127,28 +107,21 @@ payment using GOV.UK Pay.
 }
 ```
 
-You also need to send a ``return_url`` when you create a payment. This is
-because users go to pages hosted by GOV.UK Pay to actually
-make payments.  The ``return_url`` is the URL of a page on your service
-that the user will be redirected to after they have completed their payment
-(or payment has failed).  <br/><br/>
-![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/pay-api-explorer-createpay.png)
 
 Services that use test accounts can optionally use HTTP, rather than HTTPS,
 for return URLs. You can read more about this in [the __Security__
 section](/security/#https).
 
-1. Select the green __Send Request__ button.
+If the test call is successful, you will receive a `201 Created` response with
+a JSON body.
 
-2. If the API Explorer is set up correctly, you will receive a `201 Created`
-   response with a JSON body, confirming that the payment was created:
+The JSON includes a ``next_url`` link. This URL is where your service should
+redirect the user for them to make their payment. 
 
-   ![](https://s3-eu-west-1.amazonaws.com/pay-govuk-documentation/pay-api-explorer-response.png)
+You can refer to the [“Making payments” section](/making_payments) for more
+detailed information.
 
-   The JSON includes a ``next_url`` link. This URL is where your service
-   should redirect the user for them to make their payment.  <br/><br/>
-
-## Simulate an end-user payment journey
+### Simulate an end-user payment journey
 
 Go to the ``next_url`` with a browser, and you’ll see the payment screen.
 Choose a mock card number from the [__Testing GOV.UK
@@ -162,7 +135,7 @@ details, enter some test information which should have:
 
 Submit the payment.
 
-## View transactions at GOV.UK Pay admin tool
+### View transactions at GOV.UK Pay admin tool
 
 Go to the [GOV.UK Pay admin
 tool](https://selfservice.payments.service.gov.uk/). From the landing page,

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -37,10 +37,10 @@ Refunds can have 3 states:
 ## Payment refund status
 
 You can find out the refund status of a payment with the GOV.UK Pay API using the <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/v1/find-payment-by-id"
+href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
 target="blank">Find payment by ID</a> or <a
-href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/general/endpoints/search-payments"
-target="blank">Search payments</a> functions [external link].
+href="https://govukpay-api-browser.cloudapps.digital/#searchpayments"
+target="blank">Search payments</a> functions [external links].
 
 The JSON response body will contain a `refund_summary` object. For example,
 for a completed £50 payment with no previous refunds:
@@ -65,9 +65,9 @@ against the same payment. The total refunds for a single payment cannot
 be greater than the original payment.
 
 You can use the <a
-href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id/endpoints/get-all-refunds-for-a-payment"
-target="blank">Get all refunds for a payment</a> [external link].
-API call to get information about partial refunds.
+href="https://govukpay-api-browser.cloudapps.digital/#getrefunds"
+target="blank">Get all refunds for a payment</a> [external link] API call to
+get information about partial refunds.
 
 As another example, this is the JSON response body for a completed £90 payment
 with a previous refund of £30:
@@ -117,9 +117,8 @@ return an error code `P0604` with a `412` HTTP status.
 ## Refunding with the GOV.UK Pay API
 
 You can start a refund with the <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/submit-a-refund-for-a-payment"
-target="blank">Submit a refund for a payment</a> function (link opens in new
-window).
+href="https://govukpay-api-browser.cloudapps.digital/#submitrefund"
+target="blank">Submit a refund for a payment</a> function [external link].
 
 You need to specify the `paymentId` of the original payment, and provide the
 amount to refund, in pence.
@@ -138,15 +137,14 @@ such as:
 Each refund has a unique `refund_id`.
 
 You can use the <a
-href="https://gds-payments.gelato.io/docs/versions/1.0.2/resources/payment-id/endpoints/get-all-refunds-for-a-payment"
-target="blank">Get all refunds for a payment</a> function (link opens in new
-window) to get information all the refunds for a payment (including their
-`refund_id` values).
+href="https://govukpay-api-browser.cloudapps.digital/#getrefunds"
+target="blank">Get all refunds for a payment</a> function [external link] to
+get information all the refunds for a payment (including their `refund_id`
+values).
 
 You can retrieve information about an individual refund using the <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id"
-target="blank">Find payment refund by ID</a> function (link opens in new
-window).
+href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
+target="blank">Find payment refund by ID</a> function [external link].
 
 A `204` response from the API indicates that a refund was successful. Any
 other response indicates an error.
@@ -154,14 +152,14 @@ other response indicates an error.
 ## Refund errors
 
 When you try to create a refund with the API, it may fail immediately. For
-example, if you try to refund more than the amount available. In that case, the
-original <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/submit-a-refund-for-a-payment"
-target="blank">Submit a refund for a payment</a> request (link opens in new
-window) will return an error code and a description of what it means. (A
-refund attempt that fails like this with an error code is not assigned a
-`refundId` and is not available using <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id"
+example, if you try to refund more than the amount available. In that case,
+the original <a
+href="https://govukpay-api-browser.cloudapps.digital/#submitrefund"
+target="blank">Submit a refund for a payment</a> request [external link] will
+return an error code and a description of what it means. A refund attempt
+that fails like this with an error code is not assigned a `refundId` and is
+not available using <a
+href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
 target="blank">Find payment refund by ID</a> [external link].
 
 If a refund is accepted by GOV.UK Pay, it may still go on to fail at the PSP.
@@ -197,7 +195,7 @@ go directly to `success`.
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
 To manage refunds in live environments, you must use <a
-href="https://gds-payments.gelato.io/api-explorer/gov-uk-pay-api/versions/1.0.2/payment-id/find-payment-refund-by-id"
+href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
 target="blank">Find payment refund by ID</a> [external link] to
 check the processing status of the refund, until it changes to either
 `success` or `error`.

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -51,12 +51,9 @@ You can use the GOV.UK Pay API to:
 
 `GET /v1/payments/paymentId`
 
-1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> [external link].
-
-2. Under __Resource__, select __{Payment Id}__.
-
-3. Under __Action__, select __Find payment by ID__.
+Refer to the <a
+href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
+target="blank">API browser</a> [external link] for more information.
 
 If the payment exists, the JSON response body to this
 API call contains a `"state"` field. You can use this information when
@@ -98,12 +95,9 @@ have entered when making a payment:
 
 `GET /v1/payments`
 
-1. Sign in to <a href="https://gds-payments.gelato.io/api-explorer/"
-   target="blank">the API Explorer</a> [external link].
-
-2. Under __Resource__, select __General__.
-
-3. Under __Action__, select __Search payments__.
+Refer to the <a
+href="https://govukpay-api-browser.cloudapps.digital/#searchpayments"
+target="blank">API browser</a> [external link] for more information.
 
 ### Search criteria
 

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -5,9 +5,6 @@ weight: 130
 
 # Versioning
 
-You can use [our API explorer](https://gds-payments.gelato.io/) [external
-link] to use the latest version of our API.
-
 If you want to update to our latest API, make sure you test your code before
 committing to the change.
 


### PR DESCRIPTION
### Context
We're moving away from Gelato, to Slate, for the "endpoint" part of our API documentation offering. We need to remove references to it, and to an "API explorer" generally. We also need to change some surrounding text, where relevant, particularly in the Quick start guide. The Slate instance is here:

https://govukpay-api-browser.cloudapps.digital/

### Changes proposed in this pull request
@jonathanglassman and I have been through and changed the docs to satisfy the above. We refer to the new Slate instance as the "API browser". 

### Guidance to review
This should be reviewed by others because it involves a lot of changes and we need to make sure they make sense, and that the links work. @jonathanglassman and I have reviewed together and we're happy that it's OK, but it's important to get this right. Ideally @heathd or @alexbishop1 will review to confirm that from a tech perspective it's all good. 

Live preview of docs changes: https://govukpay-api-browser-changes.cloudapps.digital/