### PR TITLE
Fix links to payment links

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -146,7 +146,7 @@ However, in the failure cases, your user will never visit the `return_url`. Inst
 
 ### Have your service team manually check the payment outcome
 
-If your team manually checks payment outcomes before releasing payments to your users, you may have a low-volume service. This would always be the case if you are using [payment links](/payment_links/#payment-links).
+If your team manually checks payment outcomes before releasing payments to your users, you may have a low-volume service. This would always be the case if you are using [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 You should make sure your service staff check the outcomes of payments in the GOV.UK Pay admin tool before releasing the service to your users.
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 131
 
 GOV.UK Pay supports custom branding on all pages in your payment journey.
 
-You can use custom branding regardless of whether you [integrate your service](/integrate_with_govuk_pay/#how-to-integrate-with-the-gov-uk-pay-api) with GOV.UK Pay, or use [payment links](/payment_links/#payment-links).
+You can use custom branding regardless of whether you [integrate your service](/integrate_with_govuk_pay/#how-to-integrate-with-the-gov-uk-pay-api) with GOV.UK Pay, or use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 You can [contact the GOV.UK Pay
 team](/support_contact_and_more_information/#contact-us) to request

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -9,7 +9,7 @@ review_in: 2 months
 
 You can add custom metadata to a new payment. For example, you can add a reference number from your finance or accounting system, so you can reconcile the payment later.
 
-You add metadata when you make an API call to create a new payment. You cannot add metadata to [Direct Debit transactions](/direct_debit/#direct-debit) or [payment links](/payment_links/#payment-links).
+You add metadata when you make an API call to create a new payment. You cannot add metadata to [Direct Debit transactions](/direct_debit/#direct-debit) or [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 Your users cannot see metadata while they're making a payment.
 

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 132
 
 GOV.UK Pay supports Welsh-language payment pages.
 
-You can also [create payment links in Welsh](/payment_links).
+You can also [create payment links in Welsh](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 To use Welsh, include `"language": "cy"` in the API request when you [create a new payment](/payment_flow/#making-a-payment). Your users will see Welsh text on the payment pages as they complete the [payment flow](/payment_flow).  If you do not specify a language,
 GOV.UK Pay will default to using English-language payment pages.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -19,7 +19,7 @@ There's a different process for [taking Direct Debit payments](/direct_debit/#di
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    This does not apply to your users who use the <a href="/payment_links/#payment-links">payment links</a> functionality.
+    This does not apply to your users who use the <a href="https://www.payments.service.gov.uk/govuk-payment-pages/">payment links</a> functionality.
   </strong>
 </div>
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -40,7 +40,7 @@ GOV.UK Pay API, your service team should have the necessary skills. You can
 refer to the [GOV.UK Service
 Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have)
 for more information. This does not apply if you only use [payment
-links](/payment_links/#payment-links).
+links](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 ## The GOV.UK Pay API
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -83,7 +83,7 @@ You need to make the following changes to your live account if you made them to 
 
 3. Generate a new live API key.
 
-4. Use the new live API key to test making a real payment on your live account, using the [GOV.UK Pay API](/making_payments/#making-payments) or a [payment link](/payment_links).
+4. Use the new live API key to test making a real payment on your live account, using the [GOV.UK Pay API](/making_payments/#making-payments) or a [payment link](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 


### PR DESCRIPTION
### Context
We removed the payment links page, but didn't update the links in the rest of the docs that pointed to it.

### Changes proposed in this pull request
Update the links so they point to https://www.payments.service.gov.uk/govuk-payment-pages/

### Guidance to review
Please check links are ok.
