### PR TITLE
Update digital wallets documentation

### DIFF
--- a/source/optional_features/digital_wallets/index.html.md.erb
+++ b/source/optional_features/digital_wallets/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 137
 
 You can enable [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/) to take payments from your users.
 
-This is an invitation-only feature currently in private beta and is only available to services with a [live Worldpay account](/switching_to_live/set_up_a_live_worldpay_account/#set-up-a-live-worldpay-account). [Contact the GOV.UK Pay team](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) to request this feature for your service. After GOV.UK Pay has approved your request, GOV.UK Pay will email you a link to enable this feature. 
+This is only available to services with a [live Worldpay account](/switching_to_live/set_up_a_live_worldpay_account/#set-up-a-live-worldpay-account).
 
 ## Enable Apple Pay
 

--- a/source/optional_features/digital_wallets/index.html.md.erb
+++ b/source/optional_features/digital_wallets/index.html.md.erb
@@ -13,7 +13,7 @@ This is an invitation-only feature currently in private beta and is only availab
 
 Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
-In your __Settings__, select the __Digital wallet__ tab in __Card types__. In the next screen, enable Apple Pay. 
+In your __Settings__, select the __Digital wallet__ tab in __Card types__. In the next screen, enable Apple Pay.
 
 ## Enable Google Pay
 
@@ -41,7 +41,7 @@ Enter the generated merchant ID and select __Submit__.
 
 Apple Pay requires users to authenticate digital wallet transactions using a secure method such as a fingerprint scan. Apple Pay users do not need to complete 3D Secure authentication separately.
 
-Google Pay supports, but does not require, users to authenticate digital wallet transactions using a secure method. Users who do not use Google Pay’s secure authentication may have to complete 3D Secure authentication separately. 
+Google Pay supports, but does not require, users to authenticate digital wallet transactions using a secure method. Users who do not use Google Pay’s secure authentication may have to complete 3D Secure authentication separately.
 
 ## Restrictions
 


### PR DESCRIPTION
### Context
The https://docs.payments.service.gov.uk/optional_features/digital_wallets/ documentation page is out of date. Teams can enable digital wallet functionality through the admin tool.

### Changes proposed in this pull request
Remove references on https://docs.payments.service.gov.uk/optional_features/digital_wallets/ to the feature being invitation-only and in private beta.

(There are also 2 tiny fixes to whitespace at the end of lines elsewhere on the page.)

### Guidance to review
Check if factually correct.