### PR TITLE
Add new site verification code

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -32,7 +32,7 @@ max_toc_heading_level: 2
 
 # Prevent robots from indexing (e.g. whilst in development)
 
-google_site_verification: "IJ5HOXpZrISM6la-YO_iX0rBUC5YFftpexygcKLsNs4"
+google_site_verification: "fpG7nQ9scRuh8l7qZRseYZtqeBNssVVACROgQ7sq-CE"
 
 redirects:
   /switching_to_live/before_you_switch_to_live/index.html: /switching_to_live/index.html


### PR DESCRIPTION
### Context
In order to see search queries for the tech docs, we needed to verify that we had ownership of the domain.

### Changes proposed in this pull request
This pull request adds a new verification code that allows us to gain access to Search Console data for the tech docs and add accounts for other members of the team.

### Guidance to review
