### PR TITLE
Add link to adding payment links metadata

### DIFF
--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -11,7 +11,7 @@ You can add custom metadata to a new payment. For example, you can add a referen
 
 You add metadata when you make an API call to create a new payment. You cannot add metadata to [Direct Debit transactions](/direct_debit/#direct-debit).
 
-If you're using [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/), you can add reporting columns instead by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+If you're using [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/), you can add metadata by adding reporting columns in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
 
 Your users cannot see metadata while they're making a payment.
 

--- a/source/optional_features/custom_metadata/index.html.md.erb
+++ b/source/optional_features/custom_metadata/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Adding custom metadata
 weight: 135
-last_reviewed_on: 2020-04-21
+last_reviewed_on: 2020-05-05
 review_in: 2 months
 ---
 
@@ -9,7 +9,9 @@ review_in: 2 months
 
 You can add custom metadata to a new payment. For example, you can add a reference number from your finance or accounting system, so you can reconcile the payment later.
 
-You add metadata when you make an API call to create a new payment. You cannot add metadata to [Direct Debit transactions](/direct_debit/#direct-debit) or [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+You add metadata when you make an API call to create a new payment. You cannot add metadata to [Direct Debit transactions](/direct_debit/#direct-debit).
+
+If you're using [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/), you can add reporting columns instead by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
 
 Your users cannot see metadata while they're making a payment.
 


### PR DESCRIPTION
### Context
Teams can now add metadata ('reporting columns') to payment links.

### Changes proposed in this pull request
Update the [custom metadata](https://docs.payments.service.gov.uk//optional_features/custom_metadata/#add-metadata-to-a-payment) page to direct payment link users to the admin tool.

### Guidance to review
Please check if factually correct.