### PR TITLE
Add link to accessibility statement

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -14,6 +14,8 @@ header_links:
   Documentation: /
   Support: https://www.payments.service.gov.uk/support/
   Sign In: https://selfservice.payments.service.gov.uk/login
+footer_links:
+  Accessibility: https://www.payments.service.gov.uk/accessibility-statement/
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: UA-72121642-9
@@ -31,4 +33,3 @@ multipage_nav: true
 collapsible_nav: true
 
 enable_search: true
-


### PR DESCRIPTION
### Context and changes proposed
Adding a link to the GOV.UK Pay accessibility statement in the footer of the technical documentation.
