### PR TITLE
PP-7613 Clarify self and next_url in payment flow

### DIFF
--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How GOV.UK Pay works
-last_reviewed_on: 2020-03-03
+last_reviewed_on: 2021-01-12
 review_in: 6 months
 weight: 30
 ---

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -112,12 +112,10 @@ And response bodies would be of the form:
 
 The start of the response confirms the properties of the attempted payment.
 
-The `self` URL (also provided in the Location header of the response) is a
-unique identifier for the payment. It can be used to retrieve the payment status
-details in future.
+The `href` field in the `self` object is a URL with a unique identifier for the payment, for example `icus7b4umg4b4g5fat4831es5f`. You can [make an API request](/reporting/#get-information-about-a-single-payment) to the URL to get the payment's status in future. The URL is also in the location header of the API response. 
 
-The `next_url` is the URL where your service should direct your user next.
-It points to a payment page hosted by GOV.UK Pay where your user can enter
+The `href` field in the `next_url` object is the URL where your service should direct your user next.
+The URL points to a payment page hosted by GOV.UK Pay where your user can enter
 their payment details. This is a one-time URL. If more than one visit is attempted,
 it will give an error message.
 


### PR DESCRIPTION
### Context
Issues raised in fact check of payment flow page:

- `self` and `next_url` aren't clear that the URL is in the `href` field, not the parent object
- the unique identifier is at the end of the URL, not the whole URL
- it's not clear you need to make an API request to `self` to get the payment details

### Changes proposed in this pull request
Clarify the content to fix the issues above