### PR TITLE
Add docs about search being asynchronous

### DIFF
--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -305,7 +305,7 @@ To check the status of a payment, you must make an API call to either:
 - [get information about a single payment](/reporting/#get-information-about-a-single-payment)
 - [get events for a payment](/reporting/#get-a-payment-s-events)
 
-You must not [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
+Do not [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
 
 The response body contains information about the payment in JSON
 format. The following is the start of a typical response:

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -300,10 +300,12 @@ the `return_url`, your service should:
 
 Read more about [matching your users to payments](/making_payments/#choose-the-return-url-and-match-your-users-to-payments).
 
-To check the status of a payment, you must make a <a
-href="https://govukpay-api-browser.cloudapps.digital/#getpayment"
-target="blank">Find payment by ID</a> API call,
-using the `payment_id` of the payment as the parameter.
+To check the status of a payment, you must make an API call to either:
+
+- [get information about a single payment](/reporting/#get-information-about-a-single-payment)
+- [get events for a payment](https://govukpay-api-browser.cloudapps.digital/#get-events-for-a-payment)
+
+You must not [search payments](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
 
 The URL to do this is the same as the `self` URL provided in the response
 when the payment was first created.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -307,9 +307,6 @@ To check the status of a payment, you must make an API call to either:
 
 You must not [search payments](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
 
-The URL to do this is the same as the `self` URL provided in the response
-when the payment was first created.
-
 The response body contains information about the payment in JSON
 format. The following is the start of a typical response:
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -303,7 +303,7 @@ Read more about [matching your users to payments](/making_payments/#choose-the-r
 To check the status of a payment, you must make an API call to either:
 
 - [get information about a single payment](/reporting/#get-information-about-a-single-payment)
-- [get events for a payment](https://govukpay-api-browser.cloudapps.digital/#get-events-for-a-payment)
+- [get events for a payment](/reporting/#get-a-payment-s-events)
 
 You must not [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -305,7 +305,7 @@ To check the status of a payment, you must make an API call to either:
 - [get information about a single payment](/reporting/#get-information-about-a-single-payment)
 - [get events for a payment](https://govukpay-api-browser.cloudapps.digital/#get-events-for-a-payment)
 
-You must not [search payments](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
+You must not [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
 
 The response body contains information about the payment in JSON
 format. The following is the start of a typical response:

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -145,7 +145,7 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details
 
-You must not search payments using the API to check a payment's status during [payment flow](/payment_flow). Search results are asynchronous so the payment status may not be up-to-date.
+Do not search payments using the API to check a payment's status during [payment flow](/payment_flow). Search results are asynchronous so the payment status may not be up-to-date.
 
 ### Search criteria
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -145,6 +145,8 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details
 
+You must not search payments to check a payment's status during [payment flow](/payment_flow). Search results are asynchronous so the payment status may not be up-to-date.
+
 ### Search criteria
 
 An example search request:

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -145,7 +145,7 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details
 
-You must not search payments to check a payment's status during [payment flow](/payment_flow). Search results are asynchronous so the payment status may not be up-to-date.
+You must not search payments using the API to check a payment's status during [payment flow](/payment_flow). Search results are asynchronous so the payment status may not be up-to-date.
 
 ### Search criteria
 


### PR DESCRIPTION
### Context
Teams should not use the [search payments](https://docs.payments.service.gov.uk/reporting/#generate-a-list-of-payments-search-payments) API call during payment flow to check the status of a payment, because search is asynchronous so the payment status returned may not be up-to-date. 

### Changes proposed in this pull request
Add docs to:
- Payment flow
- Reporting

We do not have documentation about the 'Get events for a payment' API call. To keep this an agile change, I've linked to the API browser for now, and I'll add documentation about that call to the tech docs later.
 
### Guidance to review
Please check if factually correct.