### PR TITLE
Clarify maximum and minimum payments

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -38,8 +38,17 @@ For example:
 
 The amount must be a number data type rather than a string.
 
-The minimum amount is one pence. The maximum amount is 10,000,000 pence (£100,000). [Contact us](/support_contact_and_more_information/#contact-us) if you need to take payments above the maximum amount.
+The minimum amount is one pence plus your Payment Service Provider's (PSP's) transaction fee. To see your PSP's transaction fee, check your contract by either:
 
+- signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) if you use Stripe
+- asking your PSP
+
+The maximum amount is either:
+
+- 10,000,000 pence (£100,000)
+- 5,000,000 pence (£50,000) if your Worldpay contract is through [Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) 
+
+If you need to take payments above the maximum amount, [contact us](/support_contact_and_more_information/#contact-us).
 
 ### reference
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -46,9 +46,14 @@ The minimum amount is one pence plus your Payment Service Provider's (PSP's) tra
 The maximum amount is either:
 
 - 10,000,000 pence (£100,000)
-- 5,000,000 pence (£50,000) if you use the [Government Banking Service](https://www.gov.uk/government/groups/government-banking-service-gbs) 
+- 500,000 pence (£5,000) if you use Government Banking 
 
-If you need to take payments above the maximum amount, [contact us](/support_contact_and_more_information/#contact-us).
+Your PSP may set a lower maximum amount. Check with your PSP if you cannot make payments up to the maximum amount.
+
+If you need to take payments above the maximum amount, either:
+
+- [contact us](/support_contact_and_more_information/#contact-us)
+- [contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) if you use them
 
 ### reference
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -46,7 +46,7 @@ The minimum amount is one pence plus your Payment Service Provider's (PSP's) tra
 The maximum amount is either:
 
 - 10,000,000 pence (£100,000)
-- 5,000,000 pence (£50,000) if your Worldpay contract is through [Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) 
+- 5,000,000 pence (£50,000) if you use the [Government Banking Service](https://www.gov.uk/government/groups/government-banking-service-gbs) 
 
 If you need to take payments above the maximum amount, [contact us](/support_contact_and_more_information/#contact-us).
 


### PR DESCRIPTION
### Context
We need to clarify that:
- the minimum payment includes the PSP transaction fee
- the maximum payment is different if you use the Government Banking Service

### Changes proposed in this pull request
Update the [Making payments](https://docs.payments.service.gov.uk/making_payments/#making-payments) page with the extra content about minimum and maximum payments.

### Guidance to review
Please check if factually correct.