### PR TITLE
Add documentation about setting up a proxy

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -27,9 +27,9 @@ For more detailed information on each API action, you can:
 
 You can also generate a client library from the Swagger file using the <a href="http://editor.swagger.io/" target="blank">Swagger editor</a>. This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
-## Allow data to our API
+## Allowing traffic to our API
 
-If you're connecting to GOV.UK Pay from a secure network, you should use a web proxy like [Squid](http://www.squid-cache.org/) to only allow traffic to our base URL.
+If you're connecting to the GOV.UK Pay API from a secure network, we recommend using a web proxy like [Squid](http://www.squid-cache.org/) to allow traffic to our base URL.
 
 Do not add a whitelist of IP addresses to your firewall, because GOV.UK Pay’s IP addresses will change regularly. Read more about [why GOV.UK does not support whitelists of IP addresses](https://technology.blog.gov.uk/2017/01/03/a-whitelisting-approach-for-cloud-apis/).
 

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -27,6 +27,12 @@ For more detailed information on each API action, you can:
 
 You can also generate a client library from the Swagger file using the <a href="http://editor.swagger.io/" target="blank">Swagger editor</a>. This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
+## Allow data to our API
+
+If you're connecting to GOV.UK Pay from a secure network, you should use a web proxy like [Squid](http://www.squid-cache.org/) to only allow traffic to our base URL.
+
+Do not add a whitelist of IP addresses to your firewall, because GOV.UK Pay’s IP addresses will change regularly. Read more about [why GOV.UK does not support whitelists of IP addresses](https://technology.blog.gov.uk/2017/01/03/a-whitelisting-approach-for-cloud-apis/).
+
 ## Authentication
 
 GOV.UK Pay authenticates API calls with [OAuth2 HTTP bearer


### PR DESCRIPTION
### Context
It's recommended that teams use a web proxy to allow traffic to our API through a secure network. We do not support firewall whitelists of IP addresses (there's more on this in technology blog post about [a whitelisting approach for cloud APIs](A whitelisting approach for cloud APIs)). 

### Changes proposed in this pull request
Update https://docs.payments.service.gov.uk/api_reference/ with information about using a web proxy and avoiding firewall whitelists.

### Guidance to review
Please check if factually correct.