### PR TITLE
Fix link to mock card numbers

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -11,7 +11,7 @@ features. You can read more in the [__Switching to
 live__](/switching_to_live/#switching-to-live) section.
 
 When you test, you should make sure that you use [mock card
-numbers](#mock-card-numbers-for-testing) to simulate both successful
+numbers](#submit-a-test-transaction-using-mock-card-numbers) to simulate both successful
 and unsuccessful transactions. You must use test cards with your test account.
 Real card numbers will not work.
 


### PR DESCRIPTION
### Context
There's a broken link to mock card numbers in the second paragraph of https://docs.payments.service.gov.uk/testing_govuk_pay/#testing-gov-uk-pay.

### Changes proposed in this pull request
Fix the broken link.

### Guidance to review