### PR TITLE
PP-6665 Add link to responsible person guidance

### DIFF
--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -17,7 +17,7 @@ We'll also give you a link where you can provide your organisation's:
 * VAT number
 * company registration number if you've [registered your company](https://www.gov.uk/limited-company-formation/register-your-company)
 
-You must also provide us with the name, date of birth and home address of someone who's authorised to sign contracts on behalf of your organisation, also known as a ‘responsible person’.
+You must also provide us with the name, date of birth and home address of someone who's authorised to sign contracts on behalf of your organisation, also known as a ‘[responsible person](https://www.payments.service.gov.uk/what-being-a-responsible-person-means/)’.
 
 GOV.UK Pay only stores your organisation's address and telephone number. GOV.UK Pay passes all other information to Stripe without storing that information. Stripe then processes and stores that information.
 


### PR DESCRIPTION
### Context
There's a new page we can link to with guidance on being someone authorised to sign contracts on behalf of your organisation (a 'responsible person').

### Changes proposed in this pull request
Add a link to the guidance from our Stripe 'go live' documentation.

### Guidance to review
Please check if factually correct.