### PR TITLE
Update capture time for delayed capture payments

### DIFF
--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -40,7 +40,7 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 48 hours of the
+Your service must send the delayed capture request within 120 hours (5 days) of the
 payment creation, regardless of how long your user takes to complete the
 payment flow. Otherwise, it will expire.
 


### PR DESCRIPTION
### Context
We've changed how long you can capture a delayed payment from 2 days to 5 days.

### Changes proposed in this pull request
Update https://docs.payments.service.gov.uk/optional_features/delayed_capture/ with the new time limit.

### Guidance to review
Please check if factually correct.