### PR TITLE
PP-4764 Make Worldpay link clickable

### DIFF
--- a/source/stylesheets/screen-old-ie.css.scss
+++ b/source/stylesheets/screen-old-ie.css.scss
@@ -2,3 +2,11 @@ $is-ie: true;
 $ie-version: 8;
 
 @import "govuk_tech_docs";
+
+.has-sidebar .technical-documentation {
+  h1,
+  h2,
+  h3 {
+    margin-top: 0px !important;
+  }
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,9 @@
 @import 'govuk_tech_docs';
+
+.has-sidebar .technical-documentation {
+  h1,
+  h2,
+  h3 {
+    margin-top: 0px !important;
+  }
+}


### PR DESCRIPTION
### Context

Add whitespace `&nbsp;` between the `Worldpay` link and the title `The differences between test and live accounts`, because the CSS of the title makes the link un-clickable.
Avoided CSS changes not to break other pages in terms of displaying titles.

with @jonheslop