### PR TITLE
Logos can go on the right

### DIFF
--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -15,7 +15,7 @@ You can [contact the GOV.UK Pay
 team](/support_contact_and_more_information/#contact-us) to request
 customisation for the following features:
 
-* the logo displayed in the left-hand side of the top banner
+* the logo displayed in the left-hand or right-hand side of the top banner
 * the background and border colour of the top banner
 * the branding of your payment confirmation email
 


### PR DESCRIPTION
### Context
The docs currently suggest custom branding logos can only go on the left of the header, which is incorrect

### Changes proposed in this pull request
Added the ability to put the logo on the right-hand side for custom branding

### Guidance to review
