### PR TITLE
Clarify requesting Welsh emails

### DIFF
--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -22,4 +22,6 @@ When your user makes a payment, they will also see a
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. [Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop this feature.
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by signing in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/login).
+
+[Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop a feature to automatically translate emails into Welsh.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -22,6 +22,6 @@ When your user makes a payment, they will also see a
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by signing in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/login).
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by signing in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/email-notifications).
 
 [Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop a feature to automatically translate emails into Welsh.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -22,6 +22,6 @@ When your user makes a payment, they will also see a
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by signing in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/email-notifications).
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by signing in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/settings/).
 
 [Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop a feature to automatically translate emails into Welsh.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -22,4 +22,4 @@ When your user makes a payment, they will also see a
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. Please [contact us](/support_contact_and_more_information/#contact-us) if you would like to send Welsh language emails to your users.
+GOV.UK Pay does not automatically translate emails into Welsh. [Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop this feature.


### PR DESCRIPTION
### Context
Our [Welsh language payment pages](https://docs.payments.service.gov.uk/optional_features/welsh_language/#welsh-language-payment-pages) page suggests we can send Welsh-language emails, which is incorrect.

### Changes proposed in this pull request
Tweak content to clarify that teams can contact us if they'd like us to develop this feature in future.

### Guidance to review
Please check if factually correct.