### PR TITLE
Update API rate limits in documentation

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -262,11 +262,11 @@ For example:
 
 ## Rate limits
 
-You can make each of the following `POST` requests up to 15 times per second:
+Per second, you can make:
 
-- [Create a payment](/making_payments/#creating-a-payment)
-- [Capture a delayed payment](/optional_features/delayed_capture/)
-- all other `POST` requests
+- up to 15 `POST` requests to [Create a payment](/making_payments/#creating-a-payment)
+- up to 15 `POST `requests to [Capture a delayed payment](/optional_features/delayed_capture/)
+- up to 15 other `POST` requests
 
 GET requests are also rate-limited, but at a very high level. In the future,
 we will publish an official rate limit for GET requests.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -262,8 +262,11 @@ For example:
 
 ## Rate limits
 
-POST requests to the GOV.UK Pay API are rate-limited to 15 requests per
-second, for each government service.
+You can make each of the following `POST` requests up to 15 times per second:
+
+- [Create a payment](/making_payments/#creating-a-payment)
+- [Capture a delayed payment](/optional_features/delayed_capture/)
+- all other `POST` requests
 
 GET requests are also rate-limited, but at a very high level. In the future,
 we will publish an official rate limit for GET requests.


### PR DESCRIPTION
### Context
We've updated the rate limits for our API to [introduce separate 'buckets' each with their own API limit](https://github.com/alphagov/pay-publicapi/pull/701) 

### Changes proposed in this pull request
Update https://docs.payments.service.gov.uk/api_reference/#rate-limits with the new rate limits.

### Guidance to review
Please check if factually correct.