### PR TITLE
Fix bullet spacing

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -68,13 +68,9 @@ tool](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
 page to change:
 
 * 3D Secure settings
-
 * the card types you accept
-
 * email notifications settings
-
 * billing address settings
-
 * account credentials
 
 You can also change the name of a service, including how it appears on payment
@@ -86,11 +82,9 @@ service name you want to change.
 Within each gateway account for the PSP, you can edit:
 
 * what appears on your users' bank statements
-
 * which of your bank accounts your revenue goes to
 
 You can either:
 
 * [contact us](/support_contact_and_more_information/#support) (if your PSP is Stripe)
-
 * contact your PSP

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -112,13 +112,9 @@ A successful response includes ``status`` and ``finished`` values:
 The GOV.UK Pay uses standard HTTP response code conventions:
 
 * 100 codes are informational
-
 * 200 codes indicate success
-
 * 300 codes indicate a redirection
-
 * 400 codes indicate a client-side error
-
 * 500 codes indicate a server-side error
 
 Common status codes are:

--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -214,7 +214,6 @@ If your request has no query parameters, the API will return all payments.
 You can use the following query parameters to filter mandates or payments by date:
 
 * `from_date`, which is the start date to search, inclusive
-
 * `to_date`, which is the end date to search, exclusive
 
 Dates must be in [ISO

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -11,15 +11,10 @@ This guidance is for technical architects or developers planning to integrate
 their service with the GOV.UK Pay API. It describes:
 
 * the requirements for your service’s backend
-
 * what data you need to store and why
-
 * typical data flows for using the GOV.UK Pay API in an integration
-
 * when to release services to your users
-
 * making sure that all payments are processed
-
 * integrating with finance and accounting systems
 
 The following diagram shows a typical high-level architecture with a GOV.UK
@@ -32,18 +27,12 @@ Pay integration:
 Your service backend is server-side software. You should build this to:
 
 * make a call to the GOV.UK Pay API to start the payment journey
-
 * store information about user payment journeys in your datastore
-
 * redirect your user to the `next_url` provided by GOV.UK Pay, where your user
 will [enter their payment information and confirm their payment](/payment_flow/#making-a-payment)
-
 * receive your user's request when they are redirected back to your service via the `return_url`, where your user will return [after they complete their payment](/payment_flow/#making-a-payment)
-
 * identify your returning user via the session
-
 * make a call to the GOV.UK Pay API to determine the outcome of the payment
-
 * display information about the outcome of the payment and next steps to your user
 
 ## Datastore
@@ -51,13 +40,9 @@ will [enter their payment information and confirm their payment](/payment_flow/#
 You will likely need some kind of server-side datastore to record payment information for each payment journey. You should store:
 
 * an ID or primary key
-
 * the service your user requested
-
 * the GOV.UK Pay `paymentId`
-
 * the status of the payment
-
 * the date and time the payment was started
 
 ## Finance and accounting systems
@@ -132,7 +117,6 @@ There are 2 failure cases which affect the design of your integration with
 GOV.UK Pay:
 
 * your user abandons their payment journey before completing it
-
 * your user completes their payment successfully, but their network connection is
 interrupted before they return to your service
 
@@ -143,7 +127,6 @@ possible to your user, so you would check the payment outcome when your
 However, in the failure cases, your user will never visit the `return_url`. Instead, you should either:
 
 * make sure your service team can manually check payment outcomes in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login)
-
 * use an automatic mop-up job (recommended)
 
 ### Have your service team manually check the payment outcome
@@ -160,7 +143,6 @@ and automatically. A mop-up job is a background process which checks the outcome
 In order to use a mop-up job, you need:
 
 * a datastore which keeps track of incomplete payment journeys
-
 * a server-side process which periodically checks the datastore for incomplete payment journeys, and queries the GOV.UK Pay API to determine the outcome
 
 The following UML sequence diagram shows an example of an incomplete payment journey, and how a mop-up job would clean it up:

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -14,9 +14,7 @@ team](/support_contact_and_more_information/#contact-us) to request
 customisation for the following features:
 
 * the logo displayed in the left-hand side of the top banner
-
 * the background and border colour of the top banner
-
 * the branding of your payment confirmation email
 
 ## Banner logo
@@ -24,11 +22,8 @@ customisation for the following features:
 You should [email us](/support_contact_and_more_information/#contact-us) with an image of your desired custom banner logo. Your image should be:
 
 * in PNG or SVG format
-
 * at least 2x the size of the image that will be displayed on-screen
-
 * cropped to leave minimal whitespace around the logo
-
 * compressed (optimised for web)
 
 ## Banner background and border colour

--- a/source/optional_features/delayed_capture/index.html.md.erb
+++ b/source/optional_features/delayed_capture/index.html.md.erb
@@ -51,7 +51,6 @@ If a payment is available for capture, you can see its capture URL in
 responses to API calls. For example:
 
 * `GET /v1/payments/{paymentID}`
-
 * `GET /v1/payments`
 
 The `"__links"` object will contain:`

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -14,11 +14,8 @@ GOV.UK Pay payment failure pages.
 Terminal, unsuccessful payment states are:
 
 * payment declined
-
 * payment cancelled
-
 * payment expired
-
 * error (for example, technical error)
 
 If you use this feature, GOV.UK Pay will immediately redirect your user to the

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -47,15 +47,10 @@ back to your service.
 A final state means that the payment:
 
 * succeeds
-
 * fails because it is declined
-
 * fails because your user chooses to cancel
-
 * fails due to a technical error
-
 * fails because it is cancelled by your service
-
 * expires - your user has 90 minutes to complete a payment once it's created
 
 When your user arrives back at your service, you can use the API to check the
@@ -219,11 +214,8 @@ If you have set up confirmation emails, your user will receive a payment
 confirmation email containing:
 
 * a payment reference number
-
 * the date of payment
-
 * who the payment was made to
-
 * the total payment amount
 
 You can add a custom paragraph to a payment confirmation email at the [email
@@ -241,13 +233,9 @@ notifications.
 The confirmation page is hosted by your service and should:
 
 * confirm that payments have been received successfully
-
 * contain a reference number, which should be short
-
 * have a clear payment summary, showing the amount and description
-
 * clearly state what is going to happen next - this will be different for each service
-
 * if applicable, let your user know they will receive a receipt email (using GOV.UK Notify or GOV.UK Pay)
 
 Your users have different ways of recording this confirmation information. This can
@@ -263,11 +251,8 @@ System](https://www.gov.uk/service-manual/design/confirmation-pages).
 The payment can fail at any point in the process due to:
 
 * your user selecting __Cancel payment__ on the __Enter card details__ or __Confirm your payment__ pages
-
 * the payment being declined
-
 * your service cancelling the payment
-
 * a technical error
 
 If the payment fails, your user will see a GOV.UK Pay error page, which
@@ -293,9 +278,7 @@ The `return_url` should specify a page on your service. When your user visits
 the `return_url`, your service should:
 
 * match your returning user with their payment (with a secure cookie, or a secure random ID string included in the `return_url`)
-
 * check the status of the payment using an API call
-
 * display an appropriate final page, hosted by your service
 
 Read more about [matching your users to payments](/making_payments/#choose-the-return-url-and-match-your-users-to-payments).
@@ -327,7 +310,6 @@ format. The following is the start of a typical response:
 The `state` array within the JSON lets you know the outcome of the payment:
 
 * `status` describes a stage of the payment journey
-
 * `finished` indicates if the payment journey is complete or not - that is, if the `status` of this payment can change
 
 ### Resuming an incomplete payment

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -27,12 +27,9 @@ Before you start using GOV.UK Pay, you should:
 
 * read how to [get started](https://www.payments.service.gov.uk/getstarted/) and decide if GOV.UK
 Pay is right for your service
-
 * sign up to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/create-service/register)
-
 * read the GOV.UK Service Manual guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html)
-
 * visit our <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a> or look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>
 
 If you want to build a technical integration between your service and the

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -44,7 +44,6 @@ lead to significant cost savings for your organisation.
 You can use the GOV.UK Pay API to:
 
 * get information about a single payment
-
 * generate a list of payments matching search criteria
 
 ## Get information about a single payment
@@ -226,7 +225,6 @@ If your request has no query parameters, the API will return all payments.
 You can use the following query parameters to filter payments by date:
 
 * `from_date` - the start date for payments to be searched, inclusive
-
 * `to_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [the ISO
@@ -238,7 +236,6 @@ For example, a valid input would be `2015-08-13T12:35:00Z`.
 You can use the following query parameters for pagination:
 
 * `display-size` - default, and maximum, is `500`
-
 * `page` - default is `1`
 
 These must be a positive integer. For example, for the following search:


### PR DESCRIPTION
### Context
Bullet lists are inconsistent across the tech docs. Some of the lists use single line spacing while others use double line spacing (such as [Quick start](https://docs.payments.service.gov.uk/quick_start_guide/#quick-start-guide)).

### Changes proposed in this pull request
Make all bullet lists use single line spacing, so they're consistent with GOV.UK style and other GDS tech docs. 

### Guidance to review
Please check it all looks ok.