### PR TITLE
Remove "[external link]" from external links

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -30,7 +30,7 @@ You can also generate a client library from the Swagger file using the <a href="
 ## Authentication
 
 GOV.UK Pay authenticates API calls with [OAuth2 HTTP bearer
-tokens](http://tools.ietf.org/html/rfc6750) [external link]. These are easy to
+tokens](http://tools.ietf.org/html/rfc6750). These are easy to
 use and contain only your API key.
 
 When you make an API call, you need to use an “Authorization” HTTP header to
@@ -49,7 +49,7 @@ possible outcomes, excluding for delayed capture payments:
 
 You can check the status of a payment using the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
-target="blank">Find payment by ID</a> API call [external link].
+target="blank">Find payment by ID</a> API call.
 
 A successful response includes ``status`` and ``finished`` values:
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -68,7 +68,7 @@ possession of the `next_url` could hijack the user’s payment.
 
 You can track the progress of a payment using the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
-target="blank">Find payment by ID</a> call [external link].
+target="blank">Find payment by ID</a> call.
 
 The status of the payment will pass through several states until it either
 succeeds or fails. See the [“API reference”
@@ -153,7 +153,7 @@ progress. Alternatively, a service can make the following API call for a given
 A `204` response indicates success. Any other response indicates an error.
 
 See <a href="https://govukpay-api-browser.cloudapps.digital/#cancelpayment"
-target="blank">API browser</a> [external link] for more details.
+target="blank">API browser</a> for more details.
 
 ### Find out if you can cancel a payment
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -152,8 +152,7 @@ progress. Alternatively, a service can make the following API call for a given
 
 A `204` response indicates success. Any other response indicates an error.
 
-See <a href="https://govukpay-api-browser.cloudapps.digital/#cancelpayment"
-target="blank">API browser</a> for more details.
+See the <a href="https://govukpay-api-browser.cloudapps.digital/#cancelpayment" target="blank">GOV.UK Pay API browser</a> for more details.
 
 ### Find out if you can cancel a payment
 

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -9,7 +9,7 @@ GOV.UK Pay supports the delayed capture of payments.
 
 To use this feature, include `"delayed_capture": true` in the body of a <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">Create new payment</a> request [external link].
+target="blank">Create new payment</a> request.
 
 The user experience matches the current payment flow. Once the user selects
 __Confirm__ on the __Confirm your details__ page, your service can call the

--- a/source/optional_features/digital_wallets/index.html.md.erb
+++ b/source/optional_features/digital_wallets/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 137
 
 # Digital wallets
 
-You can enable [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/) [external links] to take payments from your users.
+You can enable [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/) to take payments from your users.
 
 This is an invitation-only feature currently in private beta and is only available to services with a [live Worldpay account](/switching_to_live/set_up_a_live_worldpay_account/#set-up-a-live-worldpay-account). [Contact the GOV.UK Pay team](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) to request this feature for your service. After GOV.UK Pay has approved your request, GOV.UK Pay will email you a link to enable this feature. 
 
@@ -23,7 +23,7 @@ You get your Google Pay merchant ID from your Worldpay merchant admin interface.
 
 1. If required, speak to your Worldpay account manager to upgrade your Worldpay merchant admin interface to include Google Pay functionality.
 
-1. Sign in to your [Worldpay merchant admin interface](https://secure.worldpay.com/sso/public/auth/login.html) [external link].
+1. Sign in to your [Worldpay merchant admin interface](https://secure.worldpay.com/sso/public/auth/login.html).
 
 1. Go to __Integration__ and select the __Pay with Google__ tab.
 

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -34,7 +34,7 @@ user to the start of their payment journey.
 
 Refer to the GOV.UK Pay <a
 href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
-browser</a> [external link] for more information on using the API.
+browser</a> for more information on using the API.
 
 In very rare cases, GOV.UK Pay is unable to redirect payments. You should
 [contact us](/support_contact_and_more_information/#contact-us) if this

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -32,9 +32,9 @@ knows the [state of a payment](/payment_flow/#check-the-status-of-a-payment), it
 example if a user's payment expires, you may want your service to return the
 user to the start of their payment journey.
 
-Refer to the GOV.UK Pay <a
-href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API
-browser</a> for more information on using the API.
+See the <a
+href="https://govukpay-api-browser.cloudapps.digital/" target="blank">GOV.UK Pay API
+browser</a> for more details.
 
 In very rare cases, GOV.UK Pay is unable to redirect payments. You should
 [contact us](/support_contact_and_more_information/#contact-us) if this

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -88,8 +88,7 @@ pages to make their payment.
 In the example page, when the user selects __Continue__, the service makes a
 <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">Create new payment</a> call to the GOV.UK Pay API [external
-link]. The body of the call is returned in JSON.
+target="blank">Create new payment</a> call to the GOV.UK Pay API. The body of the call is returned in JSON.
 
 For example:
 
@@ -293,7 +292,7 @@ more details about how to match users to payments.
 
 To check the status of a payment, you must make a <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
-target="blank">Find payment by ID</a> API call [external link],
+target="blank">Find payment by ID</a> API call,
 using the `payment_id` of the payment as the parameter.
 
 The URL to do this is the same as the `self` URL provided in the response

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -93,7 +93,7 @@ to keep your API key safe.
 
 You can make test API calls to GOV.UK Pay with your test API key.
 
-You can use API testing tools such as <a href="https://www.getpostman.com/" target="_blank">Postman</a> [external link] or <a href="https://insomnia.rest/" target="_blank">Insomnia REST</a> [external link] to make test API calls.
+You can use API testing tools such as <a href="https://www.getpostman.com/" target="_blank">Postman</a> or <a href="https://insomnia.rest/" target="_blank">Insomnia REST</a> to make test API calls.
 
 This section shows an example API call and request body, to make a new payment
 for a passport application:

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -40,7 +40,7 @@ You can find out the refund status of a payment with the GOV.UK Pay API using th
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
 target="blank">Find payment by ID</a> or <a
 href="https://govukpay-api-browser.cloudapps.digital/#searchpayments"
-target="blank">Search payments</a> functions [external links].
+target="blank">Search payments</a> functions.
 
 The JSON response body will contain a `refund_summary` object. For example,
 for a completed £50 payment with no previous refunds:
@@ -65,7 +65,7 @@ be greater than the original payment.
 
 You can use the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getrefunds"
-target="blank">Get all refunds for a payment</a> [external link] API call to
+target="blank">Get all refunds for a payment</a> API call to
 get information about partial refunds.
 
 As another example, this is the JSON response body for a completed £90 payment
@@ -117,7 +117,7 @@ return an error code `P0604` with a `412` HTTP status.
 
 You can start a refund with the <a
 href="https://govukpay-api-browser.cloudapps.digital/#submitrefund"
-target="blank">Submit a refund for a payment</a> function [external link].
+target="blank">Submit a refund for a payment</a> function.
 
 You need to specify the `paymentId` of the original payment, and provide the
 amount to refund, in pence.
@@ -137,13 +137,13 @@ Each refund has a unique `refund_id`.
 
 You can use the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getrefunds"
-target="blank">Get all refunds for a payment</a> function [external link] to
+target="blank">Get all refunds for a payment</a> function to
 get information all the refunds for a payment (including their `refund_id`
 values).
 
 You can retrieve information about an individual refund using the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
-target="blank">Find payment refund by ID</a> function [external link].
+target="blank">Find payment refund by ID</a> function.
 
 A `204` response from the API indicates that a refund was successful. Any
 other response indicates an error.
@@ -154,12 +154,12 @@ When you try to create a refund with the API, it may fail immediately. For
 example, if you try to refund more than the amount available. In that case,
 the original <a
 href="https://govukpay-api-browser.cloudapps.digital/#submitrefund"
-target="blank">Submit a refund for a payment</a> request [external link] will
+target="blank">Submit a refund for a payment</a> request will
 return an error code and a description of what it means. A refund attempt
 that fails like this with an error code is not assigned a `refundId` and is
 not available using <a
 href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
-target="blank">Find payment refund by ID</a> [external link].
+target="blank">Find payment refund by ID</a>.
 
 If a refund is accepted by GOV.UK Pay, it may still go on to fail at the PSP.
 This may happen if the card involved is cancelled or has expired, or if your
@@ -195,7 +195,7 @@ go directly to `success`.
 
 To manage refunds in live environments, you must use <a
 href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
-target="blank">Find payment refund by ID</a> [external link] to
+target="blank">Find payment refund by ID</a> to
 check the processing status of the refund, until it changes to either
 `success` or `error`.
 
@@ -276,8 +276,7 @@ You can use the following query parameters to filter refunds by date:
 * `to_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [ISO
-8601](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
-[external link].  For example, a valid input would be
+8601](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).  For example, a valid input would be
 `2015-08-13T12:35:00Z`.
 
 #### Pagination

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -53,7 +53,7 @@ You can use the GOV.UK Pay API to:
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
-target="blank">API browser</a> [external link] for more information.
+target="blank">API browser</a> for more information.
 
 If the payment exists, the JSON response body to this
 API call contains a `"state"` field. You can use this information when
@@ -122,7 +122,7 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#searchpayments"
-target="blank">API browser</a> [external link] for more information.
+target="blank">API browser</a> for more information.
 
 ### Search criteria
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -51,9 +51,7 @@ You can use the GOV.UK Pay API to:
 
 `GET /v1/payments/paymentId`
 
-Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
-target="blank">API browser</a> for more information.
+See the <a href="https://govukpay-api-browser.cloudapps.digital/#getpayment" target="blank">GOV.UK Pay API browser</a> for more details
 
 If the payment exists, the JSON response body to this
 API call contains a `"state"` field. You can use this information when
@@ -120,9 +118,7 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 `GET /v1/payments`
 
-Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#searchpayments"
-target="blank">API browser</a> for more information.
+See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details
 
 ### Search criteria
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -83,7 +83,7 @@ GOV.UK Pay has implemented the Cloud Security Principles. Refer to the [National
 
 Anyone involved with the processing, transmission, or storage of cardholder
 data must comply with the [Payment Card Industry Data Security
-Standards](https://www.pcisecuritystandards.org/) (PCI DSS) [external link].
+Standards](https://www.pcisecuritystandards.org/) (PCI DSS).
 GOV.UK Pay is certified as fully compliant as a Level 1 Service Provider with
 PCI DSS version 3.2. All GOV.UK Pay partners must be compliant with PCI DSS,
 and must validate their compliance annually.
@@ -102,7 +102,7 @@ your acquiring bank
 
 If you have one MID that encompasses multiple payment channels, the compliance
 requirements will be more complex for that MID. You should check [the PCI
-DSS](https://www.pcisecuritystandards.org/) [external link] for more
+DSS](https://www.pcisecuritystandards.org/) for more
 information.
 
 ### Determine your PCI DSS compliance requirements
@@ -120,16 +120,14 @@ should be confirmed with your acquiring bank.
 
 If you process fewer than 6 million transactions per scheme per year, you may
 be able to self-assess by completing one of the [PCI DSS Self-Assessment
-Questionnaires (SAQs)](https://www.pcisecuritystandards.org/document_library)
-[external link].  This is a self-assessment tool to assess security for
+Questionnaires (SAQs)](https://www.pcisecuritystandards.org/document_library).  This is a self-assessment tool to assess security for
 cardholder data.
 
 When using GOV.UK Pay, the SAQ A questionnaire should apply. You should be
 eligible to complete the SAQ A questionnaire if you fulfil all the eligibility
 criteria and comply with SAQ A requirements 2, 8, 9 and 12. You can read [more
 about
-this](https://pcissc.secure.force.com/faq/articles/Frequently_Asked_Question/How-do-PCI-DSS-Requirements-2-and-8-apply-to-SAQ-A-merchants)
-[external link]. You can also read more detailed information on the
+this](https://pcissc.secure.force.com/faq/articles/Frequently_Asked_Question/How-do-PCI-DSS-Requirements-2-and-8-apply-to-SAQ-A-merchants). You can also read more detailed information on the
 eligibility criteria in the following table:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
@@ -153,7 +151,7 @@ Security Assessor (QSA). It may be possible to be assessed against only the
 SAQ A requirements but this should be discussed with your own PCI DSS
 compliance team and your acquiring bank. More information on this can be found
 at the [PCI Security Standards Council
-website](https://www.pcisecuritystandards.org) [external link].
+website](https://www.pcisecuritystandards.org).
 
 Your service manager may also be asked to supply extra evidence on your
 internal security protocols, and you may have to undertake security awareness


### PR DESCRIPTION
### Context
It's no longer GOV.UK style to add "[external link]" after external links in tech docs.

### Changes proposed in this pull request
Remove "[external link]" everywhere it appears.
