### PR TITLE
Add docs about when to search payments

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -67,7 +67,7 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
-If you [generate a list of payments](/reporting/#generate-a-list-of-payments-search-payments) at the end of each day, you should use a `to_date` of at least one hour before you generate the list. This is because the API may not return up-to-date information about payment events from the last hour.
+If you [generate a list of payments](/reporting/#generate-a-list-of-payments-search-payments) at the end of each day, you should run it at least one hour after your `to_date`. This is because the API may not return up-to-date information about payment events from the last hour.
 
 To help you reconcile payments, you can:
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -67,6 +67,8 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
+If you [generate a list of payments](/reporting/#generate-a-list-of-payments-search-payments) at the end of each day, you should use a `to_date` of at least one hour before you generate the list. This is because the API may not return up-to-date information about payment events from the last hour.
+
 To help you reconcile payments, you can:
 
 - [add custom metadata to payments](/optional_features/custom_metadata)

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -67,7 +67,7 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
-If you [generate a list of payments](/reporting/#generate-a-list-of-payments-search-payments) at the end of each day, you should run it at least one hour after your `to_date`. This is because the API may not return up-to-date information about payment events from the last hour.
+If you [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) at the end of each day, you should run the search at least one hour after your `to_date`. This is because the API may not return up-to-date information about payment events from the last hour.
 
 To help you reconcile payments, you can:
 


### PR DESCRIPTION
### Context
If teams search payments at (say) midnight at the end of each day, and use an end time of midnight, they may miss some payments - because the API may not return fully up-to-date information about payment events from the last hour.

### Changes proposed in this pull request
Add docs to our section about [integrating finance and accounting systems](https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#finance-and-accounting-systems) on using an end date at least one hour before your search time, so you make sure to get up-to-date information about payment events up to that time.

### Guidance to review
Please check if factually correct.