### PR TITLE
Quick start guide review date change

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Quick start
-last_reviewed_on: 2020-03-01
+last_reviewed_on: 2020-09-08
 review_in: 6 months
 weight: 20
 ---


### PR DESCRIPTION
Forgot to update the last date reviewed for the quick start guide in September 2020
