### PR TITLE
Add character limits for parameters when prefilling fields

### DIFF
--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -29,9 +29,7 @@ For example:
 }
 ```
 
-All the parameters in `billing_address` are optional.
-
-The values must be no longer than:
+All the parameters in `billing_address` are optional, and these parameters' values must be no longer than:
 
 - 254 characters for `email`
 - 255 characters for `cardholder_name`

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -31,14 +31,14 @@ For example:
 
 All the parameters in `billing_address` are optional.
 
-Each value must be no longer than:
+The values must be no longer than:
 
 - 254 characters for `email`
 - 255 characters for `cardholder_name`
-- 255 characters for `line1`, `line2` and `city` in `billing_address`
+- 255 characters each for `line1`, `line2` and `city` in `billing_address`
 - 25 characters for `postcode` in `billing_address`
 
-If you include the `country` parameter, it must be an <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'Great Britain'.
+If you include the `country` parameter, it must be an <a href="https://www.iso.org/obp/ui/#search/code/" target="blank">ISO 3166-1 Alpha-2 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'Great Britain'.
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -38,7 +38,7 @@ The values must be no longer than:
 - 255 characters each for `line1`, `line2` and `city` in `billing_address`
 - 25 characters for `postcode` in `billing_address`
 
-If you include the `country` parameter, it must be an <a href="https://www.iso.org/obp/ui/#search/code/" target="blank">ISO 3166-1 Alpha-2 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'Great Britain'.
+If you include the `country` parameter, it must be an <a href="https://www.iso.org/obp/ui/#search/code/" target="_blank">ISO 3166-1 alpha-2 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'United Kingdom'.
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#newpayment"

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -31,6 +31,13 @@ For example:
 
 All the parameters in `billing_address` are optional.
 
+Each value must be no longer than:
+
+- 254 characters for `email`
+- 255 characters for `cardholder_name`
+- 255 characters for `line1`, `line2` and `city` in `billing_address`
+- 25 characters for `postcode` in `billing_address`
+
 If you include the `country` parameter, it must be an <a href="https://www.iso.org/iso-3166-country-codes.html" target="blank">ISO 3166 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'Great Britain'.
 
 Refer to the <a


### PR DESCRIPTION
### Context
We're missing the character limits for the API request parameters in https://docs.payments.service.gov.uk/optional_features/prefill_user_details/. 

### Changes proposed in this pull request
Add the character limit for each parameter.

### Guidance to review
Please check if the changes are factually correct.