### PR TITLE
Clarify apple pay doesn't need Worldpay setting

### DIFF
--- a/source/optional_features/digital_wallets/index.html.md.erb
+++ b/source/optional_features/digital_wallets/index.html.md.erb
@@ -15,6 +15,8 @@ Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.
 
 In your __Settings__, select the __Digital wallet__ tab in __Card types__. In the next screen, enable Apple Pay.
 
+You do not need to ask Worldpay to enable Apple Pay on your Worldpay account.
+
 ## Enable Google Pay
 
 To enable Google Pay, you must enter a unique Google Pay merchant ID into your GOV.UK Pay account.

--- a/source/optional_features/digital_wallets/index.html.md.erb
+++ b/source/optional_features/digital_wallets/index.html.md.erb
@@ -15,7 +15,7 @@ Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.
 
 In your __Settings__, select the __Digital wallet__ tab in __Card types__. In the next screen, enable Apple Pay.
 
-You do not need to ask Worldpay to enable Apple Pay on your Worldpay account.
+You do not need to ask Worldpay to enable Apple Pay in your Worldpay account.
 
 ## Enable Google Pay
 


### PR DESCRIPTION
### Context

GOV.UK Pay fully decrypts the apple pay payload before passing to worldpay, so
there's no need to enable any special settings in worldpay.

We had a question about this from a partner service who wanted confirmation as
to whether this setting was needed. It's mentioned in Worldpay's docs:

https://beta.developer.worldpay.com/docs/wpg/mobilewallets/applepay#setup

### Changes proposed in this pull request

Explicitly state that worldpay config changes not needed

### Guidance to review

Possibly we don't need to explain why here. I would be ok with that :-). I used the same language to describe this setting as is used in Worldpay's docs.
