### PR TITLE
Revert "Fix empty alt tags"

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -20,7 +20,7 @@ As an example, take 2 services called ‘parking permits’ and ‘parking fines
 
 ### Type 1 (GOV.UK Pay separate, PSP separate)
 
-<%= image_tag "/images/accountstructure_1.svg", { :alt => '' } %>
+![``”``](/images/accountstructure_1.svg)
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
 both GOV.UK Pay and the PSP.
@@ -34,7 +34,7 @@ If you use this account structure, you can:
 
 ### Type 2 (GOV.UK Pay combined, PSP combined)
 
-<%= image_tag "/images/accountstructure_2.svg", { :alt => '' } %>
+![``”``](/images/accountstructure_2.svg)
 
 ‘Parking permits’ and ‘Parking fines’ are considered a single combined
 service by GOV.UK Pay and the PSP.
@@ -47,7 +47,7 @@ they are a single service in the PSP. It is not possible to support multiple PSP
 
 ### Type 3 (GOV.UK Pay separate, PSP combined)
 
-<%= image_tag "/images/accountstructure_3.svg", { :alt => '' } %>
+![``”``](/images/accountstructure_3.svg)
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
 GOV.UK Pay and as a single combined service in the PSP.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -49,7 +49,7 @@ Authorization: Bearer <YOUR-API-KEY-HERE>
 The following diagram gives an overview of the payment status lifecycle and the
 possible outcomes, excluding for delayed capture payments:
 
-<%= image_tag "/images/payment-states.svg", { :alt => '' } %>
+![](/images/payment-states.svg)
 
 You can check the status of a payment using the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -28,7 +28,7 @@ There's a different process for [taking Direct Debit payments](/direct_debit/#di
 The following diagram outlines the payment process for a service that has a GOV.UK Pay
 integration:
 
-<%= image_tag "/images/card-payment-process.png", { :alt => '' } %>
+![](/images/card-payment-process.png)
 
 The diagram shows the relationship between GOV.UK Pay, payment service providers
 (PSPs) and issuing banks.
@@ -59,7 +59,7 @@ status of the transaction and show them an appropriate message.
 The following diagram illustrates the states a payment can pass through before
 reaching a final state:
 
-<%= image_tag "/images/payment-states.svg", { :alt => '' } %>
+![](/images/payment-states.svg)
 
 ## Making a payment
 
@@ -72,7 +72,7 @@ You should also have a clear call to action that tells your user they're about t
 
 You do not need to tell your user that they'll be taken to GOV.UK Pay’s pages to make their payment.
 
-<%= image_tag "/images/flow-service-payment-page.png", { :alt => '' } %>
+![](/images/flow-service-payment-page.png)
 
 When your user decides to pay, your service should make a
 <a
@@ -165,7 +165,7 @@ card details__ page where they can enter their:
 This page also shows the `description` and the amount your user has to
 pay, making it clear what they’re paying for.
 
-<%= image_tag "/images/flow-payment-details-page.png", { :alt => '' } %>
+![](/images/flow-payment-details-page.png)
 
 > GOV.UK Pay payment pages are responsive and work on both desktop and mobile.
 
@@ -191,7 +191,7 @@ The payment confirmation page shows what your user entered for their:
 This page also shows the `description` and the amount your user has to
 pay.
 
-<%= image_tag "/images/flow-payment-confirm-page.png", { :alt => '' } %>
+![](/images/flow-payment-confirm-page.png)
 
 Your user then decides whether to complete their payment.
 
@@ -264,7 +264,7 @@ show them a page that confirms that the payment failed. This should either:
 
 Your page should also tell your user that no money has been taken from their account.
 
-<%= image_tag "/images/flow-payment-declined.png", { :alt => '' } %>
+![](/images/flow-payment-declined.png)
 
 You can also choose to [use your own payment failure pages](/optional_features/use_your_own_error_pages/#use-your-own-payment-failure-pages).
 


### PR DESCRIPTION
Reverts alphagov/pay-tech-docs#426 because the build failed - htmlproofer does not like the empty alt tags.