### PR TITLE
Add prefilling fields to the billing address section

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -172,6 +172,8 @@ You can enable or disable collecting your users’ billing addresses in your [GO
 
 This change can take up to 15 minutes to take effect.
 
+If you collect a user’s billing address in your service before you redirect them to GOV.UK Pay, you can [prefill the billing address field](/optional_features/prefill_user_details) on the __Enter card details__ page.
+
 <br>
 
 <style>


### PR DESCRIPTION
### Context
For users who are turning on/off the collection of billing addresses, it's useful to know that you can prefill fields on the payment page - as this avoids end users having to enter their billing address twice.

### Changes proposed in this pull request
Add a link from ## Collecting your users’ billing addresses to the 'Prefilling fields on the payment' 

### Guidance to review
Please check for factual accuracy.