### PR TITLE
Remove inaccessible diagrams

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -77,7 +77,7 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> submitted </td>
-    <td> Your user has submitted payment details, and gone through 3D Secure.<br>The PSP has authorised the payment, but the user has not yet selected <b>Confirm</b>. </td>
+    <td> Your user has submitted payment details, and gone through authentication if required.<br>The PSP has authorised the payment, but the user has not yet selected <b>Confirm</b>. </td>
     <td> false </td>
   </tr>
   <tr>
@@ -87,7 +87,7 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> success </td>
-    <td> Your user successfully completed the payment by selecting <b>Confirm</b>. <br>The user is redirected to an appropriate payment confirmation page on your service.</td>
+    <td> Your user successfully completed the payment by selecting <b>Confirm</b>. <br>The user is redirected to an appropriate payment confirmation page.</td>
     <td> true </td>
   </tr>
   <tr>

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -50,10 +50,8 @@ Authorization: Bearer <YOUR-API-KEY-HERE>
 
 ## Payment status lifecycle
 
-The following diagram gives an overview of the payment status lifecycle and the
-possible outcomes, excluding for delayed capture payments:
+The following table summarises the payment status lifecycle and the possible outcomes, excluding for delayed capture payments.
 
-<%= image_tag "/images/payment-states.svg", { :alt => '' } %>
 
 You can check the status of a payment using the <a
 href="https://govukpay-api-browser.cloudapps.digital/#get-a-payment"
@@ -69,7 +67,7 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> created </td>
-    <td> Payment created. Your user has not yet visited <code>next_url</code>. </td>
+    <td> Payment created using the API. Your user has not yet visited <code>next_url</code>. </td>
     <td> false </td>
   </tr>
   <tr>
@@ -79,22 +77,22 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> submitted </td>
-    <td> Your user has submitted payment details but has not yet selected <b>Confirm</b>. </td>
+    <td> Your user has submitted payment details, and gone through 3D Secure.<br>The PSP has authorised the payment, but the user has not yet selected <b>Confirm</b>. </td>
     <td> false </td>
   </tr>
   <tr>
     <td> capturable </td>
-    <td> The payment is a [delayed capture](/delayed_capture/#delay-taking-a-payment), and your user has submitted payment details and selected <b>Confirm</b>. </td>
+    <td> The payment is a <a href="/delayed_capture/#delay-taking-a-payment" target="blank">delayed capture</a>, and your user has submitted payment details and selected <b>Confirm</b>. </td>
     <td> false </td>
   </tr>
   <tr>
     <td> success </td>
-    <td> Your user successfully completed the payment. </td>
+    <td> Your user successfully completed the payment by selecting <b>Confirm</b>. <br>The user is redirected to an appropriate payment confirmation page on your service.</td>
     <td> true </td>
   </tr>
   <tr>
     <td> failed </td>
-    <td> Your user attempted to make a payment but the payment did not complete. </td>
+    <td> Your user attempted to make a payment but the payment did not complete. <br>GOV.UK Pay shows an appropriate screen for the failure.<br>Check the <a href="#errors-caused-by-payment-statuses">payment status error code</a> for more information.</td>
     <td> true </td>
   </tr>
   <tr>
@@ -104,7 +102,7 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> error </td>
-    <td> Something went wrong with GOV.UK Pay or the underlying payment service provider. <a href="/support_contact_and_more_information/#contact-us">Contact us.</a> </td>
+    <td> Something went wrong with GOV.UK Pay or the underlying payment service provider. Payment fails safely with no money taken. <a href="/support_contact_and_more_information/#contact-us">Contact us.</a> </td>
     <td> true </td>
   </tr>
 </table>

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -102,7 +102,8 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
   <tr>
     <td> error </td>
-    <td> Something went wrong with GOV.UK Pay or the underlying payment service provider. Payment fails safely with no money taken. <a href="/support_contact_and_more_information/#contact-us">Contact us.</a> </td>
+    <td> Something went wrong with GOV.UK Pay or the underlying payment service provider. Payment fails safely with no money taken. <br><br>
+      The user will see a screen stating "We're experiencing technical problems. No money has been taken from your account. Cancel and go back to try the payment again."
     <td> true </td>
   </tr>
 </table>

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -16,7 +16,7 @@ There's a different process for [taking Direct Debit payments](/direct_debit/#ta
 The following payment process is for a service that is integrated with the GOV.UK Pay API.
 
 1. When your user needs to make a payment, your service makes an API call to create a new payment.
-1. Your service then redirect your use to the payment pages hosted on GOV.UK Pay.
+1. Your service then redirects your use to the payment pages hosted on GOV.UK Pay.
 1. Your user enters their payment information (for example, payment card details and billing address) on the GOV.UK Pay pages.
 1. GOV.UK Pay verifies the payment with the underlying payment service provider (PSP).
 1. After the transaction reaches a final state, GOV.UK Pay redirects your user back to your service.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -13,25 +13,13 @@ There's a different process for [taking Direct Debit payments](/direct_debit/#ta
 
 ## Overview
 
-The following diagram outlines the payment process for a service that has a GOV.UK Pay
-integration:
+The following payment process is for a service that is integrated with the GOV.UK Pay API.
 
-<%= image_tag "/images/card-payment-process.png", { :alt => 'Diagram showing the payment process for a service that has a GOV.UK Pay
-integration' } %>
-
-The diagram shows the relationship between GOV.UK Pay, payment service providers
-(PSPs) and issuing banks.
-
-When your user needs to make a payment, your service makes an API call to
-create a new payment, then redirects your user to the payment pages hosted on
-GOV.UK Pay.
-
-Your user enters their payment details (for example payment card
-details and billing address) on the GOV.UK Pay pages. GOV.UK Pay verifies the
-payment with the underlying PSP.
-
-After the transaction reaches a final state, your user is then redirected
-back to your service.
+1. When your user needs to make a payment, your service makes an API call to create a new payment.
+1. Your service then redirect your use to the payment pages hosted on GOV.UK Pay.
+1. Your user enters their payment information (for example, payment card details and billing address) on the GOV.UK Pay pages.
+1. GOV.UK Pay verifies the payment with the underlying payment service provider (PSP).
+1. After the transaction reaches a final state, GOV.UK Pay redirects your user back to your service.
 
 A final state means that the payment:
 
@@ -42,8 +30,7 @@ A final state means that the payment:
 * fails because it is cancelled by your service
 * expires - your user has 90 minutes to complete a payment once it's created
 
-When your user arrives back at your service, you can use the API to check the
-status of the transaction and show them an appropriate message.
+When your user arrives back at your service, you can use the API to check the status of the transaction and show them an appropriate message.
 
 ## Making a payment
 


### PR DESCRIPTION
As part of the 2020 accessibility work, we should remove the following two diagrams from the tech docs as they are not accessible (use colour to denote meaning, not an svg format, alt text, not clear, not necessary):

- https://docs.payments.service.gov.uk/api_reference/#payment-status-lifecycle
- https://docs.payments.service.gov.uk/payment_flow/#overview

The payment flow overview diagram is already described in the body text so does not need any further changes.

The payment status lifecycle diagram needs to be described in the body text so this ticket will encompass that work.