### PR TITLE
Add P1000 error to list of API error codes 

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -179,6 +179,7 @@ Common status codes are:
 | General | P0900 | Too many requests | Your service account is sending requests above the allowed rate. Please try the request again in a few seconds. |
 | General | P0920 | Request blocked by security rules | Our firewall blocked your request. See the [“Troubleshooting”](/troubleshooting) section for details. |
 | General | P0999 | GOV.UK Pay is unavailable | The GOV.UK Pay service is temporarily down. |
+| Delayed capture | P1000 | No match for `paymentId` | No payment matched the `paymentId` you provided. |
 | Direct Debit | P1200 | No match for `mandate_id` | No mandate matched the `mandate_id` you provided. |
 | Direct Debit | P1203 | Mandate not ready | You can only collect payments against a mandate if the mandate has a `status` of `pending` or `active`. |
 


### PR DESCRIPTION
### Context
We're missing the P1000 error code from our list of API error codes. It occurs when a team tries to collect a payment with a `paymentId` that we don't recognise.

### Changes proposed in this pull request
Add the P1000 error to https://docs.payments.service.gov.uk/api_reference/#api-error-codes.

### Guidance to review
Please check if factually correct.