### PR TITLE
Custom metadata

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -69,6 +69,8 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
+To help you reconcile, you can [add custom metadata to payments](/optional_features/custom_metadata).
+
 You could also connect a customer-relationship management (CRM) or case management system to GOV.UK Pay, so your staff can issue refunds from within your system.
 
 You can read more in the [__Reporting__](/reporting) and

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -69,7 +69,7 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
-To help you reconcile, you can [add custom metadata to payments](/optional_features/custom_metadata).
+You can also [add custom metadata to payments](/optional_features/custom_metadata) if you want to reconcile payments using your own internal reference numbers.
 
 You could also connect a customer-relationship management (CRM) or case management system to GOV.UK Pay, so your staff can issue refunds from within your system.
 

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -13,9 +13,7 @@ End users cannot see metadata while they're making a payment.
 
 ## Add metadata to a payment
 
-Include a `metadata` object in the body of your <a
-href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">Create new payment</a> request. For example:
+Include a `metadata` object in the body of your [/making_payments/#making-payments](Create new payment) request. For example:
 
 ```
 "metadata": {

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -1,21 +1,21 @@
 ---
-title: Custom metadata
+title: Adding custom metadata
 weight: 135
 ---
 
-# Custom metadata
+# Adding custom metadata
 
-You can add custom metadata to a new payment. For example, you can add a reference number from your finance or accounting system, so you can reconcile the payment against bank transaction information.
+You can add custom metadata to a new payment. For example, you can add a reference number from your finance or accounting system, so you can reconcile the payment later.
 
-You can add metadata when you make an API call to create a new payment. You cannot add metadata to Direct Debit transactions or payment links.
+You add metadata when you make an API call to create a new payment. You cannot add metadata to [Direct Debit transactions](/direct_debit/#direct-debit) or [payment links](/payment_links/#payment-links).
 
 End users cannot see metadata while they're making a payment.
 
 ## Add metadata to a payment
 
-Include a `metadata` object in the body of your [Create new payment](/making_payments/#making-payments) request. For example:
+Include a `metadata` object in the body of your [Create new payment](/making_payments/#making-payments) request, for example:
 
-```
+```javascript
 "metadata": {
    "ledger_code": "AB100",
    "an_internal_reference_number": 200,
@@ -25,26 +25,27 @@ Include a `metadata` object in the body of your [Create new payment](/making_pay
 
 The `metadata` object must contain between 1 and 10 parameters.
 
-Each parameter key must be between 1 and 30 characters long.
+Each parameter key must be a unique string between 1 and 30 characters long. If a key is not unique, the API will remove all but one of the duplicate keys from the `metadata` object.
 
-Each parameter value must be both:
+The data type of each parameter value must be either a:
 
-- no longer than 50 characters
-- a string, number or boolean data type
+- string of no more than 50 characters
+- number
+- boolean
 
-Your metadata will be included in the API response.
+Parameter values can be empty.
 
-You cannot add or change the metadata after you've created the payment request.
+The API response will include your metadata.
+
+You cannot add or change metadata keys or values after you've created the payment request.
 
 Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment" target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
 
-## See a payment's metadata
+## Getting a payment's metadata
 
-When you [make an API call to get information about a payment](/reporting/#reporting-via-the-gov-uk-pay-api), the `metadata` object will be included in the API response.
+When you [get information about a single payment](/reporting/#get-information-about-a-single-payment) or [generate a list of payments](/reporting/#generate-a-list-of-payments-search-payments), the API response will include the `metadata` object.
 
 The order of the parameters in the `metadata` object may be different to your original object.
 
-You can also sign in to the [GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/login) to see or download a payment's metadata.
+You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see or download a payment's metadata.

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -13,7 +13,7 @@ End users cannot see metadata while they're making a payment.
 
 ## Add metadata to a payment
 
-Include a `metadata` object in the body of your [/making_payments/#making-payments](Create new payment) request. For example:
+Include a `metadata` object in the body of your [Create new payment](/making_payments/#making-payments) request. For example:
 
 ```
 "metadata": {

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -1,0 +1,52 @@
+---
+title: Custom metadata
+weight: 135
+---
+
+# Custom metadata
+
+You can add custom metadata to a new payment. For example, you can add a reference number from your finance or accounting system, so you can reconcile the payment against bank transaction information.
+
+You can add metadata when you make an API call to create a new payment. You cannot add metadata to Direct Debit transactions or payment links.
+
+End users cannot see metadata while they're making a payment.
+
+## Add metadata to a payment
+
+Include a `metadata` object in the body of your <a
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
+target="blank">Create new payment</a> request. For example:
+
+```
+"metadata": {
+   "ledger_code": "AB100",
+   "an_internal_reference_number": 200,
+...
+}
+```
+
+The `metadata` object must contain between 1 and 10 parameters.
+
+Each parameter key must be between 1 and 30 characters long.
+
+Each parameter value must be both:
+
+- no longer than 50 characters
+- a string, number or boolean data type
+
+Your metadata will be included in the API response.
+
+You cannot add or change the metadata after you've created the payment request.
+
+Refer to the <a
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
+target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
+
+## See a payment's metadata
+
+When you [make an API call to get information about a payment](/reporting/#reporting-via-the-gov-uk-pay-api), the `metadata` object will be included in the API response.
+
+The order of the parameters in the `metadata` object may be different to your original object.
+
+You can also sign in to the [GOV.UK Pay admin
+tool](https://selfservice.payments.service.gov.uk/login) to see or download a payment's metadata.

--- a/source/optional_features/digital_wallets/index.html.md.erb
+++ b/source/optional_features/digital_wallets/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Digital wallets
-weight: 136
+weight: 137
 ---
 
 # Digital wallets

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -15,6 +15,8 @@ GOV.UK Pay supports some optional features which need configuration:
 
 * [corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate_card_surcharges) added to payments
 
+* [adding custom metadata](/optional_features/custom_metadata) to payments
+
 * [using your own payment failure pages](/optional_features/use_your_own_error_pages) for your service
 
 * [enabling digital wallet transactions](/optional_features/digital_wallets/#digital-wallets) for your service

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use your own payment failure pages
-weight: 135
+weight: 136
 ---
 
 # Use your own payment failure pages


### PR DESCRIPTION
###  Context
Service teams can:

- add custom metadata to payments using API calls
- retrieve the metadata using API calls or the GOV.UK Pay admin tool

### Changes proposed in this pull request
Add new content about how to add and retrieve custom metadata.

### Guidance to review
Review and check if correct.