### PR TITLE
Clarify Direct Debit availability

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -15,7 +15,7 @@ You cannot automatically schedule payments. If you need to take regular payments
 
 If you’d like to set up Direct Debit, [contact us](/support_contact_and_more_information/#contact-us) to be one of our pilot partners.
 
-Direct Debit is not currently available to central government departments or the NHS. [Contact us](/support_contact_and_more_information/#contact-us) if you’d like to know more.
+Direct Debit functionality is not currently available to central government departments in England or the NHS. [Contact us](/support_contact_and_more_information/#contact-us) if you’d like to know more.
 
 ### Set up an account with our Direct Debit supplier
 

--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -15,7 +15,7 @@ You cannot automatically schedule payments. If you need to take regular payments
 
 If you’d like to set up Direct Debit, [contact us](/support_contact_and_more_information/#contact-us) to be one of our pilot partners.
 
-Direct Debit functionality is not currently available to central government departments in England or the NHS. [Contact us](/support_contact_and_more_information/#contact-us) if you’d like to know more.
+Direct Debit is not currently available to central government departments in England or the NHS. [Contact us](/support_contact_and_more_information/#contact-us) if you’d like to know more.
 
 ### Set up an account with our Direct Debit supplier
 


### PR DESCRIPTION
### Context and changes
Minor changes to the Direct Debit page to clarify that Direct Debit functionality is not currently available to central government departments in England or the NHS.

### Guidance to review
Please check if factually correct.