### PR TITLE
Revert "Add review date to front page"

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,8 +1,6 @@
 ---
 title: Documentation – GOV.UK Pay
 weight: 10
-last_reviewed_on: 2019-09-18
-review_in: 4 months
 ---
 
 # GOV.UK Pay documentation


### PR DESCRIPTION
Remove the review date from the front page (as our test with the tech docs monitoring tool is now complete).