### PR TITLE
We don’t yet have 3DS2 enabled for ePDQ

### DIFF
--- a/source/set_up_3dsecure/index.html.md.erb
+++ b/source/set_up_3dsecure/index.html.md.erb
@@ -50,9 +50,7 @@ Worldpay enables 3DS1 on transactions by default. You can check if 3DS1 is enabl
 
 ## Set up SCA with ePDQ
 
-You do not need to do anything because we set up 3DS2 on your service by default.
-
-ePDQ does not apply any SCA exemptions to transactions.
+3DS2 is not available for ePDQ. You can only enable 3DS1.
 
 ## Set up SCA with Smartpay
 


### PR DESCRIPTION
### Context
Although we did work earlier in the year to support 3DS2 for ePDQ, it wasn’t available for live ePDQ accounts at the time. It seems to now be available but we haven’t yet configured any accounts to use it.

### Changes proposed in this pull request
See changes in pull request.

### Guidance to review
Text is basically the same as what we say for Smartpay.