### PR TITLE
Add content into the "Test your configuration" sections.

### DIFF
--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -202,8 +202,6 @@ In your [GOV.UK Pay
 
     The refund option may take up to 20 minutes to appear after submitting the transaction.
 
-    If you have not [set up notifications](#set-up-notification-settings) correctly, some features such as refunds will not be available.
-
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -185,9 +185,11 @@ In your [GOV.UK Pay
    accept are set up.
 
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
-   API](/api_reference) to do this. Make sure you use a live API key, not a test
-   one. Use [payment links](/payment_links) if your service is not yet connected
-   to GOV.UK Pay.
+   API](/api_reference) to do this.
+
+    Make sure you use a live API key, not a test one. Use [payment links](/payment_links) if your service is not yet connected to GOV.UK Pay.
+
+    If the test transaction fails, check that you have entered the correct credentials into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
@@ -198,10 +200,14 @@ In your [GOV.UK Pay
 
 5. Select the test transaction and check if you can refund it.
 
-> The refund option may take up to 20 minutes to appear after submitting the transaction.
+    The refund option may take up to 20 minutes to appear after submitting the transaction.
+
+    If you have not [set up notifications](#set-up-notification-settings) correctly, some features such as refunds will not be available.
 
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.
+
+
 
 ## Set up 3D Secure
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -139,9 +139,11 @@ Complete the following fields on this page:
    accept are set up.
 
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
-   API](/api_reference) to do this. Make sure you use a live API key, not a test
-   one. Use [payment links](/payment_links) if your service is not yet connected
-   to GOV.UK Pay.
+   API](/api_reference) to do this.
+
+    Make sure you use a live API key, not a test one. Use [payment links](/payment_links) if your service is not yet connected to GOV.UK Pay.
+
+    If the test transaction fails, check that you have entered the correct credentials into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
@@ -152,7 +154,9 @@ Complete the following fields on this page:
 
 5. Select the test transaction and check if you can refund it.
 
-> The refund option may take up to 20 minutes to appear after submitting the transaction.
+    The refund option may take up to 20 minutes to appear after submitting the transaction.
+
+    If you have not [set up notifications](#configure-server-communication-on-smartpay) correctly, some features such as refunds will not be available.
 
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -156,7 +156,7 @@ Complete the following fields on this page:
 
     The refund option may take up to 20 minutes to appear after submitting the transaction.
 
-    If you have not [set up notifications](#configure-server-communication-on-smartpay) correctly, some features such as refunds will not be available.
+    If the refund option does not appear, check you have [set up notifications correctly](#configure-server-communication-on-smartpay).
 
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -182,7 +182,7 @@ __REVOKED__
 
     The refund option may take up to 20 minutes to appear after submitting the transaction.
 
-    If you have not [set up notifications](#set-up-merchant-channel) correctly, some features such as refunds will not be available.
+    If the refund option does not appear, check you have [set up notifications correctly](#set-up-merchant-channel).
 
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -163,9 +163,11 @@ __REVOKED__
    accept are set up. Make sure you only select [card types](https://selfservice.payments.service.gov.uk/card-types/summary) within GOV.UK Pay that are also enabled in your Worldpay account.
 
 2. Make a test transaction on your live account. You can use [the GOV.UK Pay
-   API](/api_reference) to do this. Make sure you use a live API key, not a test
-   one. Use [payment links](/payment_links) if your service is not yet connected
-   to GOV.UK Pay.
+   API](/api_reference) to do this.
+
+    Make sure you use a live API key, not a test one. Use [payment links](/payment_links) if your service is not yet connected to GOV.UK Pay.
+
+    If the test transaction fails, check that you have entered the correct credentials into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
 3. Sign in to your [GOV.UK Pay
    account](https://selfservice.payments.service.gov.uk/).
@@ -178,7 +180,9 @@ __REVOKED__
 
 6. Delete the payments link you created to make the test payment.
 
-> The refund option may take up to 20 minutes to appear after submitting the transaction.
+    The refund option may take up to 20 minutes to appear after submitting the transaction.
+
+    If you have not [set up notifications](#set-up-merchant-channel) correctly, some features such as refunds will not be available.
 
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.


### PR DESCRIPTION
### Context

There have been some support tickets where payments have failed and users have not been able to figure out why. These changes clarify the most common reason why payments fail.

### Changes proposed in this pull request

Add content on checking that:
- your credentials on gov.uk pay are correct
- you have set up notifications that enable features like refunds correctly 

### Guidance to review
