### PR TITLE
Prefill fields on the payment page

### DIFF
--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -18,3 +18,5 @@ GOV.UK Pay supports some optional features which need configuration:
 * [using your own payment failure pages](/optional_features/use_your_own_error_pages) for your service
 
 * [enabling digital wallet transactions](/optional_features/digital_wallets/#digital-wallets) for your service
+
+* [prefill fields](/optional_features/prefill_user_details/) on the payment page

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -19,4 +19,4 @@ GOV.UK Pay supports some optional features which need configuration:
 
 * [enabling digital wallet transactions](/optional_features/digital_wallets/#digital-wallets) for your service
 
-* [prefill fields](/optional_features/prefill_user_details/) on the payment page
+* [prefilling fields](/optional_features/prefill_user_details/) on the payment page

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -1,22 +1,22 @@
 ---
-title: Prefill fields on the payment page
+title: Prefilling fields on the payment page
 weight: 137
 ---
 
-# Prefill fields on the payment page
+# Prefilling fields on the payment page
 
-If you collect a user's details in your service before you redirect them to GOV.UK Pay, you can prefill some of the fields on the __Enter card details__ page. This means users should not need to enter their details twice.
+If you collect a user's details in your service before you redirect them to GOV.UK Pay, you can prefill some of the fields on the __Enter card details__ page. If you prefill fields, users should not need to enter their details twice.
 
-Users can still edit the details before they complete their payment.
+Users can still edit these details before they complete their payment.
 
-To prefill fields, you can include the following optional parameters when you [create a new payment](/making_payments/#making-payments):
+To prefill fields, include the following optional parameters in the <a href="https://govukpay-api-browser.cloudapps.digital/#newpayment" target="blank">API request</a> when you [create a new payment](/payment_flow/#making-a-payment):
 
 - `email`
 - `prefilled_cardholder_details` - with optional `cardholder_name` and `billing_address` parameters
 
 For example:
 
-```json
+```javascript
 "email": "sherlock.holmes@example.com",
 "prefilled_cardholder_details": {
     "cardholder_name": "Sherlock Holmes",
@@ -29,7 +29,7 @@ For example:
  }
 ```
 
-All of the parameters in `billing_address` are optional.
+All the parameters in `billing_address` are optional.
 
 If you include the `country` parameter, it must be an <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'Great Britain'.
 
@@ -37,7 +37,7 @@ Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
 target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
 
-## Which data is collected
+## Data collected by your GOV.UK Pay admin account
 
 After the user completes their payment, your [GOV.UK Pay admin
 account](https://selfservice.payments.service.gov.uk/login) will collect the user's:

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -31,7 +31,7 @@ For example:
 
 All of the parameters in `billing_address` are optional.
 
-If you include the `country` parameter, it must be a valid <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field will default to 'Great Britain'.
+If you include the `country` parameter, it must be an <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'Great Britain'.
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -9,10 +9,10 @@ If you collect a user's details in your service before you redirect them to GOV.
 
 Users can still edit the details before they complete their payment.
 
-To prefill fields, include the following when you [create a new payment](/making_payments/#making-payments):
+To prefill fields, you can include the following optional parameters when you [create a new payment](/making_payments/#making-payments):
 
-- an `email` parameter
-- a `prefilled_cardholder_details` object with `cardholder_name` and `billing_address` parameters
+- `email`
+- `prefilled_cardholder_details` - with optional `cardholder_name` and `billing_address` parameters
 
 For example:
 
@@ -29,9 +29,9 @@ For example:
  }
 ```
 
-You can leave out any of the parameters.
+All of the parameters in `billing_address` are optional.
 
-The `country` parameter must be a valid <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field will default to 'GB'.
+If you include the `country` parameter, it must be a valid <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field will default to 'Great Britain'.
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -26,7 +26,7 @@ For example:
         "postcode": "NW1 6XE",
         "city": "London",
         "country": "GB"
- }
+}
 ```
 
 All the parameters in `billing_address` are optional.
@@ -46,4 +46,4 @@ account](https://selfservice.payments.service.gov.uk/login) will collect the use
 - cardholder name
 - billing address
 
-If the user does not complete their payment, your GOV.UK Pay admin account will still collect the billing address. This will happen even if you've chosen not to collect your users' billing addresses.
+If the user does not complete their payment, your GOV.UK Pay admin account will still collect the `billing_address` value. This will happen even if you've chosen not to collect your users' billing addresses.

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -44,4 +44,6 @@ account](https://selfservice.payments.service.gov.uk/login) will collect the use
 
 - email address - even if you've disabled collecting your users' email addresses
 - cardholder name
-- billing address - if you've enabled collecting your users' billing addresses
+- billing address
+
+If the user does not complete their payment, your GOV.UK Pay admin account will still collect the billing address. This will happen even if you've chosen not to collect your users' billing addresses.

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -1,0 +1,47 @@
+---
+title: Prefill fields on the payment page
+weight: 137
+---
+
+# Prefill fields on the payment page
+
+If you collect a user's details in your service before you redirect them to GOV.UK Pay, you can prefill some of the fields on the __Enter card details__ page. This means users should not need to enter their details twice.
+
+Users can still edit the details before they complete their payment.
+
+To prefill fields, include the following when you [create a new payment](/making_payments/#making-payments):
+
+- an `email` parameter
+- a `prefilled_cardholder_details` object with `cardholder_name` and `billing_address` parameters
+
+For example:
+
+```json
+"email": "sherlock.holmes@example.com",
+"prefilled_cardholder_details": {
+    "cardholder_name": "Sherlock Holmes",
+    "billing_address": {
+        "line1": "221 Baker Street",
+        "line2": "Flat b",
+        "postcode": "NW1 6XE",
+        "city": "London",
+        "country": "GB"
+ }
+```
+
+You can leave out any of the parameters.
+
+The `country` parameter must be a valid <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field will default to 'GB'.
+
+Refer to the <a
+href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
+target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
+
+## Which data is collected
+
+After the user completes their payment, your [GOV.UK Pay admin
+account](https://selfservice.payments.service.gov.uk/login) will collect the user's:
+
+- email address - even if you've disabled collecting your users' email addresses
+- cardholder name
+- billing address - if you've enabled collecting your users' billing addresses

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -120,7 +120,10 @@ they have completed their payment attempt on GOV.UK Pay. This should not be
 JSON-encoded, because backslashes are invalid characters. With test accounts,
 you can [use HTTP for return URLs instead of HTTPS](/security/#https).
 
-You can also provide the user's details if you've collected them earlier in your service, to [prefill fields on the payment page](/optional_features/prefill_user_details).
+You can [prefill the fields on the payment page](/optional_features/prefill_user_details) with the user's details if you collected that information:
+
+- earlier in your service, before you redirected your user to GOV.UK Pay
+- when your user previously used your service
 
 In the example, responses to the __Create new payment__ API call would have
 headers of the form:

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -122,7 +122,7 @@ you can [use HTTP for return URLs instead of HTTPS](/security/#https).
 
 You can [prefill the fields on the payment page](/optional_features/prefill_user_details) with the user's details if you collected that information:
 
-- earlier in your service, before you redirected your user to GOV.UK Pay
+- earlier in your service
 - when your user previously used your service
 
 In the example, responses to the __Create new payment__ API call would have

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -120,6 +120,8 @@ they have completed their payment attempt on GOV.UK Pay. This should not be
 JSON-encoded, because backslashes are invalid characters. With test accounts,
 you can [use HTTP for return URLs instead of HTTPS](/security/#https).
 
+You can also provide the user's details if you've collected them earlier in your service, to [prefill fields on the payment page](/optional_features/prefill_user_details).
+
 In the example, responses to the __Create new payment__ API call would have
 headers of the form:
 


### PR DESCRIPTION
### Context
When service teams create a payment through the API, they can provide user details that they've already collected in their service. This will then prefill fields on the payment page. 

### Changes proposed in this pull request
Add a new page about prefilling fields, and a link from the 'Payment flow' page.

### Guidance to review
Please review for factual accuracy.