### PR TITLE
Add content on enabling Amex cards

### DIFF
--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -162,6 +162,8 @@ __REVOKED__
 1. Contact your Worldpay account manager to confirm the cards you want to
    accept are set up. Make sure you only select [card types](https://selfservice.payments.service.gov.uk/card-types/summary) within GOV.UK Pay that are also enabled in your Worldpay account.
 
+   If you want to accept American Express cards, you must contact your relationship manager. If you are a non-Crown merchant, you must send your merchant ID to your relationship manager. You do not need to send your merchant ID if you are a Crown merchant.
+
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this. Make sure you use a live API key, not a test
    one. Use [payment links](/payment_links) if your service is not yet connected

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -162,7 +162,11 @@ __REVOKED__
 1. Contact your Worldpay account manager to confirm the cards you want to
    accept are set up. Make sure you only select [card types](https://selfservice.payments.service.gov.uk/card-types/summary) within GOV.UK Pay that are also enabled in your Worldpay account.
 
-   If you want to accept American Express cards, you must contact your relationship manager. If you are a non-Crown merchant, you must send your merchant ID to your relationship manager. You do not need to send your merchant ID if you are a Crown merchant.
+    If you want to accept American Express cards, you must enable American Express cards in your Worldpay account in addition to enabling them in your GOV.UK Pay account. To do this, contact:
+      - the Government Banking Service (GBS) if your Worldpay contract is through the GBS
+      - your Worldpay relationship manager if your Worldpay contract is not through the GBS
+
+      You must send your American Express merchant ID to your contact if you are a non-Crown merchant.
 
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
    API](/api_reference) to do this. Make sure you use a live API key, not a test


### PR DESCRIPTION
### Context

Worldpay merchants must contact their relationship manager to enable American Express cards with Worldpay before those cards start working.

The process differs slightly depending on whether the merchant is Crown or non-Crown.

### Changes proposed in this pull request

Add content that states that Worldpay merchants must contact their relationship manager to enable American Express cards with Worldpay before those cards start working

### Guidance to review

Review and check if correct. 