### PR TITLE
Add an accessibility statement for tech docs

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,7 +15,8 @@ header_links:
   Support: https://www.payments.service.gov.uk/support/
   Sign In: https://selfservice.payments.service.gov.uk/login
 footer_links:
-  Accessibility: https://www.payments.service.gov.uk/accessibility-statement/
+  GOV.UK Pay Website Accessibility: https://www.payments.service.gov.uk/accessibility-statement/
+  Technical Documentation Accessibility: /accessibility.html
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 # Removed GA Tracking ID because of ICO compliance. Re-enable when opt-in is enabled ga_tracking_id: UA-72121642-9

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -12,7 +12,7 @@ This accessibility statement applies to the GOV.UK Pay technical documentation a
 This website is run by the GOV.UK Pay team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
 + change colours, contrast levels and fonts
-+ zoom in up to 300% without the text spilling off the screen
++ zoom in up to 300% without problems
 + navigate most of the website using just a keyboard
 + navigate most of the website using speech recognition software
 + listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
@@ -21,27 +21,26 @@ We’ve also made the website text as simple as possible to understand.
 
 [AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
 
-### How accessible this website is
+## How accessible this website is
 
-We know some parts of this website are not fully accessible:
+We know some parts of this website are not fully accessible for the following reasons:
 
-- multiple pages have redundant links
+- some pages have redundant links
 - there are issues caused by our Technical Documentation Template
 
-### Feedback and contact information
+## Feedback and contact information
 
 If you need any part of this service in a different format like large print, audio recording or braille, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-We’ll consider your request and get back to you within 2 working days.
+We’ll aim to get back to you within 3 working days.
 
-### Reporting accessibility problems with this website
+## Reporting accessibility problems with this website
 
 We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-### Enforcement procedure
+## Enforcement procedure
 
-The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
-(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
 
 ## Technical information about this website’s accessibility
 
@@ -57,28 +56,13 @@ The content listed below is non-accessible for the following reasons.
 
 #### Non-compliance with the accessibility regulations
 
-The following pages have redundant links:
+Some pages have redundant links. This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
 
-- [API reference](https://docs.payments.service.gov.uk/api_reference/#api-reference)
-- [Take a Direct Debit payment](https://docs.payments.service.gov.uk/direct_debit/#take-a-direct-debit-payment)
-- [Integrate with the GOV.UK API](https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api)
-- [Take a payment over the phone (‘MOTO’ payments)](https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments)
-- [Add corporate card fees](https://docs.payments.service.gov.uk/corporate_card_surcharges/#add-corporate-card-fees)
-- [Block prepaid cards](https://docs.payments.service.gov.uk/block_prepaid_cards/#block-prepaid-cards)
-- [Go live](https://docs.payments.service.gov.uk/switching_to_live/#go-live)
-- [Connect your live account to ePDQ](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
-- [Connect your live account to Smartpay](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
-- [Support](https://docs.payments.service.gov.uk/support_contact_and_more_information/#support)
-
-This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
-
-Also, some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
-
-We plan to fix the accessibility issues with the Technical Documentation Template by [[date]].
+Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 
 ## How we tested this website
 
-We last tested this website for accessibility issues in May 2020.
+We last tested this website for accessibility issues in August 2020.
 
 We used manual and automated tests to look for issues such as:
 
@@ -95,9 +79,7 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to look at the redundant links by [date].
-
-We plan to fix the accessibility issues with the Technical Documentation Template by [[date]].
+We plan to look at the redundant links and fix the accessibility issues with the Technical Documentation Template by the end of 2020.
 
 ## Preparation of this accessibility statement
 

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -23,24 +23,10 @@ We’ve also made the website text as simple as possible to understand.
 
 ### How accessible this website is
 
-We know some parts of this website are not fully accessible.
+We know some parts of this website are not fully accessible:
 
-The following pages have redundant links:
-
-- [API reference](https://docs.payments.service.gov.uk/api_reference/#api-reference)
-- [Take a Direct Debit payment](https://docs.payments.service.gov.uk/direct_debit/#take-a-direct-debit-payment)
-- [Integrate with the GOV.UK API](https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api)
-- [Take a payment over the phone (‘MOTO’ payments)](https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments)
-- [Add corporate card fees](https://docs.payments.service.gov.uk/corporate_card_surcharges/#add-corporate-card-fees)
-- [Block prepaid cards](https://docs.payments.service.gov.uk/block_prepaid_cards/#block-prepaid-cards)
-- [Go live](https://docs.payments.service.gov.uk/switching_to_live/#go-live)
-- [Connect your live account to ePDQ](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
-- [Connect your live account to Smartpay](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
-- [Support](https://docs.payments.service.gov.uk/support_contact_and_more_information/#support)
-
-This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
-
-Also, some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+- multiple pages have redundant links
+- there are issues caused by our Technical Documentation Template
 
 ### Feedback and contact information
 

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,0 +1,120 @@
+---
+title: Accessibility statement for GOV.UK Pay's technical documentation
+last_reviewed_on: 2020-09-01
+review_in: 6 months
+hide_in_navigation: true
+---
+
+# Accessibility statement for GOV.UK Pay technical documentation
+
+This accessibility statement applies to the GOV.UK Pay technical documentation at [https://docs.payments.service.gov.uk/](https://docs.payments.service.gov.uk/).
+
+This website is run by the GOV.UK Pay team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without the text spilling off the screen
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+### How accessible this website is
+
+We know some parts of this website are not fully accessible.
+
+The following pages have redundant links:
+
+- [API reference](https://docs.payments.service.gov.uk/api_reference/#api-reference)
+- [Take a Direct Debit payment](https://docs.payments.service.gov.uk/direct_debit/#take-a-direct-debit-payment)
+- [Integrate with the GOV.UK API](https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api)
+- [Take a payment over the phone (‘MOTO’ payments)](https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments)
+- [Add corporate card fees](https://docs.payments.service.gov.uk/corporate_card_surcharges/#add-corporate-card-fees)
+- [Block prepaid cards](https://docs.payments.service.gov.uk/block_prepaid_cards/#block-prepaid-cards)
+- [Go live](https://docs.payments.service.gov.uk/switching_to_live/#go-live)
+- [Connect your live account to ePDQ](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
+- [Connect your live account to Smartpay](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
+- [Support](https://docs.payments.service.gov.uk/support_contact_and_more_information/#support)
+
+This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+
+Also, some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+
+### Feedback and contact information
+
+If you need any part of this service in a different format like large print, audio recording or braille, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+
+We’ll consider your request and get back to you within 2 working days.
+
+### Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+The following pages have redundant links:
+
+- [API reference](https://docs.payments.service.gov.uk/api_reference/#api-reference)
+- [Take a Direct Debit payment](https://docs.payments.service.gov.uk/direct_debit/#take-a-direct-debit-payment)
+- [Integrate with the GOV.UK API](https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api)
+- [Take a payment over the phone (‘MOTO’ payments)](https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments)
+- [Add corporate card fees](https://docs.payments.service.gov.uk/corporate_card_surcharges/#add-corporate-card-fees)
+- [Block prepaid cards](https://docs.payments.service.gov.uk/block_prepaid_cards/#block-prepaid-cards)
+- [Go live](https://docs.payments.service.gov.uk/switching_to_live/#go-live)
+- [Connect your live account to ePDQ](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq)
+- [Connect your live account to Smartpay](https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay)
+- [Support](https://docs.payments.service.gov.uk/support_contact_and_more_information/#support)
+
+This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+
+Also, some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+
+We plan to fix the accessibility issues with the Technical Documentation Template by [[date]].
+
+## How we tested this website
+
+We last tested this website for accessibility issues in May 2020.
+
+We used manual and automated tests to look for issues such as:
+
+- lack of keyboard accessibility
+- link text that’s not descriptive
+- non-unique or non-hierarchical headings
+- italics, bold or block capital formatting
+- inaccessible formatting in general
+- inaccessible language
+- inaccessible diagrams or images
+- lack of colour contrast for text, important graphics and controls
+- images not having meaningful alt text
+- problems when using assistive technologies such as screen readers and screen magnifiers
+
+## What we’re doing to improve accessibility
+
+We plan to look at the redundant links by [date].
+
+We plan to fix the accessibility issues with the Technical Documentation Template by [[date]].
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 3 September 2020. It was last reviewed on 3 September 2020.
+
+This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.


### PR DESCRIPTION
### Context

The deadline for publishing an accessibility statement is 23 September 2020. The GOV.UK Pay product pages already have a statement published. The content of the tech docs need an accessibility statement as well. This is separate to the statement on the tech doc template itself, which is being handled as part of a separate project.

### Changes proposed in this pull request

Add an accessibility statement for tech docs. 

### Guidance to review
