### PR TITLE
Improve documentation about card brands

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -242,25 +242,6 @@ For example:
 }
 ```
 
-## Card types
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
-| card_brand       | type   | label            |
-|------------------|--------|------------------|
-| visa             | DEBIT  | Visa             |
-| visa             | CREDIT | Visa             |
-| master-card      | DEBIT  | Mastercard       |
-| master-card      | CREDIT | Mastercard       |
-| maestro          | DEBIT  | Maestro          |
-| american-express | CREDIT | American Express |
-| diners-club      | CREDIT | Diners Club      |
-| discover         | CREDIT | Discover         |
-| jcb              | CREDIT | JCB              |
-| unionpay         | CREDIT | Union Pay        |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
 ## Rate limits
 
 Per second, you can make:

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -156,7 +156,6 @@ Some of the query parameters you can use to search for payments are:
 
 * `reference` - case insensitive, exact match only
 * `email` - case insensitive
-* `card_brand` - case insensitive, exact match only
 * `cardholder_name` - case insensitive
 * `state` - case sensitive, exact match only
 * `first_digits_card_number` - exact match only
@@ -165,6 +164,24 @@ Some of the query parameters you can use to search for payments are:
 If you search for a specific payment, all criteria you use must match. Otherwise, that payment will not be returned in the results.
 
 If your request has no query parameters, the API will return all payments.
+
+#### Search by card brand
+
+If you search for payments by `card_brand`, the value you need to use is:
+
+- case insensitive and exact match only
+- different to the value in the API response for some card brands
+
+|`card_brand` to search for|`card_brand` in API response|
+|-|-|
+|`visa`|`Visa`|
+|`master-card`|`Mastercard`|
+|`maestro`|`Maestro`|
+|`american-express`|`AmericanExpress`|
+|`diners-club`|`DinersClub`|
+|`discover`|`Discover`|
+|`jcb`|`JCB`|
+|`unionpay`|`UnionPay`|
 
 #### Filter by date
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -167,21 +167,18 @@ If your request has no query parameters, the API will return all payments.
 
 #### Search by card brand
 
-If you search for payments by `card_brand`, the value you need to use is:
-
-- case insensitive and exact match only
-- different to the value in the API response for some card brands
-
 |`card_brand` to search for|`card_brand` in API response|
 |-|-|
 |`visa`|`Visa`|
 |`master-card`|`Mastercard`|
 |`maestro`|`Maestro`|
-|`american-express`|`AmericanExpress`|
-|`diners-club`|`DinersClub`|
+|`american-express`|`American Express`|
+|`diners-club`|`Diners Club`|
 |`discover`|`Discover`|
-|`jcb`|`JCB`|
-|`unionpay`|`UnionPay`|
+|`jcb`|`Jcb`|
+|`unionpay`|`Union Pay`|
+
+`card_brand` is case insensitive. You cannot search for partial values of `card_brand`.
 
 #### Filter by date
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -56,9 +56,9 @@ Mock card numbers do not work with your live account.
 ||6011000990139424| Discover | Credit |
 ||36148900647913| Diners Club | Credit |
 |Card type not accepted |6759649826438453|Maestro| Debit |
-|Card declined|4000000000000002|Visa| null |
-|Card expired|4000000000000069|Visa| null |
-|Invalid CVC code|4000000000000127|Visa| null |
-|General error|4000000000000119|Visa| null |
+|Card declined|4000000000000002|Visa| Credit or debit |
+|Card expired|4000000000000069|Visa| Credit or debit |
+|Invalid CVC code|4000000000000127|Visa| Credit or debit |
+|General error|4000000000000119|Visa| Credit or debit |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>


### PR DESCRIPTION
### Context
The [card types table](https://docs.payments.service.gov.uk/api_reference/#card-types) is misleading and a little confusing (and oddly placed in the API reference page), especially now we've implemented `card_type` in payment information in addition to `card_brand`.

### Changes proposed in this pull request
- Move the table out of the API reference page into the Reporting page, and include only needed information (including clarifying that the search value is different to the API response value for some card brands)
- Fix incorrect card types in the [mock card numbers table](https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers) 

### Guidance to review
Please check if factually correct.