### PR TITLE
Fix Direct Debit error codes

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -168,8 +168,7 @@ Common status codes are:
 | General | P0900 | Too many requests | Your service account is sending requests above the allowed rate. Please try the request again in a few seconds. |
 | General | P0920 | Request blocked by security rules | Our firewall blocked your request. See the [“Troubleshooting”](/troubleshooting) section for details. |
 | General | P0999 | GOV.UK Pay is unavailable | The GOV.UK Pay service is temporarily down. |
-| Direct Debit | P1000 | Wrong agreement type | You can only take on-demand payments from an on-demand agreement. |
-| Direct Debit | P1001 | Invalid agreement state | You can only take on-demand payments from an agreement in `pending` or `active` states. |
+| Direct Debit | P1103 | Invalid agreement state | You can only take on-demand payments from an agreement in `pending` or `active` states. |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -168,7 +168,7 @@ Common status codes are:
 | General | P0900 | Too many requests | Your service account is sending requests above the allowed rate. Please try the request again in a few seconds. |
 | General | P0920 | Request blocked by security rules | Our firewall blocked your request. See the [“Troubleshooting”](/troubleshooting) section for details. |
 | General | P0999 | GOV.UK Pay is unavailable | The GOV.UK Pay service is temporarily down. |
-| Direct Debit | P1103 | Invalid agreement state | You can only take on-demand payments from an agreement in `pending` or `active` states. |
+| Direct Debit | P1103 | Invalid agreement state | You can only take payments from an agreement in `pending` or `active` states. |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 


### PR DESCRIPTION
### Context
The Direct Debit API error codes are incorrect on https://docs.payments.service.gov.uk/api_reference/#api-error-codes.

### Changes proposed in this pull request
Update https://docs.payments.service.gov.uk/api_reference/#api-error-codes to remove unused error message P1000, and change P1001 to P1103.

### Guidance to review
Please check factual accuracy.