### PR TITLE
add reply-to email address content to custom branding page

### DIFF
--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -41,8 +41,6 @@ Colours are customised using hexadecimal representations.
 
 ## Reply-to email address
 
-When you set up custom branding on your payment confirmation emails, you can set a reply-to email address so your users can contact you directly.
+When you ask GOV.UK Pay to set up custom branding on your payment confirmation emails, you should specify a reply-to email address so your users can contact you.
 
 This reply-to email address can be an email inbox for your service, or an automated response.
-
-If you do not set a reply-to email address, GOV.UK Pay will set this email address to [gov.uk-pay-no-reply@digital.cabinet-office.gov.uk](mailto:gov.uk-pay-no-reply@digital.cabinet-office.gov.uk).

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -44,3 +44,5 @@ Colours are customised using hexadecimal representations.
 When you ask GOV.UK Pay to set up custom branding on your payment confirmation emails, you should specify a reply-to email address so your users can contact you.
 
 This reply-to email address can be an email inbox for your service, or an automated response.
+
+If you do not use custom branding on your payment confirmation emails, you cannot specify a reply-to email address. Refer to the [confirmation email](/payment_flow/#confirmation-email) section of this documentation for more information.

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -38,3 +38,11 @@ You can make a request for custom colours [to GOV.UK Pay
 directly](/support_contact_and_more_information/#contact-us).
 
 Colours are customised using hexadecimal representations.
+
+## Reply-to email address
+
+When you set up custom branding on your payment confirmation emails, you can set a reply-to email address so your users can contact you directly.
+
+This reply-to email address can be an email inbox for your service, or an automated response.
+
+If you do not set a reply-to email address, GOV.UK Pay will set this email address to [gov.uk-pay-no-reply@digital.cabinet-office.gov.uk](mailto:gov.uk-pay-no-reply@digital.cabinet-office.gov.uk).


### PR DESCRIPTION
### Context

When services want custom branding on emails, we set them up with a Notify account. In the Notify account a reply-to email address needs to be specified. This can be the (new) generic gov.uk pay no reply address (gov.uk-pay-no-reply@digital.cabinet-office.gov.uk) but it's a better user experience if the service actually provide their own, so then users can go directly back to the service.

### Changes proposed in this pull request

Add content to state that services can set up a reply-to email address for their custom branded emails, and if they don't, that email address will default to the GOV.UK Pay no reply email address.

### Guidance to review
