### PR TITLE
Update Direct Debit pilot details

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -13,8 +13,9 @@ You cannot automatically schedule payments. If you need to take regular payments
 
 ## Before you start
 
-To use the Direct Debit feature, you must [request a GOV.UK Pay
-Direct Debit test account](/support_contact_and_more_information/#contact-us) from our support team.
+If you’d like to set up Direct Debit, [contact us](/support_contact_and_more_information/#contact-us) to be one of our pilot partners.
+
+Direct Debit is not currently available to central government departments or the NHS. [Contact us](/support_contact_and_more_information/#contact-us) if you’d like to know more.
 
 ### Set up an account with our Direct Debit supplier
 


### PR DESCRIPTION
### Context
Clarify who can sign up for the pilot of using the Direct Debit API. This will match an update on https://www.payments.service.gov.uk/direct-debit/, and match the existing mention on that page of this being a pilot.

### Changes proposed in this pull request
Update the [Direct Debit](https://docs.payments.service.gov.uk/direct_debit/#direct-debit) page with details and how to contact us to sign up for the pilot.

### Guidance to review
Please check if factually correct.