### PR TITLE
Fact check a thon - Quick Start Guide

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -43,7 +43,7 @@ You'll be able to generate API keys for 2 different accounts. These are your:
 - test account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
 - live account, for taking payments from your users after you [switch to live](/switching_to_live)
 
-When you've received a test account, follow these instructions to get started
+When you've signed up for a test account, follow these instructions to get started
 with our API and make a test API call.
 
 ## Test the API
@@ -58,7 +58,7 @@ with our API and make a test API call.
 
 Make sure you [keep your API keys safe](/security/#securing-your-developer-keys).
 
-<%= warning_text('Do not use an API key from a live account on the GOV.UK Pay admin tool. Only use a test API key.') %>
+<%= warning_text('Only use a test API key on your test account. Do not use a live API key on your test account.') %>
 
 ### Make a test API call
 
@@ -108,3 +108,5 @@ Submit the payment.
 
 Sign in to the [GOV.UK Pay admin
 tool](https://selfservice.payments.service.gov.uk/) and select __Transactions__.
+
+You can also view test transactions using the API.


### PR DESCRIPTION
### Context

The fact check a thon checked the accuracy of the different tech docs pages.

### Changes proposed in this pull request

Clarify the following:

- 'when you've received a test account' means when you have signed up to a test account or joined the service.
- "Do not use an API key from a live account on the GOV.UK Pay admin tool. Only use a test API key." means "Do not use an API from a live account to test Pay."
- you can view test transactions in the API

### Guidance to review
