### PR TITLE
A11y fixes - Remove redundant links and alt text

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -20,9 +20,9 @@ As an example, take 2 services called ‘parking permits’ and ‘parking fines
 
 ### Type 1 (GOV.UK Pay separate, PSP separate)
 
-<%= image_tag "/images/accountstructure_1.svg", { :alt => 'A flow diagram showing two GOV.UK Pay services that are completely separated within GOV.UK Pay and the Payment Service Provider' } %>
+<%= image_tag "/images/accountstructure_1.svg", { :alt => '' } %>
 
-‘Parking permits’ and ‘Parking fines’ are considered separate services by
+The diagram show two services, ‘Parking permits’ and ‘Parking fines’, that are considered separate services by
 both GOV.UK Pay and the PSP.
 
 If you use this account structure, you can:
@@ -34,9 +34,9 @@ If you use this account structure, you can:
 
 ### Type 2 (GOV.UK Pay combined, PSP combined)
 
-<%= image_tag "/images/accountstructure_2.svg", { :alt => 'A flow diagram showing two GOV.UK Pay services that are treated as a single combined service by GOV.UK Pay and the Payment Service Provider' } %>
+<%= image_tag "/images/accountstructure_2.svg", { :alt => '' } %>
 
-‘Parking permits’ and ‘Parking fines’ are considered a single combined
+The diagram shows two services, ‘Parking permits’ and ‘Parking fines’, that are considered a single combined
 service by GOV.UK Pay and the PSP.
 
 You may want to use this configuration if you want to simplify the administration of multiple services in GOV.UK Pay. For example, if you do not need reporting at an individual service level.
@@ -48,9 +48,9 @@ they are a single service in the PSP. It is not possible to support multiple PSP
 
 ### Type 3 (GOV.UK Pay separate, PSP combined)
 
-<%= image_tag "/images/accountstructure_3.svg", { :alt => 'A flow diagram showing two GOV.UK Pay services that are treated as separate services by GOV.UK Pay and a single combined service by the Payment Service Provider' } %>
+<%= image_tag "/images/accountstructure_3.svg", { :alt => '' } %>
 
-‘Parking permits’ and ‘Parking fines’ are considered separate services by
+The diagram shows two services, ‘Parking permits’ and ‘Parking fines’, that are considered separate services by
 GOV.UK Pay and as a single combined service in the PSP.
 
 You may want to use this configuration if you want to administrate multiple

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -151,37 +151,37 @@ Common status codes are:
 | Create payment | P0102 | Invalid attribute value | The value of an attribute you sent is invalid. |
 | Create payment | P0196 | MOTO payments not allowed | Contact us about [setting up your service for Mail Order / Telephone Order (MOTO) payments](/moto_payments/#take-a-payment-over-the-phone-moto-payments).|
 | Create payment | P0197 | Unable to parse JSON | The JSON you sent in the request body is invalid.|
-| Create payment | P0198 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
-| Create payment | P0199 | Account error | There is a problem with your service account. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Create payment | P0198 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
+| Create payment | P0199 | Account error | There is a problem with your service account. Contact us, quoting the error code. |
 | Find payment by ID | P0200 | `paymentId` not found | No payment matched the `paymentId` you provided. |
-| Find payment by ID | P0298 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Find payment by ID | P0298 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Return payment events by ID | P0300 | `paymentId` not found | No payment matched the `paymentId` you provided. |
-| Return payment events by ID | P0398 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Return payment events by ID | P0398 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Search payments | P0401 | Invalid parameters | The parameters you sent are invalid. |
 | Search payments | P0402 | Page not found | The requested page of search results does not exist. |
-| Search payments | P0498 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Search payments | P0498 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Cancel payment | P0500 | `paymentId` not found | No payment matched the `paymentId` you provided. |
-| Cancel payment | P0501 | Cancellation failed | Cancelling the payment failed. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Cancel payment | P0501 | Cancellation failed | Cancelling the payment failed. Contact us, quoting the error code. |
 | Cancel payment | P0502 | Payment cannot be cancelled | You can only cancel a payment if [the payment has a `cancel` field](/making_payments/#find-out-if-you-can-cancel-a-payment). |
-| Cancel payment | P0598 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Cancel payment | P0598 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Create refund | P0600 | `paymentId` not found | No payment matched the `paymentId` you provided. |
 | Create refund | P0601 | Missing mandatory attribute | The request you sent is missing a required attribute. |
 | Create refund | P0602 | Invalid attribute value | The value of an attribute you sent is invalid. |
 | Create refund | P0603 | Refund not available | The payment is not available for refund. |
 | Create refund | P0604 | Refund amount available mismatch | The `refund_amount_available` value you provided does not match the true amount available to refund. |
 | Create refund | P0697 | Unable to parse JSON | The JSON you sent in the request body is invalid. |
-| Create refund | P0698 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Create refund | P0698 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Get refund | P0700 | `refundId` not found | No refund matched the `refundId` you provided. |
-| Get refund | P0798 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Get refund | P0798 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Get refunds | P0800 | `refundId` not found | No refund matched the `refundId` you provided. |
-| Get refunds | P0898 | Downstream system error | Internal error with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| Get refunds | P0898 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | General | P0900 | Too many requests | Your service account is sending requests above the allowed rate. Try the request again in a few seconds. |
 | General | P0920 | Request blocked by security rules | Our firewall blocked your request. Find out [how to fix a P0920 error](#fix-a-p0920-api-error). |
 | General | P0999 | GOV.UK Pay is unavailable | The GOV.UK Pay service is temporarily down. |
 | Delayed capture | P1000 | No match for `paymentId` | No payment matched the `paymentId` you provided. |
-| Delayed capture | P1001 | Capturing failed | Capturing the payment failed. [Contact us](/support_contact_and_more_information/#contact-us). |
+| Delayed capture | P1001 | Capturing failed | Capturing the payment failed. Contact us, quoting the error code. |
 | Delayed capture | P1003 | Payment cannot be captured | You can only capture a payment if the payment has a `status` of `capturable`. |
-| Delayed capture | P1098 | GOV.UK Pay error | Something is wrong with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us). |
+| Delayed capture | P1098 | GOV.UK Pay error | Something is wrong with GOV.UK Pay. Contact us, quoting the error code. |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 

--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -12,7 +12,7 @@ credit or debit card. You can [contact GOV.UK Pay support](/support_contact_and_
 set this up for you.
 
 Each surcharge is a flat amount added to a payment. If you’d like to discuss
-adding surcharges as percentages, please [contact us](/support_contact_and_more_information/#contact-us).
+adding surcharges as percentages, please contact us.
 
 You can set a different surcharge for each of the following 4 corporate card types:
 

--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -13,6 +13,6 @@ You can take payments whenever you need to. You can take the same amount or a di
 
 You cannot automatically schedule payments. If you need to take regular payments, you should create your own scheduler to send API calls on a set schedule.
 
-Direct Debit is not currently available to central government departments in England or the NHS. [Contact us](/support_contact_and_more_information/#contact-us) if you’d like to know more.
+Direct Debit is not currently available to central government departments in England or the NHS.
 
-[Contact us](/support_contact_and_more_information/#contact-us) to sign up for our pilot.
+[Contact us](/support_contact_and_more_information/#contact-us) if you want to know more or to sign up for our pilot.

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -25,9 +25,8 @@ Your service backend is server-side software. You should build this to:
 
 * make a call to the GOV.UK Pay API to start the payment journey
 * store information about user payment journeys in your datastore
-* redirect your user to the `next_url` provided by GOV.UK Pay, where your user
-will [enter their payment information and confirm their payment](/payment_flow/#making-a-payment)
-* receive your user's request when they are redirected back to your service via the `return_url`, where your user will return [after they complete their payment](/payment_flow/#making-a-payment)
+* redirect your user to the `next_url` provided by GOV.UK Pay, where your user will [enter their payment information and confirm their payment](/payment_flow/#making-a-payment)
+* receive your user's request when they are redirected back to your service via the `return_url`, where your user will return [after they complete their payment](/payment_flow/#payment-successful)
 * identify your returning user via the session
 * make a call to the GOV.UK Pay API to determine the outcome of the payment
 * display information about the outcome of the payment and next steps to your user

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -17,14 +17,12 @@ You must:
 - read about [Payment Service Provider (PSP) fees](/reporting/#psp-fees)
 - have a secure domain for your service, because you must use HTTPS for the `return_url` when you [create a payment](/making_payments/#creating-a-payment) in a live service
 - sign up for updates on the [GOV.UK Pay status page](https://payments.statuspage.io), so you get a notification when there's an incident
-- know how to [contact us](/support_contact_and_more_information/#contact-us) to report an incident
+- know how to [contact us](/support_contact_and_more_information/#contact-us) to report an incident or if you need help going live
 
 Compared to your test account, your live account may have a:
 
 - slower response time, because GOV.UK Pay must wait for responses from your payment service provider (PSP)
 - lower transaction limit - check with your PSP
-
-[Contact us](/support_contact_and_more_information/#contact-us) if you need help going live.
 
 ## 1. Request a live GOV.UK Pay account
 

--- a/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_epdq_account/index.html.md.erb
@@ -68,7 +68,7 @@ If you only want to accept Visa and Mastercard, you do not need to follow these 
 
 4. Enter a SHA-IN passphrase in plain text - do not use a hash.
 
-    You should follow the guidance about [choosing and storing passwords](https://www.ncsc.gov.uk/collection/top-tips-for-staying-secure-online/password-managers) from the National Cyber Security Centre (NCSC). You cannot use ^, {, }, [, ], “, ‘, |, <, or >.
+    You should follow the [NCSC guidance on choosing and storing passwords](https://www.ncsc.gov.uk/collection/top-tips-for-staying-secure-online/password-managers). You cannot use ^, {, }, [, ], “, ‘, |, <, or >.
 
     You'll need to copy this passphrase into your GOV.UK Pay account later.
 

--- a/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_smartpay_account/index.html.md.erb
@@ -93,7 +93,7 @@ Leave the following fields unchecked:
 
 ### Set up ‘Authentication’ settings
 
-Enter a username and password. You should follow the guidance about [choosing and storing passwords](https://www.ncsc.gov.uk/collection/top-tips-for-staying-secure-online/password-managers) from the National Cyber Security Centre (NCSC).
+Enter a username and password. You should follow the [NCSC guidance on choosing and storing passwords](https://www.ncsc.gov.uk/collection/top-tips-for-staying-secure-online/password-managers).
 
 You'll need to copy this username and password into your GOV.UK Pay account later.
 


### PR DESCRIPTION
Fixes as part of accessibility corrections after the audit to remove redundant links and alt text:

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/account_structure/#how-accounts-work - shorten or remove alt text

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/direct_debit/#take-a-direct-debit-payment - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/corporate_card_surcharges/#add-corporate-card-fees - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/switching_to_live/#go-live - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/optional_features/custom_branding/#add-custom-branding - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay - remove “redundant” links i.e. concurrent identical links

https://wave.webaim.org/report#/https://docs.payments.service.gov.uk/api_reference/#api-reference - remove “redundant” links i.e. concurrent identical links

