### PR TITLE
PP-5897 Remove Google Analytics Tech Docs

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -18,7 +18,7 @@ footer_links:
   Accessibility: https://www.payments.service.gov.uk/accessibility-statement/
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-72121642-9
+# Removed GA Tracking ID because of ICO compliance. Re-enable when opt-in is enabled ga_tracking_id: UA-72121642-9
 
 # Show a block at the bottom of the page that links to the page source, so readers can easily contribute back to the documentation.
 show_contribution_banner: true


### PR DESCRIPTION
Description:
- Due to ICO compliance we can't store non-essential cookies so as a temporary measure Google Analytics has been disabled. Re-enable when opt-in has been completed.