### PR TITLE
Add downtime message

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,6 +7,8 @@ review_in: 3 months
 
 # GOV.UK Pay technical documentation
 
+<%= warning_text('GOV.UK Pay is down for maintenance from 3am to 5am on Tuesday 7 April 2020.') %>
+
 Use this technical documentation to find out how to:
 
 - use the GOV.UK Pay API

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -5,6 +5,8 @@ weight: 160
 
 # Support
 
+<%= warning_text('GOV.UK Pay is down for maintenance from 3am to 5am on Tuesday 7 April 2020.') %>
+
 You can subscribe to our public status page for updates on [the status of our
 system](https://payments.statuspage.io/).
 


### PR DESCRIPTION
### Context
GOV.UK Pay is down for maintenance from 3am to 5am on Tuesday 7 April 2020.

### Changes proposed in this pull request
Add downtime message to front page and support page.

### Guidance to review
Please check if factually correct.