### PR TITLE
Add 'capturable' status for delayed capture payments

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -71,7 +71,12 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> submitted </td>
-    <td> User has submitted payment details but has not yet selected <b>Confirm</b>. Or, user has selected <b>Confirm</b> and the payment is a delayed capture.</td>
+    <td> User has submitted payment details but has not yet selected <b>Confirm</b>. </td>
+    <td> false </td>
+  </tr>
+  <tr>
+    <td> capturable </td>
+    <td> The payment is a <a href="/optional_features/delayed_capture/">delayed capture</a>, and your user has submitted payment details and selected <b>Confirm</b>. </td>
     <td> false </td>
   </tr>
   <tr>

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -16,9 +16,12 @@ href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
 target="blank">Create new payment</a> request.
 
 The user experience matches the current payment flow. Once the user selects
-__Confirm__ on the __Confirm your details__ page, your service can call the
+__Confirm__ on the __Confirm your details__ page:
+
+- the [payment status](/api_reference/#payment-status-lifecycle) will change to `capturable`
+- your service can call the
 `POST /v1/payments/{paymentId}/capture` endpoint to send a delayed capture
-request.
+request
 
 Refer to the <a
 href="https://govukpay-api-browser.cloudapps.digital/#capturepayment"


### PR DESCRIPTION
### Context
We've added a `capturable` status to the get payments API, which shows that a [delayed capture](https://docs.payments.service.gov.uk/optional_features/delayed_capture/#delayed-capture) payment is ready for capture.

### Changes proposed in this pull request
Add the `capturable` status code to the API reference page and the Delayed capture pages in the documentation.

### Guidance to review
Please check if factually correct.