### PR TITLE
bau: Use latest version of bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,4 +213,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.17.2
+  2.1.3 


### PR DESCRIPTION
Upgrading as the deploy job is failing with

```
Fetching bundler-2.1.3.gem
Successfully installed bundler-2.1.3
1 gem installed
Traceback (most recent call last):
	2: from /usr/local/bundle/bin/bundle:23:in `<main>'
	1: from /usr/local/lib/ruby/2.7.0/rubygems.rb:294:in `activate_bin_path'
/usr/local/lib/ruby/2.7.0/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.17.2) required by your /tmp/build/80754af9/pay-tech-docs/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.2`
```

### Context


### Changes proposed in this pull request


### Guidance to review
