### PR TITLE
Add documentation about checking account settings during go-live

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -31,7 +31,7 @@ You'll need to tell us:
 - your organisation's name and address
 - if you’ll be using GOV.UK Pay’s PSP Stripe, or another PSP
 
-Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/) and select __Request a live account__.
+Select your test account from the [__My services__](https://selfservice.payments.service.gov.uk/my-services) page in the GOV.UK Pay admin tool, then select __Request a live account__.
 
 We'll respond within one working day, and we can usually activate your live account on the same day.
 
@@ -63,7 +63,17 @@ If you use Worldpay and you want to accept American Express cards, you must cont
 
 You must send your American Express merchant ID to Government Banking or Worldpay if you’re a non-Crown merchant.
 
-## 4. Check your live account works
+## 4. Check your settings match your test account
+
+You need to make the following changes to your live account if you made them to your test account:
+
+- add a custom paragraph to payment confirmation emails
+- switch off sending payment confirmation emails
+- switch off collecting your users' billing addresses
+- switch on sending refund confirmation emails
+- add payment links
+
+## 5. Check your live account works
 
 1. Select your live account from the [__My services__ page](https://selfservice.payments.service.gov.uk/my-services) in the GOV.UK Pay admin tool.
 


### PR DESCRIPTION
### Context
When users create a live account from a test account, certain settings will not be carried over.

### Changes proposed in this pull request
Add a new step to the [go live docs](https://docs.payments.service.gov.uk/switching_to_live/) about switching on/off the same settings in your live account as in your test account.

### Guidance to review
Please check if factually correct.