### PR TITLE
PP-7616 Add link to getting payment using API in errors section

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: API reference
-last_reviewed_on: 2020-05-28
+last_reviewed_on: 2021-01-12
 review_in: 6 months
 weight: 180
 ---

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -237,7 +237,7 @@ Pay admin tool or directly using the API.
 
 #### Use the API
 
-You can use the API to examine the `state` object in a payment’s API response.
+You can [get information about a payment](/reporting/#get-information-about-a-single-payment) using the API and see the payment's `state` in the API response.
 
 For example:
 


### PR DESCRIPTION
### Context
A fact check raised the issue that in https://docs.payments.service.gov.uk/api_reference/#use-the-api, we don't mention how to get a payment's information through the API.

### Changes proposed in this pull request
Added a link to the page about making a request to the API to get a payment's information.