### PR TITLE
Add payment capture method to go-live steps

### DIFF
--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -44,6 +44,16 @@ If you only want to accept Visa and Mastercard, you do not need to follow these 
 
 5. Select __Save__.
 
+### Set the payment capture method
+
+1. On the __Technical Information__ tab, select the __Global transaction parameters__ tab.
+
+2. Set __Default operation code__ to __Authorisation__.
+
+3. Set __Default data capture (payment) procedure__ to __Data capture by the merchant (manual or automatic)__.
+
+4. Select __Save__.
+
 ### Set a SHA-IN passphrase
 
 1. Select the __Data and origin verification__ tab.

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -55,6 +55,12 @@ Set the __IP address__ to `0.0.0.1`.
 
 Leave the other options as their defaults.
 
+## Set the payment capture method
+
+1. Select __Settings__.
+2. Under __Capture Delay__, select __manual__.
+3. Select __Submit__.
+
 ## Set up notification settings
 
 1. Select __Settings__ then __Server Communication__.


### PR DESCRIPTION
### Context
In our ePDQ and Smartpay go live documentation, we're missing a step about setting up the payment capture method.

### Changes proposed in this pull request
Add setting up the payment capture method in the ePDQ and Smartpay go live pages.

### Guidance to review
Please check if factually correct.