### PR TITLE
Add 'CSV' keyword to transaction fee download docs

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -137,7 +137,7 @@ The response will not contain a `fee` or `net_amount` parameter if either:
 - your PSP is SmartPay, Worldpay or ePDQ - we do not deduct these PSPs' transaction fees
 - you're [using a test API key](/quick_start_guide/#test-the-api) - we do not deduct fees from test payments
 
-You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see or export transaction fee information.
+You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see transaction fee information or export the information in a CSV file.
 
 ## Generate a list of payments (search payments)
 


### PR DESCRIPTION
### Context
For users looking to download transaction fee information in a CSV file, it's not immediately from the content in https://docs.payments.service.gov.uk/reporting/#psp-fees that 'export' means 'export as a CSV'.

### Changes proposed in this pull request
Tweak the content to clarify that you can download as a CSV.

### Guidance to review
Please check if factually correct.