### PR TITLE
Update go live docs with new admin tool settings name

### DIFF
--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -168,7 +168,7 @@ In your [GOV.UK Pay
 
 1. Go to __My services__ and select the live service you want to set up.
 
-1. Go to __Settings__ then __Account credentials__ then __Edit credentials__.
+1. Go to __Settings__ then __Your PSP - ePDQ__ then __Edit credentials__.
 
 1. Complete the following fields:
   <br> __PSP ID__ - enter your PSP ID for ePDQ</br>
@@ -205,14 +205,13 @@ In your [GOV.UK Pay
 If you are testing your integration with a [payment link](/payment_links), you
 should open it in a separate browser tab to avoid confusion.
 
-
-
 ## Set up 3D Secure
 
 To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/). Go to __My services__ to
-select the live service you want to set up. Select __Settings__, then __3D
-Secure__ and then __turn 3D Secure on__.
+tool](https://selfservice.payments.service.gov.uk/).
+
+Go to __My services__ to select the live service you want to set up.
+Select __Settings__, then the __View__ link under __3D Secure__. Then select __On__.
 
 3D Secure should be enabled by default on the [ePDQ admin
 site](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index). To check

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -168,9 +168,9 @@ In your [GOV.UK Pay
 
 1. Go to __My services__ and select the live service you want to set up.
 
-1. Go to __Settings__ then __Your PSP - ePDQ__ then __Edit credentials__.
+1. Go to __Settings__ then __Your PSP - ePDQ__.
 
-1. Complete the following fields:
+1. Under __Account credentials__, complete the following fields:
   <br> __PSP ID__ - enter your PSP ID for ePDQ</br>
   <br> __Username__ enter the API user’s username</br>
   <br> __Password__ - enter the API user’s password</br>

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -111,9 +111,7 @@ Leave all other settings to their defaults and select __Save configuration__.
 
 ### Set up account credentials
 
-Under __Your Smartpay credentials__, select __Edit credentials__ .
-
-Complete the following fields on this page:
+Under __Account credentials__, complete the following fields:
 
 * __Merchant code__
 
@@ -125,10 +123,7 @@ Complete the following fields on this page:
 
 ### Set up notification credentials
 
-1. Under __Your Smartpay notification credentials__, select __Edit
-   notification credentials__.
-
-1. Complete the __Username__ and __Password__ fields on this page using the
+1. Under __Your Smartpay notification credentials__, complete the __Username__ and __Password__ fields using the
    username and password described in [the Authentication section](#authentication).
 
 1. Select __Save credentials__ to go back to the __Your PSP - Smartpay__ page.

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -107,7 +107,7 @@ Leave all other settings to their defaults and select __Save configuration__.
 1. Go to __My services__ and select the Smartpay live service you want to
    set up.
 
-1. Go to __Settings__ then __Account credentials__.
+1. Go to __Settings__ then __Your PSP - Smartpay__.
 
 ### Set up account credentials
 
@@ -131,7 +131,7 @@ Complete the following fields on this page:
 1. Complete the __Username__ and __Password__ fields on this page using the
    username and password described in [the Authentication section](#authentication).
 
-1. Select __Save credentials__ to go back to the __Account credentials__ page.
+1. Select __Save credentials__ to go back to the __Your PSP - Smartpay__ page.
 
 ## Test your configuration
 
@@ -167,7 +167,7 @@ To enable 3D Secure payment authentication, sign in to the [GOV.UK Pay admin
 tool](https://selfservice.payments.service.gov.uk/).
 
 Go to __My services__ to select the live service you want to set up.
-Select __Settings__, then __3D Secure__ and then __Turn on 3D Secure__.
+Select __Settings__, then the __View__ link under __3D Secure__. Then select __On__.
 
 Barclaycard is responsible for setting up 3D Secure payment authentication
 for your Smartpay account. You do not need to set anything manually.

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -45,7 +45,7 @@ should have both accounts open, in different web browser tabs.
 are prompted to choose a merchant code, select the appropriate one.
 
 1. In your GOV.UK Pay browser tab, go to __My services__ to select the live
-service you want to set up. Select __Settings__, then __Account credentials__,
+service you want to set up. Select __Settings__, then __Your PSP - Worldpay__,
 then __Edit credentials__.
 
 1. In Worldpay, copy the Worldpay __Merchant Code__ from __Identification__ into
@@ -74,7 +74,7 @@ the __Save Profile__ button at the bottom of the page)
 1. Enter the Worldpay XML password into the GOV.UK Pay __Password__ field.
 
 1. In your GOV.UK Pay browser tab, select __Save credentials__ to go back to the
-__Account credentials__ page.
+__Your PSP - Worldpay__ page.
 
 1. In your Worldpay browser tab, go to the __Profile__ page. Go to the __Payment service__
 section and set __Capture delay (days)__ to __0ff__ (not `0`).
@@ -181,6 +181,7 @@ Ask your Worldpay account manager to configure your merchant code to enable 3D
 Secure for all payments.
 
 When this is available, sign in to your [GOV.UK Pay
-account](https://selfservice.payments.service.gov.uk/login). Go to __My
-services__ to select the live service you want to set up. Select __Settings__,
-then __3D Secure__ and then select __Turn 3D Secure on__.
+account](https://selfservice.payments.service.gov.uk/login).
+
+Go to __My services__ to select the live service you want to set up.
+Select __Settings__, then the __View__ link under __3D Secure__. Then select __On__.

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -46,7 +46,7 @@ are prompted to choose a merchant code, select the appropriate one.
 
 1. In your GOV.UK Pay browser tab, go to __My services__ to select the live
 service you want to set up. Select __Settings__, then __Your PSP - Worldpay__,
-then __Edit credentials__.
+then __Change__ under __Account credentials__.
 
 1. In Worldpay, copy the Worldpay __Merchant Code__ from __Identification__ into
 the GOV.UK Pay __Merchant code__ field.


### PR DESCRIPTION
### Context
The 'Account credentials' page in the admin tool is changing to 'Your PSP'.

### Changes proposed in this pull request
Update our 'Go live' documentation with the new page name.

### Guidance to review
Please check if factually correct.