### PR TITLE
PP-7067 Update maximum metadata string value length from 50 to 100

### DIFF
--- a/source/custom_metadata/index.html.md.erb
+++ b/source/custom_metadata/index.html.md.erb
@@ -33,7 +33,7 @@ Each parameter key must be a unique case-insensitive string between 1 and 30 cha
 
 The data type of each parameter value must be either a:
 
-- string of no more than 50 characters
+- string of no more than 100 characters
 - number
 - boolean
 


### PR DESCRIPTION
For payment metadata, we now support string values of up to 100 characters (previous was 50).