### PR TITLE
Remove references to BYO Contract

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -86,5 +86,6 @@ Within each gateway account for the PSP, you can edit:
 
 You can either:
 
-* [contact us](/support_contact_and_more_information/#support) (if your PSP is Stripe)
-* contact your PSP
+- [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
+- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if your PSP is Worldpay through Government Banking
+- contact your PSP directly

--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -87,5 +87,5 @@ Within each gateway account for the PSP, you can edit:
 You can either:
 
 - [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
-- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if your PSP is Worldpay through Government Banking
+- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
 - contact your PSP directly

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -16,7 +16,6 @@ You can read [non-technical information](https://www.payments.service.gov.uk/usi
 
 - creating an account and selecting a payment service provider (PSP)
 - managing your account with Stripe, GOV.UK Pay's PSP
-- setting up Direct Debit
 - using the Apple Pay and Google Pay digital wallets
 - security and compliance
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -16,7 +16,8 @@ You can read [non-technical information](https://www.payments.service.gov.uk/usi
 
 - creating an account and selecting a payment service provider (PSP)
 - managing your account with Stripe, GOV.UK Pay's PSP
-- setting up payment links
+- setting up Direct Debit
+- using the Apple Pay and Google Pay digital wallets
 - security and compliance
 
 [Contact us](/support_contact_and_more_information/#contact-us) if you have any questions or feedback.

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -63,17 +63,17 @@ You could also connect a customer-relationship management (CRM) or case manageme
 
 Read more about [reporting](/reporting/#report-on-a-payment) and [refunding payments](/refunding_payments/#refund-a-payment).
 
-### When you'll receive payments
+### Receiving payments
 
-When you receive payments into your account differs depending on your payment service provider's (PSP) minimum payout and payment times.
+The date you receive users’ payments into your account depends on your payment service provider's (PSP) minimum payout and payment times.
 
 Your PSP only transfers money to you when the total of your users' payments is above your PSP's minimum payout.
 
 If your PSP is Stripe:
 
 - the minimum payout is £1
-- you'll receive the money in your bank account within 2 working days of your user completing their payment
-- the money will take 3 working days to reach your account if your user completed their payment at the weekend or on a bank holiday
+- money will reach your bank account within 2 working days of your user completing their payment
+- money will take 3 working days to reach your account if your user completed their payment at the weekend or on a bank holiday
 
 If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see:
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -65,18 +65,22 @@ Read more about [reporting](/reporting/#report-on-a-payment) and [refunding paym
 
 ### When you'll receive payments
 
-You'll receive the money in your bank account within 2 working days of your user completing their payment.
+When you receive payments into your account differs depending on your payment service provider's (PSP) minimum payout and payment times.
 
-It will take 3 working days if your user completed their payment at the weekend or on a bank holiday.
+Your PSP only transfers money to you when the total of your users' payments is above your PSP's minimum payout.
+
+If your PSP is Stripe:
+
+- the minimum payout is £1
+- you'll receive the money in your bank account within 2 working days of your user completing their payment
+- the money will take 3 working days to reach your account if your user completed their payment at the weekend or on a bank holiday
 
 If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see:
 
 - payments ('payouts') that Stripe has made to your bank account
 - which of your users' payments are in each payout
 
-Your payment service provider (PSP) will only transfer money to you when the total of your users' payments is above your PSP's ‘minimum payout’. For example, if you use GOV.UK Pay’s PSP, the minimum payout is £1.
-
-If your PSP is Worldpay, SmartPay or ePDQ, ask your PSP if you need to know your exact minimum payout or payment times.
+If your PSP is Government Banking's contracted PSP (currently Worldpay), SmartPay or ePDQ, contact your PSP to find out your minimum payout and payment times.
 
 ## The GOV.UK Pay API
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -43,6 +43,7 @@ The amount must be a number data type rather than a string.
 The minimum amount is one pence plus your Payment Service Provider's (PSP's) transaction fee. To see your PSP's transaction fee, check your contract by either:
 
 - signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) if you use Stripe
+- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if your PSP is Worldpay through Government Banking
 - asking your PSP
 
 The maximum amount is either:
@@ -55,7 +56,7 @@ Your PSP may set a lower maximum amount. Check with your PSP if you cannot make 
 If you need to take payments above the maximum amount, either:
 
 - [contact us](/support_contact_and_more_information/#contact-us)
-- [contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) if you use them
+- [contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) if your PSP is Worldpay through Government Banking
 
 ### reference
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -43,7 +43,7 @@ The amount must be a number data type rather than a string.
 The minimum amount is one pence plus your Payment Service Provider's (PSP's) transaction fee. To see your PSP's transaction fee, check your contract by either:
 
 - signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) if you use Stripe
-- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if your PSP is Worldpay through Government Banking
+- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
 - asking your PSP
 
 The maximum amount is either:
@@ -56,7 +56,7 @@ Your PSP may set a lower maximum amount. Check with your PSP if you cannot make 
 If you need to take payments above the maximum amount, either:
 
 - [contact us](/support_contact_and_more_information/#contact-us)
-- [contact Government Banking](https://www.gov.uk/government/groups/government-banking-service-gbs) if your PSP is Worldpay through Government Banking
+- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
 
 ### reference
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -194,7 +194,7 @@ Find out [when you'll receive the payment](/integrate_with_govuk_pay/#when-you-3
 You can change what appears on your user's bank statement by:
 
 - [contacting us](/support_contact_and_more_information/#support) if your PSP is Stripe
-- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if your PSP is Worldpay through Government Banking
+- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
 - contacting your PSP directly
 
 ### Confirmation email

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -193,8 +193,9 @@ Find out [when you'll receive the payment](/integrate_with_govuk_pay/#when-you-3
 
 You can change what appears on your user's bank statement by:
 
-- [contacting us](/support_contact_and_more_information/#support) (if your PSP is Stripe)
-- contacting your PSP
+- [contacting us](/support_contact_and_more_information/#support) if your PSP is Stripe
+- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if your PSP is Worldpay through Government Banking
+- contacting your PSP directly
 
 ### Confirmation email
 

--- a/source/set_up_3dsecure/index.html.md.erb
+++ b/source/set_up_3dsecure/index.html.md.erb
@@ -16,24 +16,6 @@ How you set up 3DS payment authentication depends on:
 
 You do not need to do anything, because we set up 3DS2 on your service by default.
 
-## ePDQ
-
-1. Sign in to your [ePDQ account](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index).
-2. Go to __Configuration__ then  __Payment methods__.
-3. Select __3D Secure__.
-4. Check that 3DS is on.
-5. In the GOV.UK Pay admin tool, go to your [__My services__](https://selfservice.payments.service.gov.uk/my-services) page, then select the account you want to set up
-6. In the settings, select the __View__ link under __3D Secure__.
-7. Select __On__.
-
-## SmartPay
-
-1. Select the account you want to set up on the [__My services__](https://selfservice.payments.service.gov.uk/my-services) page in the GOV.UK Pay admin tool.
-2. In the settings, select the __View__ link under __3D Secure__.
-3. Select __On__.
-
-You do not need to do anything in your Smartpay account.
-
 ## Worldpay
 
 ### Set up 3DS
@@ -54,3 +36,21 @@ You'll need your 3DS Flex details to set up your account. Ask your Worldpay acco
 3. Select __On__.
 4. Copy your 3DS Flex details into the [PSP settings in your GOV.UK Pay account](https://selfservice.payments.service.gov.uk/your-psp).
 5. Check your account still works by [making a payment with a real payment card](/switching_to_live/#6-check-your-live-account-works).
+
+## ePDQ
+
+1. Sign in to your [ePDQ account](https://payments.epdq.co.uk/Ncol/Prod/BackOffice/login/index).
+2. Go to __Configuration__ then  __Payment methods__.
+3. Select __3D Secure__.
+4. Check that 3DS is on.
+5. In the GOV.UK Pay admin tool, go to your [__My services__](https://selfservice.payments.service.gov.uk/my-services) page, then select the account you want to set up
+6. In the settings, select the __View__ link under __3D Secure__.
+7. Select __On__.
+
+## SmartPay
+
+1. Select the account you want to set up on the [__My services__](https://selfservice.payments.service.gov.uk/my-services) page in the GOV.UK Pay admin tool.
+2. In the settings, select the __View__ link under __3D Secure__.
+3. Select __On__.
+
+You do not need to do anything in your Smartpay account.

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -44,9 +44,9 @@ You can still use your test account.
 Once you have a GOV.UK Pay live account, you can connect that account to your PSP. You can use either of the following PSPs with GOV.UK Pay:
 
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+- if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
-If you use Worldpay and Government Banking decides to change PSP in future, we will work with you at that time to move you on to the new PSP.
+If you use Government Banking's contracted PSP, and Government Banking decides to change the contract, we will work with you at that time to move you on to the new PSP.
 
 Effective from 1 August 2020, you cannot use GOV.UK Pay with any other PSPs.
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -46,9 +46,9 @@ Once you have a GOV.UK Pay live account, you can connect that account to your PS
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
 - if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
-If you use WorldPay and Government Banking decides to change PSP in future, we will work with you at that time to move you on to the new PSP.
+If you use Worldpay and Government Banking decides to change PSP in future, we will work with you at that time to move you on to the new PSP.
 
-Effective from DATE, you cannot use GOV.UK Pay with any other PSPs.
+Effective from 1 August 2020, you cannot use GOV.UK Pay with any other PSPs.
 
 If you agreed with GOV.UK Pay before this date to use either [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) or [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay), you can connect your live account to that PSP.
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -46,11 +46,11 @@ Once you have a GOV.UK Pay live account, you can connect that account to your PS
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
 - if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
-If you use Government Banking's contracted PSP, and Government Banking decides to change the contract, we will work with you at that time to move you on to the new PSP.
+If you use Government Banking's contracted PSP, and Government Banking decides to change the contract, we will work with you to move you on to the new PSP.
 
-Effective from 1 August 2020, you cannot use GOV.UK Pay with any other PSPs.
+From 1 August 2020, you cannot use GOV.UK Pay with any other PSPs.
 
-If you agreed with GOV.UK Pay before this date to use either [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) or [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay), you can connect your live account to that PSP.
+If you agreed with GOV.UK Pay before 1 August 2020 to use either [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) or [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay), you can connect your live account to that PSP.
 
 ## 3. Set up 3D Secure
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -41,12 +41,16 @@ You can still use your test account.
 
 ## 2. Connect your live account to your PSP
 
-Once you have a GOV.UK Pay live account, you can connect it to:
+Once you have a GOV.UK Pay live account, you can connect that account to your PSP. You can use either of the following PSPs with GOV.UK Pay:
 
-- [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
-- [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
-- [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+- GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
+- if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+
+If you use WorldPay and Government Banking decides to change PSP in future, we will work with you at that time to move you on to the new PSP.
+
+Effective from DATE, you cannot use GOV.UK Pay with any other PSPs.
+
+If you agreed with GOV.UK Pay before this date to use either [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) or [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay), you can connect your live account to that PSP.
 
 ## 3. Set up 3D Secure
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -7,10 +7,17 @@ weight: 163
 
 This is part of [going live](/switching_to_live/#go-live).
 
-You must be an admin on both your:
+You can only connect your live account to ePDQ if you agreed with GOV.UK Pay before 1 August 2020 to use ePDQ.
+
+To connect your live account to ePDQ, you must be an admin on both your:
 
 - GOV.UK Pay account
 - ePDQ account
+
+If you did not agree with GOV.UK Pay before 1 August 2020 to use ePDQ, you must use one of the following PSPs with GOV.UK Pay:
+
+- GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
+- if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
 ## Add payment methods to your account
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -17,7 +17,7 @@ To connect your live account to ePDQ, you must be an admin on both your:
 If you did not agree with GOV.UK Pay before 1 August 2020 to use ePDQ, you must use one of the following PSPs with GOV.UK Pay:
 
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+- if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
 ## Add payment methods to your account
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -9,13 +9,12 @@ This is part of [going live](/switching_to_live/#go-live).
 
 You can only connect your live account to SmartPay if you agreed with GOV.UK Pay before 1 August 2020 to use SmartPay.
 
-To connect your live account to SmartPay, you must be an admin on your GOV.UK Pay account to connect to SmartPay.
+You must be an admin on your GOV.UK Pay account to connect your live account to SmartPay.
 
 If you did not agree with GOV.UK Pay before 1 August 2020 to use SmartPay, you must use one of the following PSPs with GOV.UK Pay:
 
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
 - if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
-
 
 ## Configure your user profile on SmartPay
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -14,7 +14,8 @@ To connect your live account to SmartPay, you must be an admin on your GOV.UK Pa
 If you did not agree with GOV.UK Pay before 1 August 2020 to use SmartPay, you must use one of the following PSPs with GOV.UK Pay:
 
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+- if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+
 
 ## Configure your user profile on SmartPay
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -7,7 +7,14 @@ weight: 164
 
 This is part of [going live](/switching_to_live/#go-live).
 
-You must be an admin on your GOV.UK Pay account to connect to SmartPay.
+You can only connect your live account to SmartPay if you agreed with GOV.UK Pay before 1 August 2020 to use SmartPay.
+
+To connect your live account to SmartPay, you must be an admin on your GOV.UK Pay account to connect to SmartPay.
+
+If you did not agree with GOV.UK Pay before 1 August 2020 to use SmartPay, you must use one of the following PSPs with GOV.UK Pay:
+
+- GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
+- if you are a central government or health sector organisation, Government Banking's PSP, [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
 ## Configure your user profile on SmartPay
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -7,6 +7,8 @@ weight: 161
 
 This is part of [going live](/switching_to_live/#go-live).
 
+Stripe is GOV.UK Pay's payment service provider (PSP).
+
 After you request a live GOV.UK Pay account, we'll contact you to verify your organisation’s identity.
 
 We'll also give you a link where you can provide your organisation's:

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 162
 
 This is part of [going live](/switching_to_live/#go-live).
 
-Worldpay is Government Banking's payment service provider (PSP). You must be a central government or health sector organisation to use Worldpay.
+Government Banking's contracted payment service provider (PSP) is currently Worldpay. You must be a central government or health sector organisation to use Government Banking's contracted PSP.
 
 You must be an admin on your GOV.UK Pay account to connect to Worldpay.
 

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -7,6 +7,8 @@ weight: 162
 
 This is part of [going live](/switching_to_live/#go-live).
 
+Worldpay is Government Banking's payment service provider (PSP). You must be a central government or health sector organisation to use Worldpay.
+
 You must be an admin on your GOV.UK Pay account to connect to Worldpay.
 
 ## Check your Worldpay account


### PR DESCRIPTION
### Context

You must have a contract with a Payment Service Provider (PSP) to process the payments taken using GOV.UK Pay. 

You can use either of the following PSPs with GOV.UK Pay:

- GOV.UK Pay's PSP, Stripe
- if you are a central government or health sector organisation, Government Banking's PSP, WorldPay

You cannot use GOV.UK Pay with any other PSPs.

The tech docs must be amended to reflect that you cannot BYO contract with a non Stripe or non Worldpay PSP to GOV.UK Pay.

### Changes proposed in this pull request

Clarify that you must use either the Stripe or Worldpay PSPs with GOV.UK Pay

### Guidance to review

Check that it accurately reflects reality and that nothing is missing.
