### PR TITLE
Remove release section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,3 @@ Read [the changelog for the gem][gem-changelog] for the latest changes.
 [rvm]: https://www.ruby-lang.org/en/documentation/installation/#managers
 [bundler]: http://bundler.io/
 [tdt-documentation]: https://tdt-documentation.london.cloudapps.digital
-
-# Release
-
-New versions are deployed to PaaS on master builds using Github Actions you can see how it works by looking within the `.github/workflows` directory.


### PR DESCRIPTION
### Context and changes
We need to remove the recently-added 'Release' section from the Readme, as it's about the Pay tech docs in particular - rather than downloading and using the Tech Docs Template generally.