### PR TITLE
Standardise internal links

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 95
 
 # Account structure
 
-Before you read this section, you may find it useful to read the [‘Reporting’ section](/reporting/#reporting).
+You can read more about [reporting](/reporting/#reporting).
 
 GOV.UK Pay does not limit how many services you can integrate with it and how many accounts you can have with us.
 GOV.UK Pay test and live accounts are free to create and maintain but your payment service provider may charge you for the underlying accounts.
@@ -66,7 +66,7 @@ they go into a single account in the PSP.
 
 Each service defined in GOV.UK Pay has its own API key.
 
-Sign in to [the GOV.UK Pay admin
+Sign in to the [GOV.UK Pay admin
 tool](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
 page to change:
 

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -14,9 +14,7 @@ determines if actions are treated as test payments, or processed as real payment
 The API is based on REST principles. It returns data in JSON format, and uses
 standard HTTP error response codes.
 
-See the [__Quick start guide__](/quick_start_guide/#quick-start-guide) section
-to read how to get started with the API quickly. Make sure you enter your test
-API key to avoid generating real payments.
+You can [get started with the API quickly](/quick_start_guide/#quick-start-guide). Make sure you enter your test API key to avoid generating real payments.
 
 ## API browser and Swagger file
 
@@ -177,7 +175,7 @@ Common status codes are:
 | Get refunds | P0800 | `refundId` not found | No refund matched the `refundId` you provided. |
 | Get refunds | P0898 | Downstream system error | Internal error with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
 | General | P0900 | Too many requests | Your service account is sending requests above the allowed rate. Please try the request again in a few seconds. |
-| General | P0920 | Request blocked by security rules | Our firewall blocked your request. See the [“Troubleshooting”](/troubleshooting) section for details. |
+| General | P0920 | Request blocked by security rules | Our firewall blocked your request. [Check your API request](/troubleshooting/#troubleshooting). |
 | General | P0999 | GOV.UK Pay is unavailable | The GOV.UK Pay service is temporarily down. |
 | Delayed capture | P1000 | No match for `paymentId` | No payment matched the `paymentId` you provided. |
 | Delayed capture | P1003 | Payment cannot be captured | You can only capture a payment if the payment has a `status` of `capturable`. |
@@ -246,8 +244,8 @@ For example:
 
 Per second, you can make:
 
-- up to 15 `POST` requests to [Create a payment](/making_payments/#creating-a-payment)
-- up to 15 `POST `requests to [Capture a delayed payment](/optional_features/delayed_capture/)
+- up to 15 `POST` requests to [create a payment](/making_payments/#creating-a-payment)
+- up to 15 `POST `requests to [capture a delayed payment](/optional_features/delayed_capture/)
 - up to 15 other `POST` requests
 
 GET requests are also rate-limited, but at a very high level. In the future,

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -8,16 +8,13 @@ weight: 10
 Use the left-hand navigation bar to go to different sections of the
 documentation.
 
-You can also read about GOV.UK Pay on the [product
-page](https://www.payments.service.gov.uk/) and the [features
-page](https://www.payments.service.gov.uk/features).
+You can also read more about [what GOV.UK Pay offers](https://www.payments.service.gov.uk/features).
 
 Please [contact us](/support_contact_and_more_information/#contact-us) if you have any questions or feedback.
 
 ## Services using GOV.UK Pay
 
-You can see how many services are using GOV.UK Pay on [our performance
-dashboard](https://www.gov.uk/performance/govuk-pay).
+You can [see how many services are using GOV.UK Pay](https://www.gov.uk/performance/govuk-pay#number-services-heading).
 
 ## How much it costs
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -20,7 +20,7 @@ their service with the GOV.UK Pay API. It describes:
 
 * making sure that all payments are processed
 
-* integrating with finance and accounting systems (see also [__Reporting__](/reporting))
+* integrating with finance and accounting systems
 
 The following diagram shows a typical high-level architecture with a GOV.UK
 Pay integration:
@@ -38,7 +38,7 @@ Your service backend is server-side software. You should build this to:
 * redirect your user to the `next_url` provided by GOV.UK Pay, where your user
 will [enter their payment information and confirm their payment](/payment_flow/#making-a-payment)
 
-* receive your user's request when they are redirected back to your service via the `return_url`, where your user will return [after completing payment](/payment_flow/#making-a-payment)
+* receive your user's request when they are redirected back to your service via the `return_url`, where your user will return [after they complete their payment](/payment_flow/#making-a-payment)
 
 * identify your returning user via the session
 
@@ -71,8 +71,7 @@ You can also [add custom metadata to payments](/optional_features/custom_metadat
 
 You could also connect a customer-relationship management (CRM) or case management system to GOV.UK Pay, so your staff can issue refunds from within your system.
 
-You can read more in the [__Reporting__](/reporting) and
-[__Refunding payments__](/refunding_payments) sections of this documentation.
+Read more about [reporting](/reporting/#reporting) and [refunding payments](/refunding_payments/#refunding_payments).
 
 ## The GOV.UK Pay API
 
@@ -138,8 +137,7 @@ However, in the failure cases, your user will never visit the `return_url`. Inst
 
 ### Have your service team manually check the payment outcome
 
-If your team manually checks payment outcomes before releasing payments to your users, you may have a low-volume service. This
-would always be the case if you are using [payment links](/payment_links).
+If your team manually checks payment outcomes before releasing payments to your users, you may have a low-volume service. This would always be the case if you are using [payment links](/payment_links/#payment_links).
 
 You should make sure your service staff check the outcomes of payments in the GOV.UK Pay admin tool before releasing the service to your users.
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -90,8 +90,7 @@ Your service will need to store the `paymentId` (or the full URL) for each new
 payment you create. This is so you can check the status of these payments
 later.
 
-You can read more in the [“Reporting”](/reporting) and [“Payment
-flow”](/payment_flow) sections of this documentation.
+Read more about [reporting](/reporting/#reporting) and [payment flow](/payment_flow/#payment_flow).
 
 An example URL:
 `https://publicapi.payments.service.gov.uk/v1/payments/{paymentId}`

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -41,8 +41,8 @@ Colours are customised using hexadecimal representations.
 
 ## Reply-to email address
 
-When you ask GOV.UK Pay to set up custom branding on your payment confirmation emails, you should specify a reply-to email address so your users can contact you.
+When you ask GOV.UK Pay to set up custom branding on your [payment confirmation emails](/payment_flow/#confirmation-email), you should specify a reply-to email address so your users can contact you.
 
 This reply-to email address can be an email inbox for your service, or an automated response.
 
-If you do not use custom branding on your payment confirmation emails, you cannot specify a reply-to email address. Refer to the [confirmation email](/payment_flow/#confirmation-email) section of this documentation for more information.
+If you do not use custom branding on your payment confirmation emails, you cannot specify a reply-to email address.

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -13,7 +13,7 @@ Your users cannot see metadata while they're making a payment.
 
 ## Add metadata to a payment
 
-Include a `metadata` object in the body of your [Create new payment](/making_payments/#making-payments) request, for example:
+Include a `metadata` object in the body of your request to [create a new payment](/making_payments/#making-payments), for example:
 
 ```javascript
 "metadata": {

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -45,6 +45,4 @@ If your user abandons a payment and it expires, GOV.UK Pay can only redirect you
 continue their journey from the payment screen after their payment has
 expired, they will be returned to the service.
 
-You may want to read about [what happens when your user does not complete
-their payment
-journey](/making_payments/#when-a-user-does-not-complete-their-payment-journey).
+Read about [what happens when your user does not complete their payment journey](/making_payments/#when-a-user-does-not-complete-their-payment-journey).

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -12,17 +12,14 @@ You can also [create payment links in Welsh](/payment_links).
 To use Welsh, include `"language": "cy"` in the API request when you [create a new payment](/payment_flow/#making-a-payment). Your users will see Welsh text on the payment pages as they complete the [payment flow](/payment_flow).  If you do not specify a language,
 GOV.UK Pay will default to using English-language payment pages.
 
-Sign in to your [GOV.UK Pay
-account](https://selfservice.payments.service.gov.uk/login) and use the admin
-tool to add a Welsh service name to your service.
+Sign in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/login) to add a Welsh service name to your service.
 
 If you add a Welsh service name to your service, your users will see this on Welsh-language
 payment pages instead of the English service name.
 
-When your user makes a payment, they will also [see a
-`description`](/payment_flow/#making-a-payment). If you use Welsh-language
+When your user makes a payment, they will also see a
+[`description`](/payment_flow/#making-a-payment). If you use Welsh-language
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. Please [contact
-us](/support_contact_and_more_information/#contact-us) if you would like to send Welsh language emails to your users.
+GOV.UK Pay does not automatically translate emails into Welsh. Please [contact us](/support_contact_and_more_information/#contact-us) if you would like to send Welsh language emails to your users.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -282,7 +282,7 @@ the `return_url`, your service should:
 
 * display an appropriate final page, hosted by your service
 
-Read more about [matching your users to payments](https://docs.payments.service.gov.uk/making_payments/#choose-the-return-url-and-match-your-users-to-payments).
+Read more about [matching your users to payments](/making_payments/#choose-the-return-url-and-match-your-users-to-payments).
 
 To check the status of a payment, you must make a <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -282,8 +282,7 @@ the `return_url`, your service should:
 
 * display an appropriate final page, hosted by your service
 
-The [__Making payments__](/making_payments/#making-payments) section contains
-more details about how to match your users to payments.
+Read more about [matching your users to payments](https://docs.payments.service.gov.uk/making_payments/#choose-the-return-url-and-match-your-users-to-payments).
 
 To check the status of a payment, you must make a <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
@@ -315,9 +314,6 @@ The `state` array within the JSON lets you know the outcome of the payment:
 
 * `finished` indicates if the payment journey is complete or not - that is, if the `status` of this payment can change
 
-See the [__Making payments__](/making_payments/#making-payments) section for
-more information about how you can integrate your service with GOV.UK Pay.
-
 ### Resuming an incomplete payment
 
 You can send your user back to GOV.UK Pay if they return to your service before they've finished their payment.
@@ -342,5 +338,4 @@ Payments that are not confirmed and completed after 90 minutes will expire
 automatically.
 
 If the payment was authorised but incomplete, GOV.UK Pay will send a
-cancellation to the payment provider. This will raise a [P0020 API
-error](/api_reference/#api-errors-caused-by-payment-statuses).
+cancellation to the payment provider and you will receive a [P0020 API error](/api_reference/#api-errors-caused-by-payment-statuses).

--- a/source/payment_links/index.html.md.erb
+++ b/source/payment_links/index.html.md.erb
@@ -19,4 +19,4 @@ You may want to use payment links if your service:
 
 You can create payment links in English or Welsh.
 
-You can read more about payment links on [the product page](https://www.payments.service.gov.uk/payment-links/).
+Read more about [payment links](https://www.payments.service.gov.uk/payment-links/).

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -25,8 +25,7 @@ Read this section to learn about what to do to get started with GOV.UK Pay.
 
 Before you start using GOV.UK Pay, you should:
 
-* read the [__Get started__
-guide](https://www.payments.service.gov.uk/getstarted/) to decide if GOV.UK
+* read how to [get started](https://www.payments.service.gov.uk/getstarted/) and decide if GOV.UK
 Pay is right for your service
 
 * sign up to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/create-service/register)
@@ -78,8 +77,7 @@ with our API and make a test API call.
 ![](/images/DescribeAPIKey+image2.png)
 <br /><br />Your API key will be shown for you to copy:<br /><br /> ![](/images/NewKeygenerate+image+3.png)
 
-[Read the __Security__ section](/security/#security) for more information on how
-to keep your API key safe.
+Make sure you [keep your API keys safe][https://docs.payments.service.gov.uk/security/#securing-your-developer-keys).
 
 <br>
 
@@ -122,14 +120,12 @@ a JSON body.
 The JSON includes a ``next_url`` link. This URL is where your service should
 redirect your user for them to make their payment.
 
-You can refer to the [“Making payments” section](/making_payments) for more
-detailed information.
+Read more about [making payments](/making_payments#making-payments).
 
 ### Simulate your users' payment journey
 
 Go to the ``next_url`` with a browser, and you’ll see the payment screen.
-Choose a mock card number from the [__Testing GOV.UK
-Pay__](/testing_govuk_pay/#mock-card-numbers) section and
+Choose a [mock card number](/testing_govuk_pay/#mock-card-numbers) and
 enter it to simulate a payment in the test environment. For the other required
 details, enter some test information which should have:
 
@@ -141,7 +137,7 @@ Submit the payment.
 
 ### View transactions at GOV.UK Pay admin tool
 
-Go to the [GOV.UK Pay admin
+Sign in to the [GOV.UK Pay admin
 tool](https://selfservice.payments.service.gov.uk/). From the landing page,
 select __Transactions__:
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -77,7 +77,7 @@ with our API and make a test API call.
 ![](/images/DescribeAPIKey+image2.png)
 <br /><br />Your API key will be shown for you to copy:<br /><br /> ![](/images/NewKeygenerate+image+3.png)
 
-Make sure you [keep your API keys safe][https://docs.payments.service.gov.uk/security/#securing-your-developer-keys).
+Make sure you [keep your API keys safe](/security/#securing-your-developer-keys).
 
 <br>
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -68,8 +68,7 @@ To further secure your live developer keys:
 ## Securing your integration with GOV.UK Pay
 
 Make sure you’ve fully tested your integration with GOV.UK Pay. When doing so,
-take care not to use any real card numbers. Read the
-[__Testing__](/testing_govuk_pay) section for more details.
+take care not to use any real card numbers. Read more about [testing](/testing_govuk_pay/#testing-your-integration).
 
 ## Securing your users' information
 

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 160
 
 # Support
 
-You can subscribe to our public status page for updates [on the status of our
+You can subscribe to our public status page for updates on [the status of our
 system](https://payments.statuspage.io/).
 
 ## Incident severity
@@ -50,4 +50,3 @@ For all non-P1 support requests, contact us via email at
 ### General feedback
 
 If you have any feedback or questions, please email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
-


### PR DESCRIPTION
### Context
Our link text for internal links is inconsistent across our technical documentation.

### Changes proposed in this pull request
Update internal links so they're consistent, by:

- using verb-noun as far as possible when linking to guidance on doing a task
- using 'our' for links to noun-based pages such as dashboards and references, for example “Read our [API reference]”
- avoiding 'the xxx page' or 'the xxx section'
- avoiding 'refer to the...'
- avoiding 'for more information...' or 'for more details...'
- avoiding 'you may want to read...'
- removing bold
- removing links that did not actually lead to the content they claimed

I've left links in [switching to live](https://docs.payments.service.gov.uk/switching_to_live/#switching-to-live) as they are, because those will be fixed as part of https://github.com/alphagov/pay-tech-docs/pull/356.

### Guidance to review
Please check for style.