### PR TITLE
Clarify MOTO payments

### DIFF
--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -16,10 +16,9 @@ This means you can take payments:
 
 These payments are also known as Mail Order / Telephone Order (MOTO) payments.
 
-You cannot take MOTO payments:
+You cannot take MOTO payments if your payment service provider (PSP) is SmartPay.
 
-- if your payment service provider (PSP) is SmartPay
-- through a [payment link](https://www.payments.service.gov.uk/govuk-payment-pages/) - [contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop this feature
+You also cannot take MOTO payments through a [payment link](https://www.payments.service.gov.uk/govuk-payment-pages/) - [contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop this feature.
 
 ## If your PSP is Worldpay or ePDQ
 

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -25,19 +25,19 @@ You cannot take MOTO payments:
 
 If your PSP is Worldpay or ePDQ, you must first:
 
-- [create a new GOV.UK Pay account](https://selfservice.payments.service.gov.uk/create-service/register) for MOTO payments 
+- [create a new GOV.UK Pay service](https://selfservice.payments.service.gov.uk/create-service/register) for MOTO payments
 - contact your PSP and ask for a new merchant code for MOTO payments
 
 [Contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) instead if you use them.
 
-You cannot use an existing GOV.UK Pay account or an existing merchant code.
+You cannot use an existing GOV.UK Pay service or an existing merchant code.
 
 ## Set up your account
 
 Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) and we'll:
 
 - review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
-- enable MOTO payments in your account
+- enable MOTO payments in your service
 
 ## Create a MOTO payment
 
@@ -51,7 +51,7 @@ Make sure you've collected your user's:
 
 Follow these steps to create and complete the MOTO payment.
 
-1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO account in [your services](https://selfservice.payments.service.gov.uk/my-services).
+1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO service in [your services](https://selfservice.payments.service.gov.uk/my-services).
 
 2. [Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API, and include `moto: true` in the request body.
 
@@ -67,9 +67,9 @@ Follow these steps to create and complete the MOTO payment.
 
 ## Create an online payment
 
-After we enable MOTO payments in your MOTO account, you can still create payments where your user fills in their details themselves.
+After we enable MOTO payments in your account, you can still create payments where your user fills in their details themselves.
 
 [Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API using:
 
 - `moto: false` in the request body
-- an API key from your normal account in [your services](https://selfservice.payments.service.gov.uk/my-services), if your PSP is Worldpay or ePDQ
+- an API key from your normal service in [your services](https://selfservice.payments.service.gov.uk/my-services), if your PSP is Worldpay or ePDQ

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Take payments over the phone ('MOTO' payments)
-last_reviewed_on: 2020-06-15
+last_reviewed_on: 2020-06-23
 review_in: 4 months
 weight: 200
 ---
@@ -29,8 +29,6 @@ If your PSP is Worldpay or ePDQ, you must first:
 - contact your PSP and ask for a new merchant code for MOTO payments
 
 [Contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) instead if you use them.
-
-You cannot use an existing GOV.UK Pay service or an existing merchant code.
 
 ## Set up your account
 

--- a/source/optional_features/moto_payments/index.html.md.erb
+++ b/source/optional_features/moto_payments/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Take payments over the phone ('MOTO' payments)
-last_reviewed_on: 2020-06-08
+last_reviewed_on: 2020-06-15
 review_in: 4 months
 weight: 200
 ---
@@ -16,11 +16,25 @@ This means you can take payments:
 
 These payments are also known as Mail Order / Telephone Order (MOTO) payments.
 
-You cannot take MOTO payments if your payment service provider (PSP) is SmartPay.
+You cannot take MOTO payments:
+
+- if your payment service provider (PSP) is SmartPay
+- through a [payment link](https://www.payments.service.gov.uk/govuk-payment-pages/) - [contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop this feature
+
+## If your PSP is Worldpay or ePDQ
+
+If your PSP is Worldpay or ePDQ, you must first:
+
+- [create a new GOV.UK Pay account](https://selfservice.payments.service.gov.uk/create-service/register) for MOTO payments 
+- contact your PSP and ask for a new merchant code for MOTO payments
+
+[Contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) instead if you use them.
+
+You cannot use an existing GOV.UK Pay account or an existing merchant code.
 
 ## Set up your account
 
-Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) and we’ll:
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) and we'll:
 
 - review your [Payment Card Industry Data Security Standards (PCI DSS) assessment](/security/#payment-card-industry-pci-compliance) to check you can take payments over the phone and by post
 - enable MOTO payments in your account
@@ -53,7 +67,7 @@ Follow these steps to create and complete the MOTO payment.
 
 ## Create an online payment
 
-After we enable MOTO payments in your account, you can still create payments where your user fills in their details themselves.
+After we enable MOTO payments in your MOTO account, you can still create payments where your user fills in their details themselves.
 
 [Create a payment](/making_payments/#making-payments) with the GOV.UK Pay API using:
 


### PR DESCRIPTION
### Context
We need to clarify that if teams want to use MOTO payments and they're using Worldpay and ePDQ as their PSP, they need to create a separate GOV.UK Pay service and get a separate merchant code.

### Changes proposed in this pull request
Add the clarifications above.

### Guidance to review
Please check if factually correct.