### PR TITLE
Remove unneeded items from 'Merchant Channel' events list

### DIFF
--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -109,8 +109,6 @@ For __Merchant Channel Events (Production)__ and __Merchant Channel Events
 
 <br>
 
-__SIGNED_FORM_RECEIVED__
-
 __SHOPPER_REDIRECTED__
 
 __SENT_FOR_AUTHORISATION__
@@ -129,16 +127,6 @@ __SETTLED__
 
 __SETTLED_BY_MERCHANT__
 
-__CHARGED_BACK__
-
-__CHARGEBACK_REVERSED__
-
-__INFORMATION_REQUESTED__
-
-__INFORMATION_SUPPLIED__
-
-__EXPIRED__
-
 __SENT_FOR_REFUND__
 
 __REFUNDED__
@@ -150,12 +138,6 @@ __REFUSED__
 __REFUSED_BY_BANK__
 
 __REFUND_FAILED__
-
-__REVOKE_REQUESTED__
-
-__REVOKE_FAILED__
-
-__REVOKED__
 
 ## Test your configuration
 


### PR DESCRIPTION
### Context
The list of events that teams need to check when they're setting up WorldPay 'Merchant Channel' has some unneeded events.

### Changes proposed in this pull request
Update the ['Merchant Channel' events list](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_worldpay_account/#set-up-merchant-channel) to remove the events that teams no longer need to select.

### Guidance to review
Please check for factual accuracy.