### PR TITLE
Add content about end user bank statement descriptions

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -92,4 +92,8 @@ Within each gateway account for the PSP, you can edit:
 
 * which of your bank accounts your revenue goes to
 
-You should contact your PSP to find out more.
+You can either:
+
+* [contact us](/support_contact_and_more_information/#support) - if your PSP is Stripe
+
+* contact your PSP

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -208,6 +208,11 @@ will then:
 
 Find out [when you'll receive the payment](/integrate_with_govuk_pay/#when-you-39-ll-receive-payments).
 
+You can change what appears on your user's bank statement by:
+
+- [contacting us](/support_contact_and_more_information/#support) - if your PSP is Stripe
+- contacting your PSP
+
 ### Confirmation email
 
 If you have set up confirmation emails, your user will receive a payment


### PR DESCRIPTION
### Context
We need to be clearer about how teams can change the description that appears on end users' bank statements.

### Changes proposed in this pull request
- Add content on the 'Payment flow' page
- Tweak the content on the 'Account structure' page

### Guidance to review
Please check if factually correct.