### PR TITLE
Fact check a thon - reporting

### DIFF
--- a/source/custom_metadata/index.html.md.erb
+++ b/source/custom_metadata/index.html.md.erb
@@ -48,7 +48,7 @@ href="https://govukpay-api-browser.cloudapps.digital/#newpayment" target="blank"
 
 ## Getting a payment's metadata
 
-When you [get information about a single payment](/reporting/#get-information-about-a-single-payment) or [generate a list of payments](/reporting/#generate-a-list-of-payments-search-payments), the API response will include the `metadata` object.
+When you [get information about a single payment](/reporting/#get-information-about-a-single-payment) or [generate a list of payments](/reporting/#search-payments), the API response will include the `metadata` object.
 
 The order of the parameters in the `metadata` object may be different to your original object.
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -52,7 +52,7 @@ using the API.
 
 For example, you could automatically fetch data about the outcome of payment journeys. You could import that into your finance system so payments can be reconciled against bank transaction information.
 
-If you [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) at the end of each day, you should run the search at least one hour after your `to_date`. This is because the API may not return up-to-date information about payment events from the last hour.
+If you [search payments using the API](/reporting/#search-payments) at the end of each day, you should run the search at least one hour after your `to_date`. This is because the API may not return up-to-date information about payment events from the last hour.
 
 To help you reconcile payments, you can:
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -273,7 +273,7 @@ To check the status of a payment, you must make an API call to either:
 - [get information about a single payment](/reporting/#get-information-about-a-single-payment)
 - [get events for a payment](/reporting/#get-a-payment-s-events)
 
-Do not [search payments using the API](/reporting/#generate-a-list-of-payments-search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
+Do not [search payments using the API](/reporting/#search-payments) to check the status of a payment. Search results are asynchronous so the payment status may not be up-to-date.
 
 The response body contains information about the payment in JSON
 format. The following is the start of a typical response:

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -183,9 +183,9 @@ For example:
 
 `GET /v1/payments`
 
-See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details
+See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details.
 
-Do not search payments using the API to check a payment's status during [payment flow](/payment_flow). The payment status field in search results is not up to date may not be up-to-date.
+Do not search payments using the API to check a payment's status during [payment flow](/payment_flow). The payment status field in the search results does not immediately update and so may not be up to date.
 
 ### Search criteria
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -19,24 +19,21 @@ transaction information in a CSV file.
 
 You can export one file for one service's transactions, or one file for all your services' transactions.
 
-### Export one file for one service's transactions
+1. Go to [My Services](https://selfservice.payments.service.gov.uk/my-services).
 
-1. Select the account you want reporting information for in the [My Services](https://selfservice.payments.service.gov.uk/my-services) section.
+1. If you want to export one service's transactions, select the service account you want reporting information for and go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
 
-2. Go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
+    Select __View transactions for all live services__ if you want to export all your services' transactions.
 
-3. Filter transactions using the available search criteria.
+1. Filter transactions using the available search criteria if needed.
 
-4. Select __Download all transaction details as a CSV file__.
+    If you have more than 5000 transactions, you must apply a filter before the page will display your transactions.
 
-The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page. You can process CSV files using
-spreadsheet software and edit the contents you do not need.
+1. Select __Download all transaction details as a CSV file__.
 
-You can export up to 100,000 transactions.
+The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page.
 
-### Export one file for all services' transactions
-
-TBC
+You can process CSV files using spreadsheet software and edit the contents you do not need.
 
 ## Reporting via the GOV.UK Pay API
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -17,7 +17,7 @@ You can use your [GOV.UK Pay admin
 account](https://selfservice.payments.service.gov.uk/login) to export
 transaction information in a CSV file.
 
-1. Select the account you want reporting information for in the [My Service](https://selfservice.payments.service.gov.uk/my-services) section.
+1. Select the account you want reporting information for in the [My Services](https://selfservice.payments.service.gov.uk/my-services) section.
 
 2. Go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
 
@@ -44,11 +44,12 @@ lead to significant cost savings for your organisation.
 You can use the GOV.UK Pay API to:
 
 * get information about a single payment
+* get a payment's events
 * generate a list of payments matching search criteria
 
 ## Get information about a single payment
 
-`GET /v1/payments/paymentId`
+`GET /v1/payments/{paymentId}`
 
 See the <a href="https://govukpay-api-browser.cloudapps.digital/#getpayment" target="blank">GOV.UK Pay API browser</a> for more details
 
@@ -142,7 +143,7 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 Use the following API call to get a list of a payment’s events:
 
-`GET /v1/payments/paymentId/events`
+`GET /v1/payments/{paymentId}/events`
 
 The API will respond with an `events` object. For each change to the payment's state, the `events` object includes:
 
@@ -178,13 +179,13 @@ For example:
 }
 ```
 
-## Generate a list of payments (search payments)
+## Search payments
 
 `GET /v1/payments`
 
 See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details
 
-Do not search payments using the API to check a payment's status during [payment flow](/payment_flow). Search results are asynchronous so the payment status may not be up-to-date.
+Do not search payments using the API to check a payment's status during [payment flow](/payment_flow). The payment status field in search results is not up to date may not be up-to-date.
 
 ### Search criteria
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -27,9 +27,9 @@ You can export one file for one service's transactions, or one file for all your
 
 1. Filter transactions using the available search criteria if needed.
 
-    If you have more than 5000 transactions, you must apply a filter before the page will display your transactions.
-
 1. Select __Download all transaction details as a CSV file__.
+
+    If you have more than 5000 transactions, you must apply a filter before the CSV file download link appears. 
 
 The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 60
 
 # Report on a payment
 
-You can extract reporting information from GOV.UK Pay manually or via the
+You can extract reporting information from GOV.UK Pay manually or through the
 API, for each service you have set up in GOV.UK Pay.
 
 You can also read about [refunding payments](/refunding_payments/), including
@@ -29,6 +29,8 @@ The CSV file contains all transaction data, which is much more comprehensive tha
 spreadsheet software and edit the contents you do not need.
 
 You can export up to 100,000 transactions.
+
+You can export one file for one service's transactions, or one file for all your services' transactions.
 
 ## Reporting via the GOV.UK Pay API
 
@@ -96,12 +98,12 @@ The `card_type` is `null` if we did not recognise which type of card your user m
 
 ### Checking when your Payment Service Provider (PSP) took a payment
 
-If your PSP is Worldpay, you can see when Worldpay took a payment from your user's account.
+You can see when your PSP took a payment from your user's account.
 
 The response contains:
 
-- `capture_submit_time` if we've asked Worldpay to take the payment from your user's account
-- `captured_date` if Worldpay has taken the payment
+- `capture_submit_time` if we've asked your PSP to take the payment from your user's account
+- `captured_date` if your PSP has taken the payment
 
 For example:
 
@@ -112,7 +114,12 @@ For example:
 }
 ```
 
-You should receive the payment in your bank account within 2 business days of `captured_date`.
+If your PSP is Stripe, you should receive the payment in your bank account within:
+
+- 2 working days of `captured_date` if your user completed their payment during the week
+- 3 working days of `captured_date` if your user completed their payment at the weekend or on a bank holiday
+
+If your PSP is Government Banking’s contracted PSP (currently Worldpay), SmartPay or ePDQ, you should receive the payment in your bank account within 2 working days of `captured_date`.
 
 ### PSP fees
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -17,6 +17,10 @@ You can use your [GOV.UK Pay admin
 account](https://selfservice.payments.service.gov.uk/login) to export
 transaction information in a CSV file.
 
+You can export one file for one service's transactions, or one file for all your services' transactions.
+
+### Export one file for one service's transactions
+
 1. Select the account you want reporting information for in the [My Services](https://selfservice.payments.service.gov.uk/my-services) section.
 
 2. Go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
@@ -30,7 +34,9 @@ spreadsheet software and edit the contents you do not need.
 
 You can export up to 100,000 transactions.
 
-You can export one file for one service's transactions, or one file for all your services' transactions.
+### Export one file for all services' transactions
+
+TBC
 
 ## Reporting via the GOV.UK Pay API
 
@@ -118,6 +124,8 @@ If your PSP is Stripe, you should receive the payment in your bank account withi
 
 - 2 working days of `captured_date` if your user completed their payment during the week
 - 3 working days of `captured_date` if your user completed their payment at the weekend or on a bank holiday
+
+You can confirm when payments are paid into your bank account by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and going to __My Services__ > __View payments to your bank account__.
 
 If your PSP is Government Banking’s contracted PSP (currently Worldpay), SmartPay or ePDQ, you should receive the payment in your bank account within 2 working days of `captured_date`.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -29,7 +29,7 @@ You can export one file for one service's transactions, or one file for all your
 
 1. Select __Download all transaction details as a CSV file__.
 
-    If you have more than 5000 transactions, you must apply a filter before the CSV file download link appears. 
+    If you have more than 5000 transactions, you must apply a filter before the CSV file download link appears.
 
 The CSV file contains all transaction data, which is much more comprehensive than the information on the __Transactions__ page.
 
@@ -124,7 +124,7 @@ If your PSP is Stripe, you should receive the payment in your bank account withi
 
 You can confirm when payments are paid into your bank account by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and going to __My Services__ > __View payments to your bank account__.
 
-If your PSP is Government Banking’s contracted PSP (currently Worldpay), SmartPay or ePDQ, you should receive the payment in your bank account within 2 working days of `captured_date`.
+If your PSP is Government Banking’s contracted PSP (currently Worldpay), SmartPay or ePDQ, contact your PSP to find out your payment times.
 
 ### PSP fees
 


### PR DESCRIPTION
### Context


### Changes proposed in this pull request

My service should be My services 

consider /v1/payments/{paymentId} to indicate variable more clearly (and likewise throughout) 

In text we note two things you may want to do (get a single payment, search for multiple payments), but we have sections corresponding to 3 things (<- + get payment events) 

https://docs.payments.service.gov.uk/reporting/#checking-when-your-payment-service-provider-psp-took-a-payment is a bit unclear. We store captured date for PSPs other than worldpay (stripe), and it may not always be the case that settlement will occur 2 days after capture in those cases. Might need a rethink, and also how this re4lates to payout reporting. 

The sentence 'Search results are asynchronous so the payment status may not be up-to-date.' isn't quite right. The search results aren't asynchronous. I think it would be clearer and more accurate just to say there is a delay in payment statuses in search results being updated (but better than that :)) 

The sentence 'Some of the query parameters you can use to search for payments are:' seems quite vague 

The heading 'Generate a list of payments (search payments)' seems unnecessarily verbose. Can it not just be 'Search payments'? 

Miriam:

can we add that you can download one report for all of your services in Pay as well as individual ones? 

we say that we don't show fees in a test account - but can we give users an example CSV that does include those fields? or say, email us if you want an example?

### Guidance to review
