### PR TITLE
Update custom branding pages

### DIFF
--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 131
 
 GOV.UK Pay supports custom branding on all pages in your payment journey.
 
-You can use custom branding regardless of whether you integrate your service with GOV.UK Pay, or use payment links.
+You can use custom branding regardless of whether you [integrate your service](/integrate_with_govuk_pay/#how-to-integrate-with-the-gov-uk-pay-api) with GOV.UK Pay, or use [payment links](/payment_links/#payment-links).
 
 You can [contact the GOV.UK Pay
 team](/support_contact_and_more_information/#contact-us) to request

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -5,7 +5,9 @@ weight: 131
 
 # Custom branding of payment pages
 
-GOV.UK Pay supports custom branding on payment pages.
+GOV.UK Pay supports custom branding on all pages in your payment journey.
+
+You can use custom branding regardless of whether you integrate your service with GOV.UK Pay, or use payment links.
 
 You can [contact the GOV.UK Pay
 team](/support_contact_and_more_information/#contact-us) to request


### PR DESCRIPTION
### Context

You can use custom branding on all pages in your payment journey.

Not just the 'payment pages' (Enter card details, Confirm your payment pages) but also any pages associated with a payment link (eg enter your reference, payment amount page).

### Changes proposed in this pull request

Clarify that custom branding applies to all pages in your payment journey, not just payment pages, and also applies regardless of whether you integrate or use payment links.

### Guidance to review
