### PR TITLE
Swagger ref

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -16,7 +16,7 @@ standard HTTP error response codes.
 
 For full details of each API action, see the <a
 href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
-browser</a> [external link].
+browser</a> or look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>.
 
 See the [__Quick start guide__](/quick_start_guide/#quick-start-guide) section
 to read how to get started with the API quickly. Make sure you enter your test

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -77,10 +77,11 @@ You can read more in the [__Reporting__](/reporting) and
 ## The GOV.UK Pay API
 
 The GOV.UK Pay API offers a set of operations to conduct and report on
-payments. See the [__API reference__](/api_reference) section of this
-documentation for more information or use the <a
-href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
-browser</a> [external link].
+payments. For more information:
+
+- see the [__API reference__](/api_reference) section of this documentation
+- use the <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a>
+- look at the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>
 
 ## When to release your service to users
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -23,7 +23,7 @@ The minimum payment amount is one pence.
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">GOV.UK Pay API browser</a> [external link] for more
+target="blank">GOV.UK Pay API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more
 information.
 
 The response to the ‘Create new payment’ API call will include the URL for the

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -41,8 +41,6 @@ Colours are customised using hexadecimal representations.
 
 ## Reply-to email address
 
-When you set up custom branding on your payment confirmation emails, you can set a reply-to email address so your users can contact you directly.
+When you ask GOV.UK Pay to set up custom branding on your payment confirmation emails, you should specify a reply-to email address so your users can contact you.
 
 This reply-to email address can be an email inbox for your service, or an automated response.
-
-If you do not set a reply-to email address, GOV.UK Pay will set this email address to [gov.uk-pay-no-reply@digital.cabinet-office.gov.uk](mailto:gov.uk-pay-no-reply@digital.cabinet-office.gov.uk).

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -38,3 +38,11 @@ You can make a request for custom colours [to GOV.UK Pay
 directly](/support_contact_and_more_information/#contact-us).
 
 Colours are customised using hexadecimal representations.
+
+## Reply-to email address
+
+When you set up custom branding on your payment confirmation emails, you can set a reply-to email address so your users can contact you directly.
+
+This reply-to email address can be an email inbox for your service, or an automated response.
+
+If you do not set a reply-to email address, GOV.UK Pay will set this email address to [gov.uk-pay-no-reply@digital.cabinet-office.gov.uk](mailto:gov.uk-pay-no-reply@digital.cabinet-office.gov.uk).

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -9,14 +9,16 @@ GOV.UK Pay supports the delayed capture of payments.
 
 To use this feature, include `"delayed_capture": true` in the body of a <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">Create new payment</a> request [external link]. 
+target="blank">Create new payment</a> request [external link].
 
 The user experience matches the current payment flow. Once the user selects
 __Confirm__ on the __Confirm your details__ page, your service can call the
 `POST /v1/payments/{paymentId}/capture` endpoint to send a delayed capture
-request. Refer to the <a
+request.
+
+Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#capturepayment"
-target="blank">API browser</a> [external link] for more information.
+target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
 
 There are 4 possible responses:
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -34,7 +34,7 @@ Pay is right for your service
 * read the GOV.UK Service Manual guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html)
 
-* visit our <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a> [external link]
+* visit our <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a> or look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>
 
 If you want to build a technical integration between your service and the
 GOV.UK Pay API, your service team should have the necessary skills. You can
@@ -60,7 +60,7 @@ allows you to:
 When you've received a test account, follow these instructions to get started
 with our API and make a test API call.
 
-## Test the API 
+## Test the API
 
 ### Generate a test API key
 
@@ -91,7 +91,7 @@ to keep your API key safe.
 
 ### Make a test API call
 
-You can make test API calls to GOV.UK Pay with your test API key. 
+You can make test API calls to GOV.UK Pay with your test API key.
 
 You can use API testing tools such as <a href="https://www.getpostman.com/" target="_blank">Postman</a> [external link] or <a href="https://insomnia.rest/" target="_blank">Insomnia REST</a> [external link] to make test API calls.
 
@@ -118,7 +118,7 @@ If the test call is successful, you will receive a `201 Created` response with
 a JSON body.
 
 The JSON includes a ``next_url`` link. This URL is where your service should
-redirect the user for them to make their payment. 
+redirect the user for them to make their payment.
 
 You can refer to the [“Making payments” section](/making_payments) for more
 detailed information.


### PR DESCRIPTION
### Context

The tech docs refer to the API browser but do not refer to the Swagger file directly.

### Changes proposed in this pull request

Add references to the Swagger file. Also started to remove the [external link] text as latest style and linking guidance states that this is not needed as long as the link is descriptive.

### Guidance to review
