### PR TITLE
Fix full stops on bullets in 'Manual reporting'

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -17,9 +17,9 @@ You can use your [GOV.UK Pay admin
 account](https://selfservice.payments.service.gov.uk/login) to export
 transaction information in a CSV file.
 
-1. Select the account you want reporting information for in the [My Service](https://selfservice.payments.service.gov.uk/my-services) section
+1. Select the account you want reporting information for in the [My Service](https://selfservice.payments.service.gov.uk/my-services) section.
 
-2. Go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list
+2. Go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
 
 3. Filter transactions using the available search criteria.
 


### PR DESCRIPTION
### Context
We're missing full stops at the end of the bullets in the https://docs.payments.service.gov.uk/reporting/#manual-reporting section.

### Changes proposed in this pull request
Add full stops.