### PR TITLE
Add missing link from optional features to blocking prepaid cards

### DIFF
--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -22,3 +22,5 @@ GOV.UK Pay supports some optional features which need configuration:
 * [enabling digital wallet transactions](/optional_features/digital_wallets/#digital-wallets) for your service
 
 * [prefilling fields](/optional_features/prefill_user_details/) on the payment page
+
+* [blocking prepaid cards](/optional_features/block_prepaid_cards/#block-prepaid-cards)


### PR DESCRIPTION
### Context
The [optional features](https://docs.payments.service.gov.uk/optional_features/#optional-features) pages is missing a link to blocking prepaid cards. 

### Changes proposed in this pull request
Add the link.

### Guidance to review
Please check the link works.