### PR TITLE
Remove inaccessible and confusing diagram

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -17,11 +17,6 @@ their service with the GOV.UK Pay API. It describes:
 * making sure that all payments are processed
 * integrating with finance and accounting systems
 
-The following diagram shows a typical high-level architecture with a GOV.UK
-Pay integration:
-
-![A typical high-level GOV.UK Pay architecture](/images/typical-architecture.png)
-
 ## Service backend
 
 Your service backend is server-side software. You should build this to:


### PR DESCRIPTION
### Context

Nick F, Rebecca C and I reviewed some tech docs research that Nick and Mark Green carried out in March and April.

One of the things being tested in the docs was the diagram that "shows a typical high-level architecture with a GOV.UK Pay integration" located in https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api. 

The feedback on this diagram was neutral, with some people stating it was helpful and some stating it was confusing (simplifying massively here but you get the idea). 

We checked with @alexbishop1 and @sfount and agreed to remove this diagram.

### Changes proposed in this pull request

Remove first diagram in https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api.

### Guidance to review
