### PR TITLE
Clarify moving Worldpay contracts (BYOC redux) 

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -43,22 +43,24 @@ You can still use your test account.
 
 Once you have a GOV.UK Pay live account, you can connect that account to your PSP.
 
-### Connect your live account to Stripe or Government Banking's PSP
+### Connect your live account to GOV.UK Pay's or Government Banking's PSP
 
 You can use either of the following PSPs with GOV.UK Pay:
 
-- GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
+- GOV.UK Pay's contracted PSP, which is currently [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
 - if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
-If you use Government Banking's contracted PSP, and Government Banking decides to change the contract, we will work with you to move you on to the new PSP.
-
-From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking.
+If either GOV.UK Pay's or Government Banking's contracted PSP changes, we will work with you to move you on to the new PSP.
 
 ### Connect your live account to other PSPs
 
-From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not Stripe or Government Banking's contracted PSP.
+From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not GOV.UK's contracted PSP or Government Banking's contracted PSP.
 
-If you agreed with GOV.UK Pay before 1 August 2020 to use either [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) or [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay), you can connect your live account to that PSP.
+If you already had a live GOV.UK Pay account using any of the following PSPs before 1 August 2020, you can continue to use that PSP with your live account until 31 July 2021:
+
+- [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
+- [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
+- [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
 
 ## 3. Set up 3D Secure
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -56,11 +56,12 @@ If either GOV.UK Pay's or Government Banking's contracted PSP changes, we will w
 
 From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not GOV.UK's contracted PSP or Government Banking's contracted PSP.
 
-If you already had a live GOV.UK Pay account using any of the following PSPs before 1 August 2020, you can continue to use that PSP with your live account until 31 July 2021:
+If you already had at least one live GOV.UK Pay account using any of the following PSPs before 1 August 2020, you can continue to use that PSP with both pre-existing and new live account(s) until 31 July 2021:
 
 - [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 - [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
 - [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
+
 
 ## 3. Set up 3D Secure
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -41,11 +41,13 @@ You can still use your test account.
 
 ## 2. Connect your live account to your PSP
 
+## 2. Connect your live account to your PSP
+
 Once you have a GOV.UK Pay live account, you can connect that account to your PSP.
 
 ### Connect your live account to GOV.UK Pay's or Government Banking's PSP
 
-You can use either of the following PSPs with GOV.UK Pay:
+From 1 August 2020, you must connect your live GOV.UK Pay account to either of the following PSPs:
 
 - GOV.UK Pay's contracted PSP, which is currently [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
 - if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
@@ -54,14 +56,11 @@ If either GOV.UK Pay's or Government Banking's contracted PSP changes, we will w
 
 ### Connect your live account to other PSPs
 
-From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not GOV.UK's contracted PSP or Government Banking's contracted PSP.
-
-If you already had at least one live GOV.UK Pay account using any of the following PSPs before 1 August 2020, you can continue to use that PSP with both pre-existing and new live account(s) until 31 July 2021:
+If you already had at least one live GOV.UK Pay account connected to any of the following PSPs before 1 August 2020, you can continue to connect your pre-existing and new live account(s) to that PSP until 31 July 2021:
 
 - [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 - [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
 - [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
-
 
 ## 3. Set up 3D Secure
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -41,14 +41,22 @@ You can still use your test account.
 
 ## 2. Connect your live account to your PSP
 
-Once you have a GOV.UK Pay live account, you can connect that account to your PSP. You can use either of the following PSPs with GOV.UK Pay:
+Once you have a GOV.UK Pay live account, you can connect that account to your PSP.
+
+### Connect your live account to Stripe or Government Banking's PSP
+
+You can use either of the following PSPs with GOV.UK Pay:
 
 - GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
 - if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
 If you use Government Banking's contracted PSP, and Government Banking decides to change the contract, we will work with you to move you on to the new PSP.
 
-From 1 August 2020, you cannot use GOV.UK Pay with any other PSPs.
+From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking. You must end this direct Worldpay contract and open a new contract through Government Banking.
+
+### Connect your live account to other PSPs
+
+From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not Stripe or Government Banking's contracted PSP.
 
 If you agreed with GOV.UK Pay before 1 August 2020 to use either [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) or [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay), you can connect your live account to that PSP.
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -52,7 +52,7 @@ You can use either of the following PSPs with GOV.UK Pay:
 
 If you use Government Banking's contracted PSP, and Government Banking decides to change the contract, we will work with you to move you on to the new PSP.
 
-From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking. You must end this direct Worldpay contract and open a new contract through Government Banking.
+From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking.
 
 ### Connect your live account to other PSPs
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -41,26 +41,18 @@ You can still use your test account.
 
 ## 2. Connect your live account to your PSP
 
-## 2. Connect your live account to your PSP
+Once you have a GOV.UK Pay live account, you can connect that account to your payment service provider (PSP).
 
-Once you have a GOV.UK Pay live account, you can connect that account to your PSP.
+You can connect your live account to:
 
-### Connect your live account to GOV.UK Pay's or Government Banking's PSP
+- [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe), GOV.UK Pay's current PSP
+- [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay), Government Banking's current PSP - if you're a central government or health sector organisation
+- [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) if you connected another live account to ePDQ before 1 August 2020
+- [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay) if you connected another live account to SmartPay before 1 August 2020
 
-From 1 August 2020, you must connect your live GOV.UK Pay account to either of the following PSPs:
+You will no longer be able to connect live accounts to ePDQ and SmartPay after 31 July 2021.
 
-- GOV.UK Pay's contracted PSP, which is currently [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
-
-If either GOV.UK Pay's or Government Banking's contracted PSP changes, we will work with you to move you on to the new PSP.
-
-### Connect your live account to other PSPs
-
-If you already had at least one live GOV.UK Pay account connected to any of the following PSPs before 1 August 2020, you can continue to connect your pre-existing and new live account(s) to that PSP until 31 July 2021:
-
-- [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
-- [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
-- [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
+If either GOV.UK Pay's or Government Banking's PSP changes, we'll work with you to move you to the new PSP.
 
 ## 3. Set up 3D Secure
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -9,7 +9,8 @@ This is part of [going live](/switching_to_live/#go-live).
 
 From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
-If you already had a live GOV.UK Pay account using ePDQ before 1 August 2020, you can continue to use ePDQ with your live account until 31 July 2021.
+If you already had at least one live GOV.UK Pay account using ePDQ before 1 August 2020, you can continue to use ePDQ with both pre-existing and new live account(s) until 31 July 2021.
+
 
 To connect your live account to ePDQ, you must be an admin on both your:
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -7,17 +7,14 @@ weight: 163
 
 This is part of [going live](/switching_to_live/#go-live).
 
-You can only connect your live account to ePDQ if you agreed with GOV.UK Pay before 1 August 2020 to use ePDQ.
+From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+
+If you already had a live GOV.UK Pay account using ePDQ before 1 August 2020, you can continue to use ePDQ with your live account until 31 July 2021.
 
 To connect your live account to ePDQ, you must be an admin on both your:
 
 - GOV.UK Pay account
 - ePDQ account
-
-If you did not agree with GOV.UK Pay before 1 August 2020 to use ePDQ, you must use one of the following PSPs with GOV.UK Pay:
-
-- GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
 ## Add payment methods to your account
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 163
 
 This is part of [going live](/switching_to_live/#go-live).
 
-From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
 If you already had a live GOV.UK Pay account using ePDQ before 1 August 2020, you can continue to use ePDQ with your live account until 31 July 2021.
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -7,10 +7,9 @@ weight: 163
 
 This is part of [going live](/switching_to_live/#go-live).
 
-From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+From 1 August 2020, you must connect your live GOV.UK Pay account to either [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
-If you already had at least one live GOV.UK Pay account using ePDQ before 1 August 2020, you can continue to use ePDQ with both pre-existing and new live account(s) until 31 July 2021.
-
+An exception to this is if you connected at least one live GOV.UK Pay account to ePDQ before 1 August 2020. If so, you can continue to connect both pre-existing and new live account(s) to ePDQ until 31 July 2021.
 
 To connect your live account to ePDQ, you must be an admin on both your:
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -7,14 +7,12 @@ weight: 163
 
 This is part of [going live](/switching_to_live/#go-live).
 
-From 1 August 2020, you must connect your live GOV.UK Pay account to either [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+To connect your live account to ePDQ, you must:
 
-An exception to this is if you connected at least one live GOV.UK Pay account to ePDQ before 1 August 2020. If so, you can continue to connect both pre-existing and new live account(s) to ePDQ until 31 July 2021.
+- have already connected at least one live GOV.UK account to ePDQ before 1 August 2020
+- be an admin on both your GOV.UK Pay and ePDQ accounts
 
-To connect your live account to ePDQ, you must be an admin on both your:
-
-- GOV.UK Pay account
-- ePDQ account
+If you do not meet these requirements, you must connect your live GOV.UK Pay account to either [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
 ## Add payment methods to your account
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -7,14 +7,11 @@ weight: 164
 
 This is part of [going live](/switching_to_live/#go-live).
 
-You can only connect your live account to SmartPay if you agreed with GOV.UK Pay before 1 August 2020 to use SmartPay.
+From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+
+If you already had a live GOV.UK Pay account using SmartPay before 1 August 2020, you can continue to use SmartPay with your live account until 31 July 2021:
 
 You must be an admin on your GOV.UK Pay account to connect your live account to SmartPay.
-
-If you did not agree with GOV.UK Pay before 1 August 2020 to use SmartPay, you must use one of the following PSPs with GOV.UK Pay:
-
-- GOV.UK Pay's PSP, [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe)
-- if you are a central government or health sector organisation, Government Banking's contracted PSP, which is currently [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay)
 
 ## Configure your user profile on SmartPay
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 164
 
 This is part of [going live](/switching_to_live/#go-live).
 
-From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](.uk/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
 If you already had a live GOV.UK Pay account using SmartPay before 1 August 2020, you can continue to use SmartPay with your live account until 31 July 2021:
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -9,7 +9,7 @@ This is part of [going live](/switching_to_live/#go-live).
 
 From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
-If you already had a live GOV.UK Pay account using SmartPay before 1 August 2020, you can continue to use SmartPay with your live account until 31 July 2021:
+If you already had at least one live GOV.UK Pay account using SmartPay before 1 August 2020, you can continue to use SmartPay with both pre-existing and new live account(s) until 31 July 2021.
 
 You must be an admin on your GOV.UK Pay account to connect your live account to SmartPay.
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -7,9 +7,9 @@ weight: 164
 
 This is part of [going live](/switching_to_live/#go-live).
 
-From 1 August 2020, you cannot use GOV.UK Pay with PSPs that are not [GOV.UK's contracted PSP](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+From 1 August 2020, you must connect your live GOV.UK Pay account to either [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
-If you already had at least one live GOV.UK Pay account using SmartPay before 1 August 2020, you can continue to use SmartPay with both pre-existing and new live account(s) until 31 July 2021.
+An exception to this is if you connected at least one live GOV.UK Pay account to SmartPay before 1 August 2020. If so, you can continue to connect both pre-existing and new live account(s) to SmartPay until 31 July 2021.
 
 You must be an admin on your GOV.UK Pay account to connect your live account to SmartPay.
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -7,11 +7,12 @@ weight: 164
 
 This is part of [going live](/switching_to_live/#go-live).
 
-From 1 August 2020, you must connect your live GOV.UK Pay account to either [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+To connect your live account to SmartPay, you must:
 
-An exception to this is if you connected at least one live GOV.UK Pay account to SmartPay before 1 August 2020. If so, you can continue to connect both pre-existing and new live account(s) to SmartPay until 31 July 2021.
+- have already connected at least one live GOV.UK account to SmartPay before 1 August 2020
+- be an admin on your GOV.UK Pay account
 
-You must be an admin on your GOV.UK Pay account to connect your live account to SmartPay.
+If you do not meet these requirements, you must connect your live GOV.UK Pay account to either [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
 
 ## Configure your user profile on SmartPay
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 161
 
 This is part of [going live](/switching_to_live/#go-live).
 
-Stripe is GOV.UK Pay's payment service provider (PSP).
+Stripe is GOV.UK Pay's contracted payment service provider (PSP).
 
 After you request a live GOV.UK Pay account, we'll contact you to verify your organisation’s identity.
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -7,7 +7,9 @@ weight: 161
 
 This is part of [going live](/switching_to_live/#go-live).
 
-Stripe is GOV.UK Pay's contracted payment service provider (PSP).
+From 1 August 2020, you must connect your live GOV.UK Pay account to either GOV.UK's contracted payment service provider (PSP) or [Government Banking's contracted PSP](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+
+Stripe is GOV.UK Pay's contracted PSP.
 
 After you request a live GOV.UK Pay account, we'll contact you to verify your organisation’s identity.
 

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -9,6 +9,8 @@ This is part of [going live](/switching_to_live/#go-live).
 
 Government Banking's contracted payment service provider (PSP) is currently Worldpay. You must be a central government or health sector organisation to use Government Banking's contracted PSP.
 
+From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking. You must end this direct Worldpay contract and open a new contract through Government Banking.
+
 You must be an admin on your GOV.UK Pay account to connect to Worldpay.
 
 ## Check your Worldpay account

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -7,6 +7,8 @@ weight: 162
 
 This is part of [going live](/switching_to_live/#go-live).
 
+From 1 August 2020, you must connect your live GOV.UK Pay account either the [GOV.UK's contracted payment service provider (PSP)](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe) or Government Banking's contracted PSP.
+
 Government Banking's contracted payment service provider (PSP) is currently Worldpay. You must be a central government or health sector organisation to use Government Banking's contracted PSP.
 
 You must be an admin on your GOV.UK Pay account to connect to Worldpay.

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -9,7 +9,7 @@ This is part of [going live](/switching_to_live/#go-live).
 
 Government Banking's contracted payment service provider (PSP) is currently Worldpay. You must be a central government or health sector organisation to use Government Banking's contracted PSP.
 
-From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking. You must end this direct Worldpay contract and open a new contract through Government Banking.
+From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking.
 
 You must be an admin on your GOV.UK Pay account to connect to Worldpay.
 

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -9,8 +9,6 @@ This is part of [going live](/switching_to_live/#go-live).
 
 Government Banking's contracted payment service provider (PSP) is currently Worldpay. You must be a central government or health sector organisation to use Government Banking's contracted PSP.
 
-From 1 August 2020, if you are a central government or health sector organisation and have a direct contract with Worldpay that is not through Government Banking, you cannot move this contract over to Government Banking.
-
 You must be an admin on your GOV.UK Pay account to connect to Worldpay.
 
 ## Check your Worldpay account


### PR DESCRIPTION
### Context

Need to clarify that you cannot move an existing direct Worldpay contract over to Government Banking.

### Changes proposed in this pull request

- Clarify that you cannot move an existing direct Worldpay contract over to Government Banking
- Split out Stripe / Govt Banking vs others

### Guidance to review

Check if accurate
