### PR TITLE
Add guidance on changing bank statement description

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -67,7 +67,10 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
-You can also [add custom metadata to payments](/optional_features/custom_metadata) if you want to reconcile payments using your own internal reference numbers.
+To help you reconcile payments, you can:
+
+- [add custom metadata to payments](/optional_features/custom_metadata)
+- [contact us](/support_contact_and_more_information/#support) to change what appears on your bank statement - if you use Stripe
 
 You could also connect a customer-relationship management (CRM) or case management system to GOV.UK Pay, so your staff can issue refunds from within your system.
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -194,8 +194,6 @@ will then:
 
 You'll receive the payment in your bank account within 2 business days. It may take 3 business days if your user completed their payment after 11pm.
 
-If you're using GOV.UK's PSP, payments will show on your bank statement as 'STRIPE PAYMENTS UKGOV.UKPAY'.
-
 ### Confirmation email
 
 If you have set up confirmation emails, your user will receive a payment


### PR DESCRIPTION
### Context
Teams can now ask us to change what appears on their bank statements if they use Stripe.

### Changes proposed in this pull request
Add that teams can ask us to change their bank statement description - and move the content to the Integrating page, as it's most related to the need of reconciling payments.

### Guidance to review
Please check if factually accurate.