### PR TITLE
Clarify when we send confirmation emails for delayed capture payments

### DIFF
--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -42,9 +42,8 @@ There are 4 possible responses:
 
 Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. If you do not, [the payment will expire](/payment_flow/#payment-expires).
 
-If your service has enabled payment receipt emails, GOV.UK Pay will send a
-payment receipt email to your user once your service’s capture request is
-received and accepted.
+If your service has enabled sending payment confirmation emails, GOV.UK Pay will send a
+payment confirmation email to your user once we've received and processed your service’s capture request.
 
 ## See the capture URL for a payment
 

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -42,7 +42,7 @@ There are 4 possible responses:
 
 Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. If you do not, [the payment will expire](/payment_flow/#payment-expires).
 
-If your service has enabled sending payment confirmation emails, GOV.UK Pay will send a
+If you've enabled sending payment confirmation emails, GOV.UK Pay will send a
 payment confirmation email to your user once we've received and processed your service’s capture request.
 
 ## See the capture URL for a payment


### PR DESCRIPTION
### Context and changes
A small tweak to make it clearer when we send confirmation emails for delayed capture payments.
I've also rejigged the paragraph slightly for style and active voice.

### Guidance to review
Please check if factually correct.