### PR TITLE
Clarify that minimum payment includes transaction fee

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -38,7 +38,9 @@ For example:
 
 The amount must be a number data type rather than a string.
 
-The minimum amount is one pence. The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
+The minimum amount is one pence plus your Payment Service Provider's (PSP's) transaction fee. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and check your contract to see your PSP's transaction fee.
+
+The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
 
 
 ### reference

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -38,10 +38,12 @@ For example:
 
 The amount must be a number data type rather than a string.
 
-The minimum amount is one pence plus your Payment Service Provider's (PSP's) transaction fee. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and check your contract to see your PSP's transaction fee.
+The minimum amount is one pence plus your Payment Service Provider's (PSP's) transaction fee. To see your PSP's transaction fee, check your contract by either:
+
+- signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) if you use Stripe
+- asking your PSP
 
 The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
-
 
 ### reference
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -186,13 +186,17 @@ user then decides whether or not to complete their payment:
 
 ![](/images/flow-payment-confirm-page.png)
 
-If your user decides to complete the payment, they select __Confirm__. They
-will then:
+If your user decides to complete the payment, they select __Confirm__. They will then:
 
 * receive a confirmation email, if you have chosen to send these using GOV.UK Pay
 * be redirected to your `return_url` page which will then send your user to your payment confirmation page
 
-You'll receive the payment in your bank account within 2 business days. It may take 3 business days if your user completed their payment after 11pm.
+You'll receive the payment in your bank account within either:
+
+- 2 business days
+- 3 business days if your user completed their payment after 11pm
+
+It may take longer if the payment is below the minimum 'payout', which is the total amount you must receive from your users before your PSP will transfer payments to you. If you're using GOV.UK's PSP, the minimum payout is £1.
 
 If you're using GOV.UK's PSP, payments will show on your bank statement as 'STRIPE PAYMENTS UKGOV.UKPAY'.
 


### PR DESCRIPTION
### Context
It's not clear from our [Creating a payment](https://docs.payments.service.gov.uk/making_payments/#creating-a-payment) documentation that the minimum payment includes the PSP transaction fee.

### Changes proposed in this pull request
Clarify that the minimum payment includes the transaction fee, and add how to find out the fee.

### Guidance to review
Please check if factually correct.