### PR TITLE
Re-add link checking with fixed config and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ bundle exec middleman build
 This will create a `build` subfolder in the application folder which contains
 the HTML and asset files ready to be published.
 
+During the build, [`html-proofer`](https://github.com/gjtorikian/html-proofer)
+will check the HTML files for broken internal links.
+
 ## Updating the template
 
 You can update to the latest version of [tech-docs-template][] by running:

--- a/config.rb
+++ b/config.rb
@@ -9,4 +9,33 @@ end
 
 GovukTechDocs.configure(self)
 
+after_build do |builder|
+  begin
+    HTMLProofer.check_directory(config[:build_dir],
+      { :assume_extension => true,
+        :disable_external => true,
+        :allow_hash_href => true,
+        :url_ignore => [
+          /.+-authentication/,
+          /.+-before-you-start/,
+          /.+-filtering-by-date/,
+          /.+-set-up-3d-secure/,
+          /.+-splitting-results-into-pages/,
+          /.+-copy-your-details-into-your-gov-uk-pay-account/,
+          /.+-set-up-notification-settings/,
+          /.+-test-your-configuration/,
+          /.+-set-up-an-api-user/,
+          /.+-the-gov-uk-pay-api/,
+          /.+creating-a-refund-amount/,
+          /.+creating-a-payment-amount/,
+          /.+before-you-switch-to-live-support/,
+          /.+support-2/,
+          /.+set-the-payment-capture-method/
+        ],
+        :url_swap => { "https://docs.payments.service.gov.uk" => "" } }).run
+  rescue RuntimeError => e
+    abort e.to_s
+  end
+end
+
 redirect "payment_flow_overview/index.html", to: "payment_flow/index.html"

--- a/config.rb
+++ b/config.rb
@@ -15,6 +15,7 @@ after_build do |builder|
       { :assume_extension => true,
         :disable_external => true,
         :allow_hash_href => true,
+        :log_level => ':debug',
         :url_ignore => [
           /.+-authentication/,
           /.+-before-you-start/,

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -18,9 +18,9 @@ You cannot take MOTO payments if your payment service provider (PSP) is SmartPay
 
 ## Set up your account
 
-Email [govuk-pay-support@digital.cabinet-office.gov.uk](govuk-pay-support@digital.cabinet-office.gov.uk) and we’ll:
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) and we’ll:
 
-- review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
+- review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
 - enable MOTO payments in your account
 
 ## Create a MOTO payment


### PR DESCRIPTION
### Context
We added a link checker in https://github.com/alphagov/pay-tech-docs/pull/353, but reverted it later due to build issues.

### Changes proposed in this pull request
- Re-add `html-proofer` to check links during the tech docs build (this time with a correction to the `url_swap` parameter to correctly remove the domain from links that have it)
- Fixes incorrect links identified by html-proofer in the current content

### Guidance to review
Please check the changes to `config.rb`, and that the corrected links work.