### PR TITLE
Clarify delayed capture statuses and error codes

### DIFF
--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -40,7 +40,7 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. Otherwise [the payment will expire](https://docs.payments.service.gov.uk/payment_flow/#resuming-an-incomplete-payment).
+Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. Otherwise [the payment will expire](/payment_flow/#payment-expires).
 
 If your service has enabled payment receipt emails, GOV.UK Pay will send a
 payment receipt email to your user once your service’s capture request is

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -31,18 +31,16 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-| Response Code  | Meaning                    |
-| -------------- | -------------------------- |
-|204             | Capture request accepted   |
-|404             | `paymentId` does not exist |
-|409             | Capture request rejected   |
-|500             | Downstream error           |
+|Response code | Meaning |
+|--|--|
+|204| Your capture request was accepted. |
+|404| No payment matched the `paymentId` you provided. |
+|409| The payment cannot be captured because its `status` is not `capturable`. |
+|500| Something is wrong with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us). |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 120 hours (5 days) of the
-payment creation, regardless of how long your user takes to complete the
-payment flow. Otherwise, it will expire.
+Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. Otherwise the payment will expire. An expired payment has a `status` of `failed` and returns a [P0020 API error](/api_reference/#api-error-codes).
 
 If your service has enabled payment receipt emails, GOV.UK Pay will send a
 payment receipt email to your user once your service’s capture request is

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -40,7 +40,7 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. Otherwise the payment will expire. An expired payment has a `status` of `failed` and returns a [P0020 API error](/api_reference/#api-error-codes).
+Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. Otherwise [the payment will expire](https://docs.payments.service.gov.uk/payment_flow/#resuming-an-incomplete-payment).
 
 If your service has enabled payment receipt emails, GOV.UK Pay will send a
 payment receipt email to your user once your service’s capture request is

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -33,9 +33,9 @@ There are 4 possible responses:
 
 |Response code | Meaning |
 |--|--|
-|204| Your capture request was accepted. |
+|204| Your capture request succeeded. |
 |404| No payment matched the `paymentId` you provided. |
-|409| The payment cannot be captured because its `status` is not `capturable`. |
+|409| You cannot capture the payment because its `status` is not `capturable`. |
 |500| Something is wrong with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us). |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -40,7 +40,7 @@ There are 4 possible responses:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. Otherwise [the payment will expire](/payment_flow/#payment-expires).
+Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. If you do not, [the payment will expire](/payment_flow/#payment-expires).
 
 If your service has enabled payment receipt emails, GOV.UK Pay will send a
 payment receipt email to your user once your service’s capture request is

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -337,4 +337,4 @@ You cannot resume a payment if the `status` is `failed`, `cancelled` or `error`.
 Payments that are not confirmed and completed after 90 minutes will expire
 automatically.
 
-If the payment was authorised but incomplete, GOV.UK Pay will send a cancellation to the payment provider. If you [check the status of the payment](/reporting/#get-information-about-a-single-payment), its `status` will be `failed` and you'll receive a [P0020 API error](/api_reference/#api-error-codes).
+If your PSP authorised the payment but your user did not finish paying, GOV.UK Pay will send a cancellation to the payment provider. If you [check the status of the payment](/reporting/#get-information-about-a-single-payment), its `status` will be `failed` and you'll receive a [P0020 API error](/api_reference/#api-error-codes).

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -337,4 +337,4 @@ You cannot resume a payment if the `status` is `failed`, `cancelled` or `error`.
 Payments that are not confirmed and completed after 90 minutes will expire
 automatically.
 
-If the payment was authorised but incomplete, GOV.UK Pay will send a cancellation to the payment provider and you will receive a [P0020 API error](/api_reference/#api-error-codes).
+If the payment was authorised but incomplete, GOV.UK Pay will send a cancellation to the payment provider. If you [check the status of the payment](/reporting/#get-information-about-a-single-payment), its `status` will be `failed` and you'll receive a [P0020 API error](/api_reference/#api-error-codes).


### PR DESCRIPTION
### Context
The status codes in our [Delayed capture] docs are misleading or ambiguous. We also don't say what status a payment will have if the capture times out.

### Changes proposed in this pull request
- Clarify the codes in the error codes table, and make them consistent with the descriptions in the [API reference](https://docs.payments.service.gov.uk/api_reference/#api-reference) page.
- Add the status for expired payments

### Guidance to review
Please check if factually correct.