### PR TITLE
Fix host url in config file

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: https://www.payments.service.gov.uk/
+host: https://docs.payments.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true


### PR DESCRIPTION
### Context
Daniel the Manual Spaniel is using incorrect urls for his Slack alerts, because the host url for the Pay tech docs is set wrongly in `tech-docs.yml`.

### Changes proposed in this pull request
Fix the host url (the lack of trailing slash is important).

### Guidance to review
Please check it looks ok