### PR TITLE
Add reference to NCSC cloud security principles to the Security section

### DIFF
--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -75,6 +75,10 @@ take care not to use any real card numbers. Read the
 
 GOV.UK Pay does not store full card numbers or CVV data for security reasons. This means you will not be able to search for transactions using card numbers. You can, however, search for the first six digits and the last four digits of a card.
 
+## Cloud security principles
+
+GOV.UK Pay has implemented the Cloud Security Principles. Refer to the [National Cyber Security Centre documentation on implementing the Cloud Security Principles](https://www.ncsc.gov.uk/collection/cloud-security?curPage=/collection/cloud-security/implementing-the-cloud-security-principles) for more information.
+
 ## Payment Card Industry (PCI) compliance
 
 Anyone involved with the processing, transmission, or storage of cardholder


### PR DESCRIPTION
### Context

The product security page at https://www.payments.service.gov.uk/security/ will have a reference to the cloud security principles.

### Changes proposed in this pull request

Add a reference to the NCSC page on implementing the cloud security principles to the security section.

### Guidance to review
