### PR TITLE
Remove downtime messages

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,8 +7,6 @@ review_in: 3 months
 
 # GOV.UK Pay technical documentation
 
-<%= warning_text('GOV.UK Pay is down for maintenance from 3am to 5am on Tuesday 7 April 2020.') %>
-
 Use this technical documentation to find out how to:
 
 - use the GOV.UK Pay API

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -5,8 +5,6 @@ weight: 160
 
 # Support
 
-<%= warning_text('GOV.UK Pay is down for maintenance from 3am to 5am on Tuesday 7 April 2020.') %>
-
 You can subscribe to our public status page for updates on [the status of our
 system](https://payments.statuspage.io/).
 


### PR DESCRIPTION
### Context
The 7 April downtime is complete.

### Changes proposed in this pull request
Remove the downtime messages from the front page and the support page.

### Guidance to review
Please check if all ok.