### PR TITLE
Add link to Stripe payout reporting

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -69,6 +69,8 @@ You'll receive the money in your bank account within 2 working days of your user
 
 It will take 3 working days if your user completed their payment at the weekend or on a bank holiday.
 
+If your PSP is Stripe, you can see payments Stripe has made to your bank account by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+
 Your payment service provider (PSP) will only transfer money to you when the total of your users' payments is above your PSP's ‘minimum payout’. For example, if you use GOV.UK Pay’s PSP, the minimum payout is £1.
 
 If your PSP is Worldpay, SmartPay or ePDQ, ask your PSP if you need to know your exact minimum payout or payment times.

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -69,7 +69,10 @@ You'll receive the money in your bank account within 2 working days of your user
 
 It will take 3 working days if your user completed their payment at the weekend or on a bank holiday.
 
-If your PSP is Stripe, you can see payments Stripe has made to your bank account by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see:
+
+- payments ('payouts') that Stripe has made to your bank account
+- which of your users' payments are in each payout
 
 Your payment service provider (PSP) will only transfer money to you when the total of your users' payments is above your PSP's ‘minimum payout’. For example, if you use GOV.UK Pay’s PSP, the minimum payout is £1.
 


### PR DESCRIPTION
### Context
We're adding payout reporting for Stripe to the GOV.UK Pay admin tool.

### Changes proposed in this pull request
Add a link in the [finance and accounting section of the integrating docs](https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#finance-and-accounting-systems).

### Guidance to review
Please check if factually correct.
Do not merge until the payout reporting is live.