### PR TITLE
Add character limit for return_url

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -64,7 +64,7 @@ The description must be no longer than 255 characters, and must not contain URLs
 
 This is a URL that your service hosts for your user to return to, after their payment journey on GOV.UK Pay ends.
 
-The URL should not be JSON-encoded, because backslashes are invalid characters in the API.
+The URL must be no longer than 2,000 characters, and must not be JSON-encoded because backslashes are invalid characters in the API.
 
 If you're making a test payment using a test account, you can [use HTTP for return URLs instead of HTTPS](/security/#https).
 


### PR DESCRIPTION
### Context
We're missing the character limit for the `return_url` parameter in requests to create a payment.

### Changes proposed in this pull request
Add the 2,000 character limit for the `return_url` parameter on the [Making payments](https://docs.payments.service.gov.uk/making_payments/#making-payments) page.

### Guidance to review
Please check if factually correct.