### PR TITLE
Correct link to contact support section

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -23,7 +23,7 @@ funds. It takes 3 to 4 working days to confirm the success of the payment.
 ## Get started
 
 To use the Direct Debit feature, you [must request a GOV.UK Pay
-Direct Debit test account](support_contact_and_more_information/#contact-us) from our support team.
+Direct Debit test account](/support_contact_and_more_information/#contact-us) from our support team.
 
 [Contact us](/support_contact_and_more_information/#contact-us) if you want to add Direct Debit to an existing integration.
 


### PR DESCRIPTION
### Context

First link in https://docs.payments.service.gov.uk/direct_debit/#get-started is incorrect.

### Changes proposed in this pull request

Correct link by adding a `/` at the start.

### Guidance to review
