### PR TITLE
Add Direct Debit test account details

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -243,9 +243,9 @@ This would return payments 501 to 1000.
 
 ## Test a mock bank account
 
-To test confirming bank account details as a user, use the following with your test account:
+To test entering bank account details as a user, use the following with your test account:
 
-- `200000` as the sort code
+- `20 00 00` as the sort code
 - `55779911` as the account number
 
 ## Mandate statuses

--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -241,6 +241,13 @@ You could then get a single page of these mandates by running:
 
 This would return payments 501 to 1000.
 
+## Test a mock bank account
+
+To test confirming bank account details as a user, use the following with your test account:
+
+- `200000` as the sort code
+- `55779911` as the account number
+
 ## Mandate statuses
 
 <div style = "overflow-x:auto;">


### PR DESCRIPTION
### Context
Service teams can test their Direct Debit integration in their test account by using a mock sort code and account number.

### Changes proposed in this pull request
Add a 'Test a mock bank account' section to our [Direct Debit documentation](https://docs.payments.service.gov.uk/direct_debit/#direct-debit).

### Guidance to review
Please check if factually correct.