### PR TITLE
Fix markdown on `bearer` on Troubleshooting page

### DIFF
--- a/source/troubleshooting/index.html.md.erb
+++ b/source/troubleshooting/index.html.md.erb
@@ -38,7 +38,7 @@ Possible reasons why your call may be rejected include:
 
 **Problem**: The “Example Request” code snippets in the API documentation always cause the request to fail with a `"401 unauthorized"` error.
 
-**Fix**: You must send the API key with `"Bearer " in front of it (not including the quotation marks.) This is not made clear in the code examples due to a technical limitation.
+**Fix**: You must send the API key with `Bearer` in front of it. This is not made clear in the code examples due to a technical limitation.
 
 If the code example includes a line like this:
 


### PR DESCRIPTION
### Context
There's a stray quote mark on the Troubleshooting page because of incorrect markdown around `bearer`.

### Changes proposed in this pull request
Fix the markdown around `bearer`, and remove the mention of quote marks (as these now don't appear).

### Guidance to review