### PR TITLE
Add feedback and GitHub links to each page 

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,11 @@
 require 'govuk_tech_docs'
 
+GovukTechDocs::SourceUrls.class_eval do
+  def report_issue_url
+    "mailto:govuk-pay-support@digital.cabinet-office.gov.uk?subject=Problem with GOV.UK Pay technical documentation"
+  end
+end
+
 GovukTechDocs.configure(self)
 
 redirect "payment_flow_overview/index.html", to: "payment_flow/index.html"

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -20,6 +20,10 @@ footer_links:
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: UA-72121642-9
 
+# Show a block at the bottom of the page that links to the page source, so readers can easily contribute back to the documentation.
+show_contribution_banner: true
+github_repo: alphagov/pay-tech-docs/
+
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.


### PR DESCRIPTION
### Context and changes proposed
Activate the tech docs template feature that adds 'contribution' links on each page for users to:
- see the page in our GitHub repo
- report a problem with the page

There's an example of what this looks like at the bottom of any Verify tech docs page, for example the [front page](https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation).

To do this I've:
- added the relevant flag in the tech docs config file
- added code to config.rb to rewrite the 'report a problem' link so it's a `mailto` rather than a link to create a PR (similarly to [Verify tech docs](https://github.com/alphagov/verify-tech-docs/blob/a0a205c5ebac330c7c510f62929f7d31e2f97be9/config.rb)). This is to help users who want to report feedback without using GitHub.

### Guidance to review
Please check it all looks ok.