### PR TITLE
(Draft) PP-6616 Add payouts API documentation

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -80,11 +80,11 @@ Example response:
 ```json
 "settlement_summary": {
   ...
-  "psp_settled_date": "2016-01-22",
+  "settled_date": "2016-01-22",
 }
 ```
 
-`psp_settled_date` is either:
+`settled_date` is either:
 
 - the date that Stripe sent the payment to your bank account as part of a group of payments (‘payout’)
 - missing if Stripe has not yet sent the payment to your bank account

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -65,18 +65,31 @@ Read more about [reporting](/reporting/#reporting) and [refunding payments](/ref
 
 ### When you'll receive payments
 
-You'll receive the money in your bank account within 2 working days of your user completing their payment.
+You'll receive the money in your bank account within 2 working days of your user completing their payment. It will take 3 working days if your user completed their payment at the weekend or on a bank holiday.
 
-It will take 3 working days if your user completed their payment at the weekend or on a bank holiday.
-
-If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see:
-
-- payments ('payouts') that Stripe has made to your bank account
-- which of your users' payments are in each payout
-
-Your payment service provider (PSP) will only transfer money to you when the total of your users' payments is above your PSP's ‘minimum payout’. For example, if you use GOV.UK Pay’s PSP, the minimum payout is £1.
+Your payment service provider (PSP) will only transfer money to you when the total of your users' payments is above your PSP's ‘minimum payout’. For example if your PSP is Stripe, the minimum payout is £1.
 
 If your PSP is Worldpay, SmartPay or ePDQ, ask your PSP if you need to know your exact minimum payout or payment times.
+
+#### Checking when your PSP sent a payment
+
+If your PSP is Stripe, you can check when Stripe sent a payment to your bank account by making an API call to [get information about a payment](/reporting/#reporting-via-the-gov-uk-pay-api).
+
+Example response:
+
+```json
+"settlement_summary": {
+  ...
+  "psp_settled_date": "2016-01-22",
+}
+```
+
+`psp_settled_date` is either:
+
+- the date that Stripe sent the payment to your bank account as part of a group of payments (‘payout’)
+- missing if Stripe has not yet sent the payment to your bank account
+
+You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see your payout for each day, and which of your users’ payments are in each payout.
 
 ## The GOV.UK Pay API
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -123,14 +123,14 @@ If your PSP is Stripe, you can see when Stripe took the refund when you make an 
 
 Example response:
 
-```
+```json
 "settlement_summary": {
   ...
-  "psp_settled_date": "2016-01-22",
+  "settled_date": "2016-01-22",
 }
 ```
 
-`psp_settled_date` will be either:
+`settled_date` will be either:
 
 - the date that Stripe took the refund from the payments they sent to your bank account
 - missing if Stripe has not yet taken the refund
@@ -197,10 +197,15 @@ For example, a valid input would be `2015-08-13T12:35:00Z`.
 
 ### Filter by when your PSP took refunds
 
-If your payment service provider (PSP) is Stripe, you can use the following query parameters to filter by when your PSP took refunds:
+If your payment service provider (PSP) is Stripe, you can use the following query parameters to filter by [when your PSP took refunds](#where-your-psp-takes-the-refund-amount-from):
 
-- `from_psp_settled_date` - the start date for payments to be searched, inclusive
-- `to_psp_settled_date` - the end date for payments to be searched, exclusive
+- `from_settled_date` - the start date for payments to be searched, inclusive
+- `to_settled_date` - the end date for payments to be searched, exclusive
+
+For example, to list all the refunds your PSP took on 16 June 2020:
+
+`GET
+/v1/refunds?from_settled_date=2020-06-16T00:00:00Z&to_settled_date=2020-06-16T23:00:00Z`
 
 These take inputs based on a subset of [the ISO
 8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -119,7 +119,7 @@ If the payment has reached your bank account, your PSP will take the refund amou
 - the next payment or payments you receive from any of your users, if your PSP is Stripe or ePDQ
 - your bank account, if your PSP is SmartPay or Worldpay
 
-If your PSP is Stripe, you can see when Stripe took the refund by making an API call to [get information about a payment](/reporting/#reporting-via-the-gov-uk-pay-api).
+If your PSP is Stripe, you can see when Stripe took the refund when you make an API call to [check the status of a refund](#checking-the-status-of-a-refund).
 
 Example response:
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -119,6 +119,22 @@ If the payment has reached your bank account, your PSP will take the refund amou
 - the next payment or payments you receive from any of your users, if your PSP is Stripe or ePDQ
 - your bank account, if your PSP is SmartPay or Worldpay
 
+If your PSP is Stripe, you can see when Stripe took the refund by making an API call to [get information about a payment](/reporting/#reporting-via-the-gov-uk-pay-api).
+
+Example response:
+
+```
+"settlement_summary": {
+  ...
+  "psp_settled_date": "2016-01-22",
+}
+```
+
+`psp_settled_date` will be either:
+
+- the date that Stripe took the refund from the payments they sent to your bank account
+- missing if Stripe has not yet taken the refund
+
 ### Send email notifications about refunds
 
 You can use the GOV.UK Pay admin tool to turn on [sending refund email notifications to your users](https://selfservice.payments.service.gov.uk/email-notifications).
@@ -168,15 +184,27 @@ An example search request:
 `GET
 /v1/refunds?from_date=2019-09-20T13:30:00Z&to_date=2019-09-22T15:00:00Z`
 
-### Filtering by date
+### Filter by when you created refunds
 
-You can use the following query parameters to filter refunds by date:
+You can use the following query parameters to filter by the date you created refunds:
 
-* `from_date`, which is the start date to search, inclusive
-* `to_date`, which is the end date to search, exclusive
+* `from_date` - the start date for payments to be searched, inclusive
+* `to_date` - the end date for payments to be searched, exclusive
 
-Dates must be in [ISO
-8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard). For example `2019-09-20T13:30:00Z`.
+These take inputs based on a subset of [the ISO
+8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+For example, a valid input would be `2015-08-13T12:35:00Z`.
+
+### Filter by when your PSP took refunds
+
+If your payment service provider (PSP) is Stripe, you can use the following query parameters to filter by when your PSP took refunds:
+
+- `from_psp_settled_date` - the start date for payments to be searched, inclusive
+- `to_psp_settled_date` - the end date for payments to be searched, exclusive
+
+These take inputs based on a subset of [the ISO
+8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+For example, a valid input would be `2015-08-13T12:35:00Z`.
 
 ### Splitting results into pages
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -235,10 +235,15 @@ For example, a valid input would be `2015-08-13T12:35:00Z`.
 
 #### Filter by when your PSP sent payments to your bank account
 
-If your PSP is Stripe, you can use the following query parameters to filter by when your PSP sent payments to your bank account:
+If your PSP is Stripe, you can use the following query parameters to filter by [when your PSP sent payments to your bank account](/integrate_with_govuk_pay/#checking-when-your-psp-sent-a-payment):
 
-- `from_psp_settled_date` - the start date for payments to be searched, inclusive
-- `to_psp_settled_date` - the end date for payments to be searched, exclusive
+- `from_settled_date` - the start date for payments to be searched, inclusive
+- `to_settled_date` - the end date for payments to be searched, exclusive
+
+For example, to list all the payments your PSP sent to you on 16 June 2020:
+
+`GET
+/v1/payments?from_settled_date=2020-06-16T00:00:00Z&to_settled_date=2020-06-16T23:00:00Z`
 
 These take inputs based on a subset of [the ISO
 8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -222,12 +222,23 @@ If your request has no query parameters, the API will return all payments.
 
 `card_brand` is case insensitive. You cannot search for partial values of `card_brand`.
 
-#### Filter by date
+#### Filter by when you created payments
 
-You can use the following query parameters to filter payments by date:
+You can use the following query parameters to filter by the date you created payments:
 
 * `from_date` - the start date for payments to be searched, inclusive
 * `to_date` - the end date for payments to be searched, exclusive
+
+These take inputs based on a subset of [the ISO
+8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+For example, a valid input would be `2015-08-13T12:35:00Z`.
+
+#### Filter by when your PSP sent payments to your bank account
+
+If your PSP is Stripe, you can use the following query parameters to filter by when your PSP sent payments to your bank account:
+
+- `from_psp_settled_date` - the start date for payments to be searched, inclusive
+- `to_psp_settled_date` - the end date for payments to be searched, exclusive
 
 These take inputs based on a subset of [the ISO
 8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).


### PR DESCRIPTION
### Context
We're testing documentation about getting information about Stripe payouts through the API. 

### Changes proposed in this pull request
Add new parameter for payout date to getting information about a payment or refund, and searching for payments or refunds.
