### PR TITLE
BAU - Fix Ruby version error

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -57,6 +57,7 @@ jobs:
             type: docker-image
             source:
               repository: ruby
+              tag: 2.7.2-buster
           inputs:
             - name: pay-tech-docs
           outputs:
@@ -97,6 +98,7 @@ jobs:
             type: docker-image
             source:
               repository: ruby
+              tag: 2.7.2-buster
           inputs:
             - name: pull-request
           caches:


### PR DESCRIPTION
Description:
- Deploy and builds are failing on Concourse because it is pulling the latest Ruby version. This PR ensures that it pulls a specific version of the Ruby docker image rather than the latest one.
