### PR TITLE
Add content stating that minimum payment amount is one pence.

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -14,6 +14,8 @@ The call to create a payment with the GOV.UK Pay API is:
 
 `POST  /v1/payments`
 
+The minimum payment amount is one pence.
+
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
 target="blank">GOV.UK Pay API browser</a> [external link] for more

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -104,6 +104,8 @@ For example:
 
 `amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type rather than a string.
 
+The minimum payment amount is one pence.
+
 `reference`: The reference number you wish to associate with this payment. The
 format is variable: if you have an existing format, you can keep using it with
 GOV.UK Pay (maximum 255 characters, and must not contain URLs). The reference


### PR DESCRIPTION
### Context

The minimum transaction value is one pence or £0.01. It is possible to have a transaction value of £0.00, however this is not a feature that we want to publicise. 

The tech docs do not currently state this minimum transaction value.

### Changes proposed in this pull request

Add content stating that minimum payment amount is one pence.

### Guidance to review
