### PR TITLE
Add missing )

### DIFF
--- a/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
+++ b/source/switching_to_live/before_you_switch_to_live/index.html.md.erb
@@ -57,7 +57,7 @@ Refer to the following GOV.UK Pay documentation to see what information you must
 
 * [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#set-up-live-gov-uk-pay-credentials)
 * [Smartpay](/switching_to_live/set_up_a_live_smartpay_account/#set-up-credentials-on-gov-uk-pay)
-* [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#set-up-your-profile
+* [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#set-up-your-profile)
 
 ## Support
 


### PR DESCRIPTION
### Context

One of the links is missing a ")". This means that it is not a link.

### Changes proposed in this pull request

Add the missing ")" to make the link a link again

### Guidance to review

Accept the PR :-)
