### PR TITLE
Fix payment links 404

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -36,6 +36,7 @@ google_site_verification: "IJ5HOXpZrISM6la-YO_iX0rBUC5YFftpexygcKLsNs4"
 redirects:
   /switching_to_live/before_you_switch_to_live/index.html: /switching_to_live/index.html
   /troubleshooting/index.html: /api_reference/index.html
+  /payment_links/index.html: /api_reference/index.html
 
 multipage_nav: true
 collapsible_nav: true


### PR DESCRIPTION
### Context
We removed the payment links page, but the url is now 404-ing.

### Changes proposed in this pull request
Redirect the payment links url to the tech docs homepage.

### Guidance to review
Please check it works ok.