### PR TITLE
Add setting maximum transaction amount in Worldpay settings

### DIFF
--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -49,11 +49,15 @@ If __Test Mode__ is at the bottom of the left-hand menu, switch to __Production 
 
 10. Enter your XML password into the __Password__ field in your GOV.UK Pay account.
 
-11. In the __Payment service__ section of your Worldpay account, set __Capture delay (days)__ to __Off__ (not __0__).
+11. Go to the __Payment service__ section of your Worldpay account.
+
+12. Set __Capture delay (days)__ to __Off__ (not __0__).
 
     If you do not do this, you may take money from your users before they've confirmed their payment.
 
-12. In your GOV.UK Pay account, select __Save credentials__.
+13. Set __Maximum Transaction Amount__ to the highest payment you will take. The maximum amount is 10,000,000 pence (£100,000).
+
+14. In your GOV.UK Pay account, select __Save credentials__.
 
 ## Set up your Worldpay 'Merchant Channels'
 

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -55,7 +55,7 @@ If __Test Mode__ is at the bottom of the left-hand menu, switch to __Production 
 
     If you do not do this, you may take money from your users before they've confirmed their payment.
 
-13. Set __Maximum Transaction Amount__ to the highest payment you will take. The maximum amount is 10,000,000 pence (£100,000).
+13. Contact Worldpay if you want to take payments higher than the amount in __Maximum Transaction Amount__.
 
 14. In your GOV.UK Pay account, select __Save credentials__.
 


### PR DESCRIPTION
### Context
Some payments are causing errors because they're higher than the 'Maximum transaction limit' in the team's Worldpay settings.

### Changes proposed in this pull request
Add setting 'Maximum transaction amount' during the go-live process for Worldpay.

### Guidance to review
Please check if factually correct.