### PR TITLE
Add config for docs review monitoring

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -41,3 +41,8 @@ multipage_nav: true
 collapsible_nav: true
 
 enable_search: true
+
+owner_slack_workspace: gds
+default_owner_slack: '#govuk-pay-support'
+show_review_banner: false
+show_expiry: false


### PR DESCRIPTION
### Context
We're adding the [Tech Docs Template page expiry notifier](https://github.com/alphagov/tech-docs-monitor) - aka Daniel the Manual Spaniel - to our documentation. The monitor will monitor pages where we've added review metadata, and alert us when a page needs reviewing for factual accuracy.

### Changes proposed in this pull request
Update the config file to:
- tell the monitor where to alert us
- not display review banners on docs pages (for now)

### Guidance to review
Please check the config file looks ok.