### PR TITLE
Add MOTO payments documentation

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -150,7 +150,7 @@ Common status codes are:
 |--------------|------------|---------|-------|
 | Create payment | P0101 | Missing mandatory attribute | The request you sent is missing a required attribute. |
 | Create payment | P0102 | Invalid attribute value | The value of an attribute you sent is invalid. |
-| Create payment | P0196 | MOTO payments not allowed | Contact us about [setting up your service for Mail Order Telephone Order (MOTO) payments](/optional_features/moto_payments/).|
+| Create payment | P0196 | MOTO payments not allowed | Contact us about [setting up your service for Mail Order / Telephone Order (MOTO) payments](/optional_features/moto_payments/).|
 | Create payment | P0197 | Unable to parse JSON | The JSON you sent in the request body is invalid.|
 | Create payment | P0198 | Downstream system error | Internal error with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
 | Create payment | P0199 | Account error | There is a problem with your service account. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -150,7 +150,7 @@ Common status codes are:
 |--------------|------------|---------|-------|
 | Create payment | P0101 | Missing mandatory attribute | The request you sent is missing a required attribute. |
 | Create payment | P0102 | Invalid attribute value | The value of an attribute you sent is invalid. |
-| Create payment | P0197 | Unable to parse JSON | The JSON you sent in the request body is invalid. |
+| Create payment | P0197 | Unable to parse JSON | The JSON you sent in the request body is invalid. Check the JSON in your request body, or [contact us about Mail Order Telephone Order (MOTO) payments](/optional_features/moto_payments/) if you've used `moto: true` in your request.|
 | Create payment | P0198 | Downstream system error | Internal error with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
 | Create payment | P0199 | Account error | There is a problem with your service account. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
 | Find payment by ID | P0200 | `paymentId` not found | No payment matched the `paymentId` you provided. |

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -150,7 +150,8 @@ Common status codes are:
 |--------------|------------|---------|-------|
 | Create payment | P0101 | Missing mandatory attribute | The request you sent is missing a required attribute. |
 | Create payment | P0102 | Invalid attribute value | The value of an attribute you sent is invalid. |
-| Create payment | P0197 | Unable to parse JSON | The JSON you sent in the request body is invalid. Check the JSON in your request body, or [contact us about Mail Order Telephone Order (MOTO) payments](/optional_features/moto_payments/) if you've used `moto: true` in your request.|
+| Create payment | P0196 | MOTO payments not allowed | Contact us about [setting up your service for Mail Order Telephone Order (MOTO) payments](/optional_features/moto_payments/).|
+| Create payment | P0197 | Unable to parse JSON | The JSON you sent in the request body is invalid.|
 | Create payment | P0198 | Downstream system error | Internal error with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
 | Create payment | P0199 | Account error | There is a problem with your service account. Please [contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
 | Find payment by ID | P0200 | `paymentId` not found | No payment matched the `paymentId` you provided. |

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -14,6 +14,6 @@ You can use the following optional features with GOV.UK Pay:
 * [delay capturing payments](/optional_features/delayed_capture/#delayed-capture-of-payments)
 * [enable Apple Pay and Google Pay](/optional_features/digital_wallets/#digital-wallets)
 * [prefill fields](/optional_features/prefill_user_details/) on the **Enter card details** page
-* [take payments over the phone ('MOTO' payments)](/optional_features/moto_payments)
+* [take Mail Order Telephone Order (MOTO) payments](/optional_features/moto_payments)
 * [use your own payment failure pages](/optional_features/use_your_own_error_pages)
 * [use Welsh](/optional_features/welsh_language/#welsh-language-payment-pages) on payment pages

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -5,22 +5,15 @@ weight: 130
 
 # Optional features
 
-GOV.UK Pay supports some optional features which need configuration:
+You can use the following optional features with GOV.UK Pay:
 
-* [custom branding](/optional_features/custom_branding/#custom-branding-of-payment-pages) of payment pages
-
-* [Welsh language](/optional_features/welsh_language/#welsh-language-payment-pages) of payment pages
-
-* [delayed capture](/optional_features/delayed_capture/#delayed-capture-of-payments) of payments
-
-* [corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate-card-surcharges) added to payments
-
-* [adding custom metadata](/optional_features/custom_metadata) to payments
-
-* [using your own payment failure pages](/optional_features/use_your_own_error_pages) for your service
-
-* [enabling digital wallet transactions](/optional_features/digital_wallets/#digital-wallets) for your service
-
-* [prefilling fields](/optional_features/prefill_user_details/) on the payment page
-
-* [blocking prepaid cards](/optional_features/block_prepaid_cards/#block-prepaid-cards)
+* [add corporate card surcharges](/optional_features/corporate_card_surcharges/#corporate-card-surcharges) to payments
+* [add custom branding](/optional_features/custom_branding/#custom-branding-of-payment-pages) to payment pages
+* [add custom metadata](/optional_features/custom_metadata) to payments
+* [block prepaid cards](/optional_features/block_prepaid_cards/#block-prepaid-cards)
+* [delay capturing payments](/optional_features/delayed_capture/#delayed-capture-of-payments)
+* [enable Apple Pay and Google Pay](/optional_features/digital_wallets/#digital-wallets)
+* [prefill fields](/optional_features/prefill_user_details/) on the **Enter card details** page
+* [take payments over the phone ('MOTO' payments)](/optional_features/moto_payments)
+* [use your own payment failure pages](/optional_features/use_your_own_error_pages)
+* [use Welsh](/optional_features/welsh_language/#welsh-language-payment-pages) on payment pages

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -1,0 +1,44 @@
+---
+title: Take payments over the phone ('MOTO' payments)
+weight: 200
+---
+
+# Take payments over the phone (‘MOTO’ payments)
+
+We can set up your service so you can fill in GOV.UK Pay payment pages with your users’ details.
+
+This means you can take payments:
+
+- over the phone
+- by post
+
+These payments are also known as Mail Order Telephone Order (MOTO) payments.
+
+After we set up your service, you'll no longer be able to create payments where users fill in their details themselves. [Create a separate service](https://selfservice.payments.service.gov.uk/my-services/create) if you need to do this.
+
+You cannot take MOTO payments if your payment service provider (PSP) is SmartPay.
+
+## Set up your account
+
+[Contact us](/support_contact_and_more_information/#general-feedback) and we’ll:
+
+- review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
+- enable MOTO payments in your service
+
+## Creating MOTO payments
+
+To complete a MOTO payment, you must collect the following from your user:
+
+- card number
+- card expiry date
+- card security code
+- name from their card
+- email address - if you’ve [enabled collecting your users’ email addresses](/integrate_with_govuk_pay/#collecting-your-users-39-billing-addresses)
+
+1. [Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API, and include `moto: true` in the request body.
+
+2. Go to the `next_url` included in the body of the response to your API call.
+
+3. Fill in your user’s information on the **Enter card details** page.
+
+4. Confirm the payment on the **Confirm your payment** page.

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 200
 
 # Take payments over the phone (‘MOTO’ payments)
 
-We can set up your service so you can fill in GOV.UK Pay payment pages with your users’ details.
+We can set up your GOV.UK Pay account so you can fill in GOV.UK Pay payment pages with your users’ details.
 
 This means you can take payments:
 
@@ -14,8 +14,6 @@ This means you can take payments:
 
 These payments are also known as Mail Order Telephone Order (MOTO) payments.
 
-After we set up your service, you'll no longer be able to create payments where users fill in their details themselves. [Create a separate service](https://selfservice.payments.service.gov.uk/my-services/create) if you need to do this.
-
 You cannot take MOTO payments if your payment service provider (PSP) is SmartPay.
 
 ## Set up your account
@@ -23,11 +21,11 @@ You cannot take MOTO payments if your payment service provider (PSP) is SmartPay
 [Contact us](/support_contact_and_more_information/#general-feedback) and we’ll:
 
 - review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
-- enable MOTO payments in your service
+- enable MOTO payments in your account
 
-## Creating MOTO payments
+## Create a MOTO payment
 
-To complete a MOTO payment, you must collect the following from your user:
+Make sure you've collected your user's:
 
 - card number
 - card expiry date
@@ -35,10 +33,25 @@ To complete a MOTO payment, you must collect the following from your user:
 - name from their card
 - email address - if you’ve [enabled collecting your users’ email addresses](/integrate_with_govuk_pay/#collecting-your-users-39-billing-addresses)
 
-1. [Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API, and include `moto: true` in the request body.
+Do the following to create and complete the MOTO payment.
 
-2. Go to the `next_url` included in the body of the response to your API call.
+1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO account in [your services](https://selfservice.payments.service.gov.uk/my-services).
 
-3. Fill in your user’s information on the **Enter card details** page.
+2. [Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API, and include `moto: true` in the request body.
 
-4. Confirm the payment on the **Confirm your payment** page.
+3. Go to the `next_url` included in the body of the response to your API call.
+
+4. Fill in your user’s information on the **Enter card details** page.
+
+    The **Enter Card Details** page will not have a billing address field, even if you've enabled collecting billing addresses.
+
+5. Confirm the payment on the **Confirm your payment** page.
+
+    You will not need to do a 3D Secure confirmation.
+
+## Create an online payment
+
+To create a payment where your user fills in their details themselves, [create a payment](/making_payments/#making-payments) with the GOV.UK Pay API using:
+
+- `moto: false` in the request body
+- an API key from your normal account in [your services](https://selfservice.payments.service.gov.uk/my-services), if your PSP is Worldpay or ePDQ

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -12,13 +12,13 @@ This means you can take payments:
 - over the phone
 - by post
 
-These payments are also known as Mail Order Telephone Order (MOTO) payments.
+These payments are also known as Mail Order / Telephone Order (MOTO) payments.
 
 You cannot take MOTO payments if your payment service provider (PSP) is SmartPay.
 
 ## Set up your account
 
-[Contact us](/support_contact_and_more_information/#general-feedback) and we’ll:
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](govuk-pay-support@digital.cabinet-office.gov.uk) and we’ll:
 
 - review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
 - enable MOTO payments in your account
@@ -33,7 +33,7 @@ Make sure you've collected your user's:
 - name from their card
 - email address - if you’ve [enabled collecting your users’ email addresses](/integrate_with_govuk_pay/#collecting-your-users-39-billing-addresses)
 
-Do the following to create and complete the MOTO payment.
+Follow these steps to create and complete the MOTO payment.
 
 1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO account in [your services](https://selfservice.payments.service.gov.uk/my-services).
 
@@ -51,7 +51,9 @@ Do the following to create and complete the MOTO payment.
 
 ## Create an online payment
 
-To create a payment where your user fills in their details themselves, [create a payment](/making_payments/#making-payments) with the GOV.UK Pay API using:
+After we enable MOTO payments in your account, you can still create payments where your user fills in their details themselves.
+
+[Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API using:
 
 - `moto: false` in the request body
 - an API key from your normal account in [your services](https://selfservice.payments.service.gov.uk/my-services), if your PSP is Worldpay or ePDQ


### PR DESCRIPTION
### Context
We can now set up a teams' GOV.UK Pay services so they can take MOTO payments (payments by over the phone or by post).

### Changes proposed in this pull request
- Add documentation about MOTO payments, including error codes
- Alphabetise the 'Optional feature' page so it's easier to navigate

### Guidance to review
Please check if factually correct.