### PR TITLE
Fix empty alt tags and update htmlproofer config

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,6 +15,7 @@ after_build do |builder|
       { :assume_extension => true,
         :disable_external => true,
         :allow_hash_href => true,
+        :empty_alt_ignore => true,
         :log_level => ':debug',
         :url_ignore => [
           /.+-authentication/,

--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -20,7 +20,7 @@ As an example, take 2 services called ‘parking permits’ and ‘parking fines
 
 ### Type 1 (GOV.UK Pay separate, PSP separate)
 
-![``”``](/images/accountstructure_1.svg)
+<%= image_tag "/images/accountstructure_1.svg", { :alt => '' } %>
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
 both GOV.UK Pay and the PSP.
@@ -34,7 +34,7 @@ If you use this account structure, you can:
 
 ### Type 2 (GOV.UK Pay combined, PSP combined)
 
-![``”``](/images/accountstructure_2.svg)
+<%= image_tag "/images/accountstructure_2.svg", { :alt => '' } %>
 
 ‘Parking permits’ and ‘Parking fines’ are considered a single combined
 service by GOV.UK Pay and the PSP.
@@ -47,7 +47,7 @@ they are a single service in the PSP. It is not possible to support multiple PSP
 
 ### Type 3 (GOV.UK Pay separate, PSP combined)
 
-![``”``](/images/accountstructure_3.svg)
+<%= image_tag "/images/accountstructure_3.svg", { :alt => '' } %>
 
 ‘Parking permits’ and ‘Parking fines’ are considered separate services by
 GOV.UK Pay and as a single combined service in the PSP.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -49,7 +49,7 @@ Authorization: Bearer <YOUR-API-KEY-HERE>
 The following diagram gives an overview of the payment status lifecycle and the
 possible outcomes, excluding for delayed capture payments:
 
-![](/images/payment-states.svg)
+<%= image_tag "/images/payment-states.svg", { :alt => '' } %>
 
 You can check the status of a payment using the <a
 href="https://govukpay-api-browser.cloudapps.digital/#getpayment"

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -28,7 +28,7 @@ There's a different process for [taking Direct Debit payments](/direct_debit/#di
 The following diagram outlines the payment process for a service that has a GOV.UK Pay
 integration:
 
-![](/images/card-payment-process.png)
+<%= image_tag "/images/card-payment-process.png", { :alt => '' } %>
 
 The diagram shows the relationship between GOV.UK Pay, payment service providers
 (PSPs) and issuing banks.
@@ -59,7 +59,7 @@ status of the transaction and show them an appropriate message.
 The following diagram illustrates the states a payment can pass through before
 reaching a final state:
 
-![](/images/payment-states.svg)
+<%= image_tag "/images/payment-states.svg", { :alt => '' } %>
 
 ## Making a payment
 
@@ -72,7 +72,7 @@ You should also have a clear call to action that tells your user they're about t
 
 You do not need to tell your user that they'll be taken to GOV.UK Pay’s pages to make their payment.
 
-![](/images/flow-service-payment-page.png)
+<%= image_tag "/images/flow-service-payment-page.png", { :alt => '' } %>
 
 When your user decides to pay, your service should make a
 <a
@@ -165,7 +165,7 @@ card details__ page where they can enter their:
 This page also shows the `description` and the amount your user has to
 pay, making it clear what they’re paying for.
 
-![](/images/flow-payment-details-page.png)
+<%= image_tag "/images/flow-payment-details-page.png", { :alt => '' } %>
 
 > GOV.UK Pay payment pages are responsive and work on both desktop and mobile.
 
@@ -191,7 +191,7 @@ The payment confirmation page shows what your user entered for their:
 This page also shows the `description` and the amount your user has to
 pay.
 
-![](/images/flow-payment-confirm-page.png)
+<%= image_tag "/images/flow-payment-confirm-page.png", { :alt => '' } %>
 
 Your user then decides whether to complete their payment.
 
@@ -264,7 +264,7 @@ show them a page that confirms that the payment failed. This should either:
 
 Your page should also tell your user that no money has been taken from their account.
 
-![](/images/flow-payment-declined.png)
+<%= image_tag "/images/flow-payment-declined.png", { :alt => '' } %>
 
 You can also choose to [use your own payment failure pages](/optional_features/use_your_own_error_pages/#use-your-own-payment-failure-pages).
 


### PR DESCRIPTION
### Context
Alt tags for decorative images (where the content is already explained in surrounding text, so alt text is not needed) are rendering as alt="``”``". This will be potentially confusing for users who use screen readers.

### Changes proposed in this pull request
Fix the markdown for each image so the HTML renders as just alt, in line with other documentation examples. This passes the accessibility check at for example https://wave.webaim.org/.

This also involves updating `htmlproofer` config so it ignores empty alt tags, otherwise the build will fail (as happened with https://github.com/alphagov/pay-tech-docs/pull/426).