### PR TITLE
Increase maximum CSV export rows

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -28,7 +28,7 @@ transaction information in a CSV file.
 The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page. You can process CSV files using
 spreadsheet software and edit the contents you do not need.
 
-You cannot download CSV for more than 100,000 transactions.
+You can export up to 100,000 transactions in a CSV file.
 
 ## Reporting via the GOV.UK Pay API
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -28,7 +28,7 @@ transaction information in a CSV file.
 The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page. You can process CSV files using
 spreadsheet software and edit the contents you do not need.
 
-You cannot download CSV for more than 10,000 transactions.
+You cannot download CSV for more than 100,000 transactions.
 
 ## Reporting via the GOV.UK Pay API
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -28,7 +28,7 @@ transaction information in a CSV file.
 The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page. You can process CSV files using
 spreadsheet software and edit the contents you do not need.
 
-You can export up to 100,000 transactions in a CSV file.
+You can export up to 100,000 transactions.
 
 ## Reporting via the GOV.UK Pay API
 


### PR DESCRIPTION
### Context
The number of transactions teams can export in a CSV file has increased.

### Changes proposed in this pull request
Update the maximum value from 10,000 to 100,000.

### Guidance to review
Please check if factually correct.