### PR TITLE
Amend heading structure to comply with accessibility requirements

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -7,8 +7,10 @@ weight: 95
 
 Before you read this section, you may find it useful to read the [‘Reporting’ section](/reporting/#reporting).
 
-GOV.UK Pay does not limit how many services you can integrate with it and how many accounts you can have with us. 
+GOV.UK Pay does not limit how many services you can integrate with it and how many accounts you can have with us.
 GOV.UK Pay test and live accounts are free to create and maintain but your payment service provider may charge you for the underlying accounts.
+
+## Account structure examples
 
 If you do integrate multiple services, you can treat them separately or as a
 combined single service within GOV.UK Pay and your payment service provider (PSP).
@@ -54,7 +56,7 @@ they are a single service in the PSP. It is not possible to support multiple PSP
 GOV.UK Pay and as a single combined service in the PSP.
 
 You may want to use this configuration if you want to administrate multiple
-services individually in GOV.UK Pay. For example, if you want separate reporting for each service, or different service names on the payment pages. 
+services individually in GOV.UK Pay. For example, if you want separate reporting for each service, or different service names on the payment pages.
 This option also allows you to give access for each service to different staff members.
 
 In this configuration, payments for both services are settled to the same bank account because

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -17,7 +17,7 @@ customisation for the following features:
 
 * the branding of your payment confirmation email
 
-### Banner logo
+## Banner logo
 
 You should provide an image of your desired custom banner logo [to GOV.UK Pay
 directly](/support_contact_and_more_information/#contact-us). Your image should be:
@@ -30,7 +30,7 @@ directly](/support_contact_and_more_information/#contact-us). Your image should 
 
 * compressed (optimised for web)
 
-### Banner background and border colour
+## Banner background and border colour
 
 You can make a request for custom colours [to GOV.UK Pay
 directly](/support_contact_and_more_information/#contact-us).

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -23,19 +23,19 @@ You should also:
 
  * [test the whole user journey](/#test-your-service-with-your-users) from your service to the payment service provider
 
-#### HTTP with test accounts
+## HTTP with test accounts
 
 Services using test accounts can optionally use HTTP (rather than HTTPS)
 for return URLs. You can read more in [the __Security__
 section](/security/#https).
 
-### Make a demo payment
+## Make a demo payment
 
 You can [try the payment experience as a
 user](https://selfservice.payments.service.gov.uk/make-a-demo-payment), and
 then view the completed payment in the GOV.UK Pay [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
 
-### Test your service with your users
+## Test your service with your users
 
 You can [create a reusable
 link](https://selfservice.payments.service.gov.uk/test-with-your-users) to
@@ -67,7 +67,7 @@ If you experience any problems when testing, please email us at
 
 ## Performance testing
 
-The contract you have with GOV.UK Pay requires you to seek written approval from GOV.UK Pay before you conduct any performance testing. 
+The contract you have with GOV.UK Pay requires you to seek written approval from GOV.UK Pay before you conduct any performance testing.
 If you’d like to carry out any kind of performance testing, including in a
 rate-limiting environment, please contact us at
 [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).


### PR DESCRIPTION
Remove gaps in heading hierarchy to comply with accessibility requirements.

### Context

All documentation websites must meet the new public sector requirement to be more accessible. The website meets this requirement if it complies with the international WCAG 2.1 AA accessibility standard.

The GOV.UK Pay (and other) tech docs mostly meet this requirement already. However, one of the requirements is that the heading structure cannot miss levels i.e. you cannot follow an H1 with an H3, or an H2 with an H4. I've audited the Pay tech docs content to see if this occurs anywhere and proposed some changes to rectify this.

### Changes proposed in this pull request

Corrected all instances of headings skipping levels. 

### Guidance to review

Check that the changes do not make the tech docs any less useful for the user.
