### PR TITLE
Add documentation about Stripe refunding and payment description

### DIFF
--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -199,7 +199,9 @@ will then:
 
 * receive a confirmation email, if you have chosen to send these using GOV.UK Pay
 
-* be redirected to your `return_url`, page which will then send the user to your payment confirmation page
+* be redirected to your `return_url` page which will then send the user to your payment confirmation page
+
+If you're using GOV.UK's Payment Service Provider (PSP), payments will show on your bank statement as 'STRIPE PAYMENTS UKGOV.UKPAY'.
 
 ### Confirmation email
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -201,7 +201,7 @@ will then:
 
 * be redirected to your `return_url` page which will then send the user to your payment confirmation page
 
-If you're using GOV.UK's Payment Service Provider (PSP), payments will show on your bank statement as 'STRIPE PAYMENTS UKGOV.UKPAY'.
+If you're using GOV.UK's PSP, payments will show on your bank statement as 'STRIPE PAYMENTS UKGOV.UKPAY'.
 
 ### Confirmation email
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -161,7 +161,7 @@ not available using <a
 href="https://govukpay-api-browser.cloudapps.digital/#getrefundbyid"
 target="blank">Find payment refund by ID</a>.
 
-If a refund is accepted by GOV.UK Pay, it may still go on to fail at the PSP.
+If a refund is accepted by GOV.UK Pay, it may still go on to fail at the payment service provider (PSP).
 This may happen if the card involved is cancelled or has expired, or if your
 account with the PSP does not have enough funds to process the refund.
 
@@ -176,6 +176,7 @@ For example, the response body for a refund would include:
 "refund_id": "j6se0f2o427g28g8yg3u3i",
 "status": "submitted",
 ...
+}
 ```
 
 In a live environment, the status returned will initially be `submitted`.
@@ -228,12 +229,17 @@ __Refund payment__ button to make a full or partial payment.
 
 ## What happens next
 
-Refunds are sent back to the source account of the original payment. You cannot refund a payment to another card or bank account.
+If the payment did not reach your bank account yet, your PSP will:
 
-If you're using GOV.UK Pay's Payment Service Provider (PSP), it will not take the refund amount from your bank account. It will either:
+- cancel the payment, if your PSP is Stripe, ePDQ or SmartPay
+- take the refund amount after the payment has reached your bank account, if your PSP is Worldpay
 
-- cancel the payment if it did not reach your bank account
-- take the refund amount from the next payment or payments you receive from any user
+If the payment has reached your bank account, your PSP will take the refund amount from:
+
+- the next payment or payments you receive from any user, if your PSP is Stripe or ePDQ
+- your bank account, if your PSP is SmartPay or Worldpay
+
+Your PSP will send refunds back to the source account of the original payment. You cannot refund a payment to another card or bank account.
 
 ### Send email notifications about refunds
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -226,16 +226,21 @@ __Refund payment__ button to make a full or partial payment.
 
 ![](/images/refund-payment-button.png)
 
-## Refund email notifications
+## What happens next
 
-You can use the GOV.UK Pay admin tool to [send email notifications to
+Refunds are sent back to the source account of the original payment.
+
+You cannot refund a payment to another card or bank account. It's the responsibility of the service to provide an alternative refund method.
+
+If you're using GOV.UK Pay's Payment Service Provider (PSP), they will not take the refund amount directly from your bank account. They'll either:
+
+- cancel the payment - if it didn't reach your bank account
+- take the refund amount from the next payment or payments you receive from any user
+
+### Refund email notifications
+
+You can use the GOV.UK Pay admin tool to turn on [sending refund email notifications to
 users](https://selfservice.payments.service.gov.uk/email-notifications).
-
-## Refund destination
-
-Refunds are sent back to the source account of the original payment. It is not
-possible to refund a payment to another card or bank account. It is the
-responsibility of the service to provide an alternative refund method.
 
 ## Search refunds with the API
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -228,16 +228,14 @@ __Refund payment__ button to make a full or partial payment.
 
 ## What happens next
 
-Refunds are sent back to the source account of the original payment.
+Refunds are sent back to the source account of the original payment. You cannot refund a payment to another card or bank account.
 
-You cannot refund a payment to another card or bank account.
+If you're using GOV.UK Pay's Payment Service Provider (PSP), it will not take the refund amount from your bank account. It will either:
 
-If you're using GOV.UK Pay's Payment Service Provider (PSP), they will not take the refund amount directly from your bank account. They'll either:
-
-- cancel the payment - if it didn't reach your bank account
+- cancel the payment if it did not reach your bank account
 - take the refund amount from the next payment or payments you receive from any user
 
-### Refund email notifications
+### Send email notifications about refunds
 
 You can use the GOV.UK Pay admin tool to turn on [sending refund email notifications to
 users](https://selfservice.payments.service.gov.uk/email-notifications).

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -230,7 +230,7 @@ __Refund payment__ button to make a full or partial payment.
 
 Refunds are sent back to the source account of the original payment.
 
-You cannot refund a payment to another card or bank account. It's the responsibility of the service to provide an alternative refund method.
+You cannot refund a payment to another card or bank account.
 
 If you're using GOV.UK Pay's Payment Service Provider (PSP), they will not take the refund amount directly from your bank account. They'll either:
 


### PR DESCRIPTION
### Context
We're missing documentation for Stripe users about:

- how payments will show on the merchant's bank account
- how refunds will be taken

### Changes proposed in this pull request
Added documentation about both of the above to the 'Payment flow' and 'Refunding payments' pages respectively.
I've also rejigged the 'Refunding payments' page to collect together 'What happens next' documentation in one section.

### Guidance to review
Please review for factual accuracy.