### PR TITLE
Update `reference` parameter in documentation about searching for payments

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -176,13 +176,13 @@ For example:
 
 The query parameters you can use to search are:
 
-- `reference`
-- `status`
-- `bank_statement_reference`
+- `reference` - exact match only
+- `status` - exact match only
+- `bank_statement_reference` - exact match only
 - `email`
 - `name`
 
-All the parameters are case insensitive. You can search for partial values of `reference`, `email` and `name`.
+All the parameters are case insensitive.
 
 If you search for a specific mandate, all criteria you use must match. Otherwise your search will not return that mandate in the results.
 
@@ -204,7 +204,7 @@ The query parameters you can use to search are:
 - `status`
 - `mandate_id`
 
-All the parameters are case insensitive. You can search for partial values of `reference`.
+All the parameters are case insensitive but must be an exact match.
 
 If you search for a specific payment, all criteria you use must match. Otherwise your search will not return that payment in the results.
 

--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -176,13 +176,11 @@ For example:
 
 The query parameters you can use to search are:
 
-- `reference` - exact match only
-- `status` - exact match only
-- `bank_statement_reference` - exact match only
-- `email`
-- `name`
-
-All the parameters are case insensitive.
+- `reference` - case insensitive, exact match only
+- `bank_statement_reference` - case insensitive, exact match only
+- `email` - case insensitive
+- `name` - case insensitive
+- `state` - case sensitive, exact match only
 
 If you search for a specific mandate, all criteria you use must match. Otherwise your search will not return that mandate in the results.
 
@@ -200,11 +198,11 @@ For example:
 
 The query parameters you can use to search are:
 
-- `reference`
-- `status`
-- `mandate_id`
+- `reference` - case insensitive
+- `mandate_id` - case insensitive
+- `state` - case sensitive
 
-All the parameters are case insensitive but must be an exact match.
+All the parameters must be an exact match.
 
 If you search for a specific payment, all criteria you use must match. Otherwise your search will not return that payment in the results.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -149,22 +149,15 @@ An example search request:
 
 Some of the query parameters you can use to search for payments are:
 
-* `reference`
-
-* `email`
-
-* `state`
-
-* `card_brand`
-
+* `reference` - case insensitive, exact match only
+* `email` - case insensitive
+* `card_brand` - case insensitive, exact match only
+* `cardholder_name` - case insensitive
+* `state` - case sensitive, exact match only
 * `first_digits_card_number`
-
 * `last_digits_card_number`
 
-* `cardholder_name`
-
-If you search for a specific payment, all criteria you use must match.
-Otherwise, that payment will not be returned in the results.
+If you search for a specific payment, all criteria you use must match. Otherwise, that payment will not be returned in the results.
 
 If your request has no query parameters, the API will return all payments.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -154,8 +154,8 @@ Some of the query parameters you can use to search for payments are:
 * `card_brand` - case insensitive, exact match only
 * `cardholder_name` - case insensitive
 * `state` - case sensitive, exact match only
-* `first_digits_card_number`
-* `last_digits_card_number`
+* `first_digits_card_number` - exact match only
+* `last_digits_card_number` - exact match only
 
 If you search for a specific payment, all criteria you use must match. Otherwise, that payment will not be returned in the results.
 


### PR DESCRIPTION
### Context
When you search for payments by `reference` using the API, the parameter now needs to be an exact match, rather than a partial string.

### Changes proposed in this pull request
Update the Reporting and Direct Debit pages to update `reference`, and clarify as a whole which parameters are case sensitive or exact match only.

### Guidance to review
Please check if factually correct.