### PR TITLE
Transaction fee information through API

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -21,5 +21,6 @@ dashboard](https://www.gov.uk/performance/govuk-pay).
 
 ## How much it costs
 
-There is no charge to use GOV.UK Pay. You will still need to pay your payment
-service provider’s (PSP’s) transaction fees.
+There is no charge to use GOV.UK Pay.
+
+You will still need to pay your payment service provider’s (PSP’s) transaction fees. If you use GOV.UK Pay's PSP, GOV.UK Pay will automatically deduct the transaction fee from each user payment.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -23,4 +23,4 @@ dashboard](https://www.gov.uk/performance/govuk-pay).
 
 There is no charge to use GOV.UK Pay.
 
-You will still need to pay your payment service provider’s (PSP’s) transaction fees. If you use GOV.UK Pay's PSP, GOV.UK Pay will automatically deduct the transaction fee from each payment.
+You will still need to pay your payment service provider’s (PSP’s) transaction fees. If you use GOV.UK Pay's PSP, we'll automatically deduct the transaction fee from each payment.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -23,4 +23,4 @@ dashboard](https://www.gov.uk/performance/govuk-pay).
 
 There is no charge to use GOV.UK Pay.
 
-You will still need to pay your payment service provider’s (PSP’s) transaction fees. If you use GOV.UK Pay's PSP, GOV.UK Pay will automatically deduct the transaction fee from each user payment.
+You will still need to pay your payment service provider’s (PSP’s) transaction fees. If you use GOV.UK Pay's PSP, GOV.UK Pay will automatically deduct the transaction fee from each payment.

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -53,8 +53,7 @@ for a completed £50 payment with no previous refunds:
   },
 ```
 
-The `amount_available` value includes [any corporate card
-surcharges](/optional_features/corporate_card_surcharges/#corporate-card-surcharges).
+The `amount_available` value includes any [transaction fees](/reporting/#payment-service-provider-psp-fees) or [corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate-card-surcharges).
 
 The `amount_submitted` is `0`, showing that there have been no previous refunds.
 
@@ -105,7 +104,7 @@ refund. When the accidental second request arrives, the payment has a
 ``refund_amount_available`` of £5 even though only £3 is available. GOV.UK
 Pay determines that it’s a stale request, and rejects the refund request.
 
-You must include any [corporate card
+You must include any [transaction fees](/reporting/#payment-service-provider-psp-fees) and [corporate card
 surcharges](/optional_features/corporate_card_surcharges/#corporate-card-surcharges)
 in the `refund_amount_available` value.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -93,16 +93,14 @@ have entered when making a payment:
 
 ### Payment service provider (PSP) fees
 
-If you use GOV.UK's Payment Service Provider (PSP), we'll automatically deduct the PSP's transaction fee from each user payment. You can see how much the fee was when you make the API call to get information about a payment.
+If you use GOV.UK's Payment Service Provider (PSP), we'll automatically deduct the PSP's transaction fee from each payment. You can see how much the fee was when you make the API call to get information about a payment.
 
-The JSON response body will contain for example:
+Example response:
 
-```javascript
-{
-  "total_amount": 4000,
-  "fee": 200,
-  "net_amount": 3800
-}
+```
+"total_amount": 4000,
+"fee": 200,
+"net_amount": 3800
 ```
 
 Where:
@@ -111,10 +109,10 @@ Where:
 - `fee` is the PSP transaction fee that we took from the amount the user paid, in pence
 - `net_amount` is the amount that will be paid into your account, in pence
 
-The JSON response body will not contain a `fee` or `net_amount` parameter if either:
+The response will not contain a `fee` or `net_amount` parameter if either:
 
-- your PSP is SmartPay, WorldPay or ePDQ - we don't deduct these PSPs' transaction fees
-- you're [using a test API key](/quick_start_guide/#test-the-api) - we don't deduct fees from test payments
+- your PSP is SmartPay, WorldPay or ePDQ - we do not deduct these PSPs' transaction fees
+- you're [using a test API key](/quick_start_guide/#test-the-api) - we do not deduct fees from test payments
 
 You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see or export transaction fee information.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -91,6 +91,33 @@ have entered when making a payment:
     },
 ```
 
+### Payment service provider (PSP) fees
+
+If you use GOV.UK's Payment Service Provider (PSP), we'll automatically deduct the PSP's transaction fee from each user payment. You can see how much the fee was when you make the API call to get information about a payment.
+
+The JSON response body will contain for example:
+
+```javascript
+{
+  "total_amount": 100,
+  "fee": 1.5,
+  "net_amount": 98.5
+}
+```
+
+Where:
+
+- `total_amount` is the amount the user paid in pence, including a [corporate card surcharge](/optional_features/corporate_card_surcharges/#corporate_card_surcharges) if you added one
+- `fee` is the PSP transaction fee that we took from the amount the user paid, in pence
+- `net_amount` is the amount that will be paid into your account, in pence
+
+The JSON response body will not contain a `fee` or `net_amount` parameter if either:
+
+- your PDP is SmartPay, WorldPay or ePDQ - we don't deduct these PDPs' transaction fees
+- you're [using a test API key](/quick_start_guide/#test-the-api) - we don't deduct fees from test payments
+
+You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see or export transaction fee information.
+
 ## Generate a list of payments (search payments)
 
 `GET /v1/payments`

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -99,9 +99,9 @@ The JSON response body will contain for example:
 
 ```javascript
 {
-  "total_amount": 100,
-  "fee": 1.5,
-  "net_amount": 98.5
+  "total_amount": 40,
+  "fee": 2,
+  "net_amount": 38
 }
 ```
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -99,9 +99,9 @@ The JSON response body will contain for example:
 
 ```javascript
 {
-  "total_amount": 40,
-  "fee": 2,
-  "net_amount": 38
+  "total_amount": 4000,
+  "fee": 200,
+  "net_amount": 3800
 }
 ```
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -113,7 +113,7 @@ Where:
 
 The JSON response body will not contain a `fee` or `net_amount` parameter if either:
 
-- your PDP is SmartPay, WorldPay or ePDQ - we don't deduct these PDPs' transaction fees
+- your PSP is SmartPay, WorldPay or ePDQ - we don't deduct these PSPs' transaction fees
 - you're [using a test API key](/quick_start_guide/#test-the-api) - we don't deduct fees from test payments
 
 You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see or export transaction fee information.


### PR DESCRIPTION
### Context
Service teams using GOV.UK's Payment Service Provider (PSP) can retrieve information about transaction fees using API calls or the GOV.UK Pay admin tool. 

### Changes proposed in this pull request
Add new content about how to add and retrieve transaction fee information.

### Guidance to review
Review and check if correct.