### PR TITLE
Remove 'From August 2019' on Direct Debit page

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 80
 
 # Direct Debit
 
-From August 2019, you can use Direct Debit if you want to take recurring payments.
+You can use Direct Debit if you want to take recurring payments.
 
 You can take payments whenever you need to. You can take the same amount or a different amount each time.
 


### PR DESCRIPTION
### Context / Changes
Remove 'From August 2019' from the Direct Debit documentation page, as we're now into August.
