### PR TITLE
Mention not using real cards in test accounts

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -32,7 +32,7 @@ You must [contact us](/support_contact_and_more_information) to get written appr
 
 ## Mock card numbers
 
-Use mock card numbers with your test account when you try payments as a user.
+Use mock card numbers with your test account when you try payments as a user. Do not use real card numbers.
 
 You can enter any valid value for other payment fields. For example, the card expiry date can be any date in the future.
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -32,7 +32,7 @@ You must [contact us](/support_contact_and_more_information) to get written appr
 
 ## Mock card numbers
 
-Use mock card numbers with your test account when you try payments as a user. Do not use real card numbers.
+Use mock card numbers with your test account when you try payments as a user. Do not use real card numbers with your test account.
 
 You can enter any valid value for other payment fields. For example, the card expiry date can be any date in the future.
 


### PR DESCRIPTION
### Context
We've seen a couple of instances where teams have tried to test a sandbox account using a real card. 

### Changes proposed in this pull request
Add clarification that real cards should not be used in test accounts.

### Guidance to review
Please check if factually correct.