### PR TITLE
Update to 2.0.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,6 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     kramdown (1.17.0)
-    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -175,7 +174,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
-    ref (2.0.0)
     rouge (3.19.0)
     ruby-enum (0.8.0)
       i18n
@@ -187,9 +185,6 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -208,9 +203,8 @@ DEPENDENCIES
   govuk_tech_docs (~> 2.0.12)
   html-proofer
   middleman-search!
-  therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-  2.1.3 
+   2.1.3


### PR DESCRIPTION
### Context and changes
- Update to version 2.0.12
- Remove `therubyracer` as it does not seem to work, and breaks the build