### PR TITLE
Remove link checking from build

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -9,32 +9,4 @@ end
 
 GovukTechDocs.configure(self)
 
-after_build do |builder|
-  begin
-    HTMLProofer.check_directory(config[:build_dir],
-      { :assume_extension => true,
-        :disable_external => true,
-        :allow_hash_href => true,
-        :url_ignore => [
-          /.+-authentication/,
-          /.+-before-you-start/,
-          /.+-filtering-by-date/,
-          /.+-set-up-3d-secure/,
-          /.+-splitting-results-into-pages/,
-          /.+-copy-your-details-into-your-gov-uk-pay-account/,
-          /.+-set-up-notification-settings/,
-          /.+-test-your-configuration/,
-          /.+-set-up-an-api-user/,
-          /.+-the-gov-uk-pay-api/,
-          /.+creating-a-refund-amount/,
-          /.+creating-a-payment-amount/,
-          /.+before-you-switch-to-live-support/,
-          /.+support-2/
-        ],
-        :url_swap => { "https://docs.payments.service.gov.uk/" => "" } }).run
-  rescue RuntimeError => e
-    abort e.to_s
-  end
-end
-
 redirect "payment_flow_overview/index.html", to: "payment_flow/index.html"


### PR DESCRIPTION
### Context
We're having deployment issues with the documentation since we deployed https://github.com/alphagov/pay-tech-docs/pull/353 to add html-proofer.

### Changes proposed in this pull request
Remove html-proofer from the build in `config.rb` for now, so we can restart deployment. We'll then investigate how to re-add html-proofer in a way that doesn't block deployments unexpectedly. 

### Guidance to review
Please check code updates are ok.