### PR TITLE
Fix incorrect table markdown in card brands table

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -167,8 +167,9 @@ If your request has no query parameters, the API will return all payments.
 
 #### Search by card brand
 
+
 |`card_brand` to search for|`card_brand` in API response|
-|-|-|
+|---|---|
 |`visa`|`Visa`|
 |`master-card`|`Mastercard`|
 |`maestro`|`Maestro`|


### PR DESCRIPTION
### Context
The [search by card brand table](https://docs.payments.service.gov.uk/reporting/#search-by-card-brand) is displaying incorrectly because of a markdown error.

### Changes proposed in this pull request
Fix the table markdown.