### PR TITLE
Add maximum transaction limit

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -32,23 +32,42 @@ For example:
 }
 ```
 
-`amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type rather than a string.
+### amount
 
-The minimum payment amount is one pence. The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
+`amount` is the amount in pence. In the example, the payment is for £145.
 
-`reference`: The reference number you wish to associate with this payment. The
-format is variable: if you have an existing format, you can keep using it with
-GOV.UK Pay (maximum 255 characters, and must not contain URLs). The reference
-number does not need to be unique.
+The amount must be a number data type rather than a string.
 
-`description`: A human-readable description of the payment. This will be shown to the end
-user on the payment pages and to your staff on the GOV.UK Pay admin tool
-(maximum 255 characters, and must not contain URLs).
+The minimum amount is one pence. The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
 
-`return_url`: A HTTPS URL on your site that the user will be sent back to once
-they have completed their payment attempt on GOV.UK Pay. This should not be
-JSON-encoded, because backslashes are invalid characters. With test accounts,
-you can [use HTTP for return URLs instead of HTTPS](/security/#https).
+
+### reference
+
+`reference` is the reference number you wish to associate with this payment.
+
+The reference number does not need to be unique, and must not:
+
+- be longer than 255 characters
+- contain URLs
+
+The format is variable. If you have an existing format, you can keep using it if your values are no longer than 255 characters.
+
+
+### description
+
+`description` is a human-readable description of the payment. This is shown to the end user on the payment pages and to your staff on the GOV.UK Pay admin tool.
+
+The description must be no longer than 255 characters, and must not contain URLs.
+
+
+### return_url
+
+This is a URL that your service hosts for the user to return to, after their payment journey on GOV.UK Pay ends.
+
+The URL should not be JSON-encoded, because backslashes are invalid characters in the API.
+
+If you're making a test payment using a test account, you can [use HTTP for return URLs instead of HTTPS](/security/#https).
+
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -15,16 +15,47 @@ Your service will also need to supply a
 is a URL that your service hosts for the user to return to, after their
 payment journey on GOV.UK Pay ends.
 
+## Creating a payment
+
 The call to create a payment with the GOV.UK Pay API is:
 
 `POST  /v1/payments`
 
-The minimum payment amount is one pence.
+For example:
+
+```javascript
+{
+  "amount": 14500,
+  "reference" : "12345",
+  "description": "Pay your council tax",
+  "return_url": "https://your.service.gov.uk/completed"
+}
+```
+
+`amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type rather than a string.
+
+The minimum payment amount is one pence. The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
+
+`reference`: The reference number you wish to associate with this payment. The
+format is variable: if you have an existing format, you can keep using it with
+GOV.UK Pay (maximum 255 characters, and must not contain URLs). The reference
+number does not need to be unique.
+
+`description`: A human-readable description of the payment. This will be shown to the end
+user on the payment pages and to your staff on the GOV.UK Pay admin tool
+(maximum 255 characters, and must not contain URLs).
+
+`return_url`: A HTTPS URL on your site that the user will be sent back to once
+they have completed their payment attempt on GOV.UK Pay. This should not be
+JSON-encoded, because backslashes are invalid characters. With test accounts,
+you can [use HTTP for return URLs instead of HTTPS](/security/#https).
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
 target="blank">GOV.UK Pay API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more
 information.
+
+## Receiving the API response
 
 The response to the ‘Create new payment’ API call will include the URL for the
 payment. You can get this from either:

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -97,28 +97,17 @@ For example:
 {
   "amount": 14500,
   "reference" : "12345",
-  "description": "Payment description",
+  "description": "Pay your council tax",
   "return_url": "https://your.service.gov.uk/completed"
 }
 ```
 
-`amount`: The amount in pence - in the example, the payment is for £145. This value must be a number data type rather than a string.
+Where:
 
-The minimum payment amount is one pence.
-
-`reference`: The reference number you wish to associate with this payment. The
-format is variable: if you have an existing format, you can keep using it with
-GOV.UK Pay (maximum 255 characters, and must not contain URLs). The reference
-number does not need to be unique.
-
-`description`: A human-readable description of the payment. This will be shown to the end
-user on the payment pages and to your staff on the GOV.UK Pay admin tool
-(maximum 255 characters, and must not contain URLs).
-
-`return_url`: A HTTPS URL on your site that the user will be sent back to once
-they have completed their payment attempt on GOV.UK Pay. This should not be
-JSON-encoded, because backslashes are invalid characters. With test accounts,
-you can [use HTTP for return URLs instead of HTTPS](/security/#https).
+- `amount` is the amount in pence - in the example, the payment is for £145
+- `reference` is the reference number you wish to associate with this payment
+- `description` is a human-readable description of the payment - this will be shown to the end user
+- `return_url` is a HTTPS URL on your site that the user will be sent back to once they have completed their payment attempt on GOV.UK Pay
 
 You can [prefill the fields on the payment page](/optional_features/prefill_user_details) with the user's details if you collected that information:
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -106,7 +106,7 @@ where:
 - `amount` is the amount in pence - in the example, the payment is for £145
 - `reference` is the reference number you want to associate with this payment
 - `description` is a human-readable description of the payment shown to the end user
-- `return_url` is a HTTPS URL on your site that the end user will be sent back to once they have completed their payment attempt on GOV.UK Pay
+- `return_url` is an HTTPS URL on your site that the end user will be sent back to once they have completed their payment attempt on GOV.UK Pay
 
 Read more about [making payments](/making_payments/).
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -101,12 +101,14 @@ For example:
 }
 ```
 
-Where:
+where:
 
 - `amount` is the amount in pence - in the example, the payment is for £145
-- `reference` is the reference number you wish to associate with this payment
-- `description` is a human-readable description of the payment - this will be shown to the end user
-- `return_url` is a HTTPS URL on your site that the user will be sent back to once they have completed their payment attempt on GOV.UK Pay
+- `reference` is the reference number you want to associate with this payment
+- `description` is a human-readable description of the payment shown to the end user
+- `return_url` is a HTTPS URL on your site that the end user will be sent back to once they have completed their payment attempt on GOV.UK Pay
+
+Read more about [making payments](/making_payments/).
 
 You can [prefill the fields on the payment page](/optional_features/prefill_user_details) with the user's details if you collected that information:
 


### PR DESCRIPTION
### Context
We're missing the maximum transaction limit in the documentation about making payments.

### Changes proposed in this pull request
- Add the transaction limit to documentation about creating a payment
- Move API call detail and example from the Payment flow page to the Making payments page - to avoid content duplication and better meet the user need on each page
- Quick tweak to the `description` in the examples so it's clearer this value will be shown to end users

### Guidance to review
Please review for factual accuracy.