### PR TITLE
Improve testing documentation

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -129,7 +129,7 @@ detailed information.
 
 Go to the ``next_url`` with a browser, and you’ll see the payment screen.
 Choose a mock card number from the [__Testing GOV.UK
-Pay__](/testing_govuk_pay/#mock-card-numbers-for-testing-purposes) section and
+Pay__](/testing_govuk_pay/#mock-card-numbers) section and
 enter it to simulate a payment in the test environment. For the other required
 details, enter some test information which should have:
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -54,7 +54,7 @@ allows you to:
 * view transactions and refunds within a specified time period
 * issue full or partial refunds
 
-You'll be able to generate API keys for two different accounts. These are your:
+You'll be able to generate API keys for 2 different accounts. These are your:
 
 - test account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
 - live account, for taking payments from your users after you [switch to live](/switching_to_live)

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -50,12 +50,14 @@ in JSON format, and standard HTTP error response codes. The platform API
 allows you to:
 
 * begin and complete payments
-
 * view the event history for individual payments
-
 * view transactions and refunds within a specified time period
-
 * issue full or partial refunds
+
+You'll be able to generate API keys for two different accounts. These are your:
+
+- test account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
+- live account, for taking payments from your users after you [switch to live](/switching_to_live)
 
 When you've received a test account, follow these instructions to get started
 with our API and make a test API call.

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -168,5 +168,5 @@ clients and to provide secure connections.
 You must use HTTPS for all direct communication between your service and
 GOV.UK Pay.
 
-Return URLs for live services using GOV.UK Pay must use HTTPS, but [you can use HTTP for return
-URLs with test accounts](/testing_govuk_pay/#testing-gov-uk-pay).
+Return URLs for live services using GOV.UK Pay must use HTTPS, but you can use HTTP for return
+URLs with test accounts.

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -11,7 +11,7 @@ Please read the guidance on what to do [before you switch to live](/switching_to
 
 Follow these steps to switch your account from ‘test’ to ‘live’. You should
 only do this when you’ve finished [testing with your test
-account](/testing_govuk_pay/#testing-gov-uk-pay), and you’re confident that
+account](/testing_govuk_pay/), and you’re confident that
 [you can make payments successfully](/making_payments/#making-payments).
 
 This guidance is for services that have integrated

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -1,20 +1,20 @@
 ---
-title: Testing GOV.UK Pay
+title: Testing your integration
 weight: 90
 ---
 
 # Testing your integration
 
-### Testing your service
+## Testing your service
 
 You can use your test account to:
 
 - explore how the GOV.UK Pay API works
 - run automated [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy)
 
-Do not use your test account for automated integration tests that run every time you change your code. Build a stub of GOV.UK Pay's API instead, using a tool like [WireMock](https://github.com/WireMock-Net/WireMock.Net) or [mountebank](http://www.mbtest.org/).
+Do not use your test account for automated integration tests that run every time you change your code. Build a ‘stub’ to simulate the GOV.UK Pay API instead, using a tool like [WireMock](http://wiremock.org/) or [mountebank](http://www.mbtest.org/).
 
-### Testing the whole user journey
+## Testing the whole user journey
 
 You should test the whole user journey from your service to your payment service provider (PSP).
 
@@ -22,11 +22,11 @@ To help you test, you can:
 
 - [create a link to GOV.UK Pay payment pages](https://selfservice.payments.service.gov.uk/test-with-your-users) and add it to your service's prototype page
 - use [mock card numbers](#mock-card-numbers) to test both successful and unsuccessful payments
-- use HTTP instead of HTTPs for the `return_url` with your test account
+- use HTTP instead of HTTPs for the `return_url` with your test account, so you do not need to set up a secure url for testing
 
 ## Performance testing
 
-You must [contact us](support_contact_and_more_information) to get written approval before you do any performance testing, even if you limit the rate that you’re making API requests.
+You must [contact us](support_contact_and_more_information) to get written approval before you do any performance testing.
 
 ## Mock card numbers
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -7,17 +7,12 @@ weight: 90
 
 ### Testing your service
 
-You should:
+You can use your test account to:
 
-- run regular [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy) using your test account to check your service is always connected to GOV.UK Pay
-- build a stub of GOV.UK Pay's API, and use it to run frequent integration tests to check your service is making API requests correctly
+- explore how the GOV.UK Pay API works
+- run automated [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy)
 
-You can use a library like [WireMock](https://github.com/WireMock-Net/WireMock.Net) to build a stub of GOV.UK Pay's API.
-
-Do not use your:
-
-- test account for integration tests that run every time you change your code
-- live account for any code testing
+Do not use your test account for automated integration tests that run every time you change your code. Build a stub of GOV.UK Pay's API instead, using a tool like [WireMock](https://github.com/WireMock-Net/WireMock.Net) or [mountebank](http://www.mbtest.org/).
 
 ### Testing the whole user journey
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -26,7 +26,7 @@ To help you test, you can:
 
 ## Performance testing
 
-You must [contact us](support_contact_and_more_information) to get written approval before you do any performance testing.
+You must [contact us](/support_contact_and_more_information) to get written approval before you do any performance testing.
 
 ## Mock card numbers
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -3,105 +3,65 @@ title: Testing GOV.UK Pay
 weight: 90
 ---
 
-# Testing GOV.UK Pay
+# Testing your integration
 
-When your GOV.UK Pay account is made live, you will still have a ‘test’
-account for general testing and experimenting with different settings and
-features. You can read more in the [__Switching to
-live__](/switching_to_live/#switching-to-live) section.
+### Testing your service
 
-When you test, you should make sure that you use [mock card
-numbers](#submit-a-test-transaction-using-mock-card-numbers) to simulate both successful
-and unsuccessful transactions. You must use test cards with your test account.
-Real card numbers will not work.
+You should:
 
-You should also:
+- run regular [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy) using your test account to check your service is always connected to GOV.UK Pay
+- build a stub of GOV.UK Pay's API, and use it to run frequent integration tests to check your service is making API requests correctly
 
- * only use your test account, not your live account
+You can use a library like [WireMock](https://github.com/WireMock-Net/WireMock.Net) to build a stub of GOV.UK Pay's API.
 
- * make sure that test calls to the GOV.UK Pay API succeed with [200 codes](/api_reference/#http-status-codes)
+Do not use your:
 
- * [test the whole user journey](/#test-your-service-with-your-users) from your service to the payment service provider
+- test account for integration tests that run every time you change your code
+- live account for any code testing
 
-## HTTP with test accounts
+### Testing the whole user journey
 
-Services using test accounts can optionally use HTTP (rather than HTTPS)
-for return URLs. You can read more in [the __Security__
-section](/security/#https).
+You should test the whole user journey from your service to your payment service provider (PSP).
 
-## Make a demo payment
+To help you test, you can:
 
-You can [try the payment experience as a
-user](https://selfservice.payments.service.gov.uk/make-a-demo-payment), and
-then view the completed payment in the GOV.UK Pay [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
-
-## Test your service with your users
-
-You can [create a reusable
-link](https://selfservice.payments.service.gov.uk/test-with-your-users) to
-integrate your service prototype with GOV.UK Pay, and test with your users.
-This feature only works in test accounts, and not in live accounts.
-
-## Integration testing
-
-To check your integration with GOV.UK Pay is working as expected, you should
-run a series of tests. You can read more about [software
-testing](https://www.gov.uk/service-manual/technology#testing-your-service)
-and [smoke
-testing](https://www.gov.uk/service-manual/making-software/deployment.html) in
-the GOV.UK Service Manual.
-
-Ideally you should build tests to include both the GOV.UK Pay API and its
-frontend user journey. The GOV.UK Pay interface is continuously iterated, so
-you should not rely on any specific page layout. You can still build tests
-that address form elements such as buttons, using their IDs. Alternatively,
-you can build stubs that will emulate GOV.UK Pay functionality.
-
-You can read the section on [__How to integrate with the GOV.UK Pay
-API__](/integrate_with_govuk_pay/#how-to-integrate-with-the-gov-uk-pay-api).
-You can also read [the __Versioning__ section](/versioning/#versioning) to
-find out about the evolution of the GOV.UK Pay API.
-
-If you experience any problems when testing, please email us at
-[govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+- [create a link to GOV.UK Pay payment pages](https://selfservice.payments.service.gov.uk/test-with-your-users) and add it to your service's prototype page
+- use [mock card numbers](#mock-card-numbers) to test both successful and unsuccessful payments
+- use HTTP instead of HTTPs for the `return_url` with your test account
 
 ## Performance testing
 
-The contract you have with GOV.UK Pay requires you to seek written approval from GOV.UK Pay before you conduct any performance testing.
-If you’d like to carry out any kind of performance testing, including in a
-rate-limiting environment, please contact us at
-[govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+You must [contact us](support_contact_and_more_information) to get written approval before you do any performance testing, even if you limit the rate that you’re making API requests.
 
-## Submit a test transaction using mock card numbers
+## Mock card numbers
 
-When you test your integration with GOV.UK Pay by submitting a test transaction, you must use mock card numbers.
+Use mock card numbers with your test account when you try payments as a user.
 
-You can enter any valid value for the other required information for that test transaction. For example, card expiry dates can be any date in the future.
+You can enter any valid value for other payment fields. For example, the card expiry date can be any date in the future.
 
-The following example mock card numbers only work with a test account. If you use mock card numbers after you have [switched to a live account](/switching_to_live/#switching-to-live), your payment service provider will not authorise the payment.
+Mock card numbers do not work with your live account.
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-|Testing action |Card numbers to use | Card type | Debit/Credit |
+|Testing action |Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |
-|Simulate a successful transaction | 4444333322221111 | Visa | Credit |
+|Successful payment | 4444333322221111 | Visa | Credit |
 ||4242424242424242| Visa | Credit |
 ||4000056655665556| Visa | Debit |
-||4988080000000000| Visa | Debit Corporate |
-||4000160000000004| Visa | Debit Prepaid |
-||4131840000000003| Visa | Debit Corporate Prepaid |
-||4000620000000007| Visa | Credit Corporate |
+||4988080000000000| Visa | Debit - corporate |
+||4000160000000004| Visa | Debit - prepaid |
+||4131840000000003| Visa | Debit - corporate prepaid |
+||4000620000000007| Visa | Credit - corporate |
 ||5105105105105100| Mastercard | Debit |
 ||5200828282828210| Mastercard | Debit |
 ||371449635398431| American Express | Credit |
 ||3566002020360505| JCB | Credit |
 ||6011000990139424| Discover | Credit |
 ||36148900647913| Diners Club | Credit |
-|Simulate card type not accepted |6759649826438453|Maestro| Debit |
-|Simulate a declined card|4000000000000002|Visa| N/A |
-|Simulate an invalid CVC security code|4000000000000127|Visa| N/A |
-|Simulate an expired card|4000000000000069|Visa| N/A |
-|Simulate a general processing error|4000000000000119|Visa| N/A |
+|Card type not accepted |6759649826438453|Maestro| Debit |
+|Card declined|4000000000000002|Visa| null |
+|Card expired|4000000000000069|Visa| null |
+|Invalid CVC code|4000000000000127|Visa| null |
+|General error|4000000000000119|Visa| null |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
-


### PR DESCRIPTION
### Context
We're improving the documentation for developers testing GOV.UK Pay, to make it more user-focused and concise.

### Changes proposed in this pull request
General improvements to the content on https://docs.payments.service.gov.uk/testing_govuk_pay/, to:

- clarify integration testing and which accounts to use
- remove the mock payment section
- rename the page to 'Testing your integration' so it better reflects the content
- remove the link on the security page (as clicking through doesn't provide users with more information about using http instead of https on their test account)

### Guidance to review
Please check everything's factually accurate.