### PR TITLE
Fix identical weights in page metadata

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Making payments
-weight: 70
+weight: 68
 ---
 
 # Making payments

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Optional features
-weight: 130
+weight: 125
 ---
 
 # Optional features


### PR DESCRIPTION
### Context
Some pages had an identical `weight` in their metadata, which was leading their respective positions in the navigation to be random.

### Changes proposed in this pull request
Fix the `weight` for 2 pages so they're no longer identical to 2 other pages.

### Guidance to review
Please check and merge.