### PR TITLE
Add case insensitive string requirement to custom metadata docs

### DIFF
--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -27,11 +27,11 @@ Include a `metadata` object in the body of your request to [create a new payment
 
 The `metadata` object must contain between 1 and 10 parameters.
 
-Each parameter key must be a unique string between 1 and 30 characters long. If 2 or more keys are identical, the API will remove all but one of the identical keys from the `metadata` object.
+Each parameter key must be a unique case-insensitive string between 1 and 30 characters long. If 2 or more keys are identical, the API will remove all but one of the identical keys from the `metadata` object.
 
 The data type of each parameter value must be either a:
 
-- case-insensitive string of no more than 50 characters
+- string of no more than 50 characters
 - number
 - boolean
 

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Adding custom metadata
 weight: 135
+last_reviewed_on: 2020-02-18
+review_in: 2 months
 ---
 
 # Adding custom metadata
@@ -25,11 +27,11 @@ Include a `metadata` object in the body of your request to [create a new payment
 
 The `metadata` object must contain between 1 and 10 parameters.
 
-Each parameter key must be a unique string between 1 and 30 characters long. If a key is not unique, the API will remove all but one of the duplicate keys from the `metadata` object.
+Each parameter key must be a unique string between 1 and 30 characters long. If 2 or more keys are identical, the API will remove all but one of the identical keys from the `metadata` object.
 
 The data type of each parameter value must be either a:
 
-- string of no more than 50 characters
+- case-insensitive string of no more than 50 characters
 - number
 - boolean
 


### PR DESCRIPTION
### Context
We're changing the way that [custom metadata](https://docs.payments.service.gov.uk/optional_features/custom_metadata/#add-metadata-to-a-payment) is validated, so that strings are case insensitive.

### Changes proposed in this pull request
Update the custom metadata page with the change, and tweak the line about unique keys so it better matches the requirements.

I've also added a review date in the metadata (see https://github.com/alphagov/pay-tech-docs/pull/384).

### Guidance to review
Please check if factually correct.