### PR TITLE
Fix table markdown on delayed capture page

### DIFF
--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -32,7 +32,7 @@ There are 4 possible responses:
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
 |Response code | Meaning |
-|--|--|
+|:---|:---|
 |204| Your capture request succeeded. |
 |404| No payment matched the `paymentId` you provided. |
 |409| You cannot capture the payment because its `status` is not `capturable`. |


### PR DESCRIPTION
### Context
The table of response codes on the [Delayed capture](https://docs.payments.service.gov.uk/optional_features/delayed_capture/#delayed-capture-of-payments) page is not displaying correctly, due to incorrect markdown. 

### Changes proposed in this pull request
Fix the markdown.

### Guidance to review
Please check it looks right.