### PR TITLE
Fix whitespace above tables on Direct Debit pages

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -245,7 +245,6 @@ This would return payments 501 to 1000.
 
 ## Mandate statuses
 
-<br>
 <div style = "overflow-x:auto;">
   <table style = "width:100%">
     <tr>
@@ -281,7 +280,6 @@ This would return payments 501 to 1000.
 
 ## Payment statuses
 
-<br>
 <div style = "overflow-x:auto;">
   <table style = "width:100%">
     <tr>


### PR DESCRIPTION
### Context
Quick fix to remove unnecessary whitespace above the '## Mandate statuses' and '## Payment statuses' tables on https://docs.payments.service.gov.uk/direct_debit/

### Changes proposed in this pull request
Remove the `<br>` tags above the tables to remove the whitespace.

### Guidance to review
