### PR TITLE
PP-7634 Update content to reflect new admin tool URLs

### DIFF
--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -24,6 +24,6 @@ When your user makes a payment, they will also see a
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by [selecting an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/) and selecting **Settings**.
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by [selecting an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
 
 [Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop a feature to automatically translate emails into Welsh.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -24,6 +24,6 @@ When your user makes a payment, they will also see a
 payment pages, you may also want to use Welsh text in the
 `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by signing in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/settings/).
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by [selecting an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/) and selecting **Settings**.
 
 [Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop a feature to automatically translate emails into Welsh.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -188,7 +188,7 @@ confirmation email containing:
 
 You can add a custom paragraph to a payment confirmation email.
 
-1. [Select an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/).
+1. [Select an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services).
 2. Select **Settings**.
 3. Select **See templates and add a custom paragraph**.
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -186,10 +186,11 @@ confirmation email containing:
 * who the payment was made to
 * the total payment amount
 
-You can add a custom paragraph to a payment confirmation email at the [email
-notifications
-page](https://selfservice.payments.service.gov.uk/email-notifications) on the
-GOV.UK Pay admin tool.
+You can add a custom paragraph to a payment confirmation email.
+
+1. [Select an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/).
+2. Select **Settings**.
+3. Select **See templates and add a custom paragraph**.
 
 You can further customise using [GOV.UK
 Notify](https://www.notifications.service.gov.uk/) to set up custom

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -141,7 +141,7 @@ All dates are in Coordinated Universal Time (UTC).
 
 ### Send email notifications about refunds
 
-You can use the GOV.UK Pay admin tool to turn on sending refund email notifications to your users. [Select the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/), then select **Settings**.
+You can use the GOV.UK Pay admin tool to turn on sending refund email notifications to your users. [Select the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services), then select **Settings**.
 
 ## Getting a list of refunds
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -141,7 +141,7 @@ All dates are in Coordinated Universal Time (UTC).
 
 ### Send email notifications about refunds
 
-You can use the GOV.UK Pay admin tool to turn on [sending refund email notifications to your users](https://selfservice.payments.service.gov.uk/email-notifications).
+You can use the GOV.UK Pay admin tool to turn on sending refund email notifications to your users. [Select the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/), then select **Settings**.
 
 ## Getting a list of refunds
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -23,7 +23,7 @@ You can export one file for one service's transactions, or one file for all your
 
 1. Go to [My Services](https://selfservice.payments.service.gov.uk/my-services).
 
-1. If you want to export one service's transactions, select the service account you want reporting information for and go to the [transactions](https://selfservice.payments.service.gov.uk/transactions) list.
+1. If you want to export one service's transactions, select the service account you want reporting information for, then select **Transactions**.
 
     You can also [view transactions for all your live services](https://selfservice.payments.service.gov.uk/all-service-transactions) if you want to export all your services' transactions.
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -29,7 +29,7 @@ Follow these steps to revoke your API key immediately if you believe it has been
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
 
-2. Select the correct services in the [My services](https://selfservice.payments.service.gov.uk/my-services) section.
+2. Select the correct accounts in the [My services](https://selfservice.payments.service.gov.uk/my-services) section.
 
 3. Select **API keys**.
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -27,13 +27,13 @@ source code repositories.
 
 Follow these steps to revoke your API key immediately if you believe it has been accidentally shared or compromised:
 
-1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login)
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
 
-2. Select the correct services in the [My services](https://selfservice.payments.service.gov.uk/my-services) section
+2. Select the correct services in the [My services](https://selfservice.payments.service.gov.uk/my-services) section.
 
-3. Navigate to the [API keys](https://selfservice.payments.service.gov.uk/api-keys) page in the Settings section.
+3. Select **API keys**.
 
-4. Revoke all compromised API keys
+4. Revoke all compromised API keys.
 
 <%= warning_text('If you believe your key has been used to make fraudulent payments, contact the GOV.UK support team using the urgent contact methods provided to your service manager.') %>
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -67,7 +67,7 @@ How you set up 3DS2 or 3DS1 payment authentication depends on which Payment Serv
 
 ## 4. Choose which card types to accept
 
-Choose which card types to accept by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/payment-types).
+Choose which card types to accept by [selecting an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/) and selecting **Settings**.
 
 If you use Worldpay, SmartPay or ePDQ, you must also make sure the same card types are selected in your PSP account.
 
@@ -131,12 +131,13 @@ You make a real payment using either:
 
 1. After you've confirmed the payment, check you received a [confirmation email](/payment_flow/#confirmation-email).
 
-1. Check the payment appears in [your transactions](https://selfservice.payments.service.gov.uk/transactions) in the GOV.UK Pay admin tool.
+1. Check the payment appears in [your transactions](https://selfservice.payments.service.gov.uk/all-service-transactions) in the GOV.UK Pay admin tool.
 
 1. Select the payment and check you can refund it. It may take up to 20 minutes for the __Refund payment__ button to appear.
 
 If your payment or refund fails, check:
 
-- [your PSP settings](https://selfservice.payments.service.gov.uk/your-psp) are correct
 - you [connected your live account to your PSP](#2-connect-your-live-account-to-your-psp) correctly
 - your ['risk management' settings](/security/#preventing-fraudulent-payments) if your PSP is Worldpay
+
+You can also check your PSP settings by [selecting the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/) then selecting **Your PSP**.

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -67,7 +67,7 @@ How you set up 3DS2 or 3DS1 payment authentication depends on which Payment Serv
 
 ## 4. Choose which card types to accept
 
-Choose which card types to accept by [selecting an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/) and selecting **Settings**.
+Choose which card types to accept by [selecting the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
 
 If you use Worldpay, SmartPay or ePDQ, you must also make sure the same card types are selected in your PSP account.
 
@@ -140,4 +140,4 @@ If your payment or refund fails, check:
 - you [connected your live account to your PSP](#2-connect-your-live-account-to-your-psp) correctly
 - your ['risk management' settings](/security/#preventing-fraudulent-payments) if your PSP is Worldpay
 
-You can also check your PSP settings by [selecting the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/) then selecting **Your PSP**.
+You can also check your PSP settings by [selecting the account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services) then selecting **Your PSP**.

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -20,9 +20,13 @@ Do not use your test account for automated integration tests that run every time
 
 You should test the whole user journey.
 
-To help you test, you can:
+If you're using the API integration, you can create a link to GOV.UK Pay payment pages and add it to your service's prototype page. 
 
-- if you are using the API integration, [create a link to GOV.UK Pay payment pages](https://selfservice.payments.service.gov.uk/test-with-your-users) and add it to your service's prototype page
+1. [Select the account you want to test in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/).
+2. Select **Test with your users** to create the link.
+
+You can also:
+
 - use [mock card numbers](#mock-card-numbers) to test both successful and unsuccessful payments
 - use HTTP instead of HTTPs for the `return_url` with your test account, so you do not need to set up a secure url for testing
 - test any [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/) you have set up

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -22,7 +22,7 @@ You should test the whole user journey.
 
 If you're using the API integration, you can create a link to GOV.UK Pay payment pages and add it to your service's prototype page. 
 
-1. [Select the account you want to test in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/).
+1. [Select the account you want to test in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services).
 2. Select **Test with your users** to create the link.
 
 You can also:


### PR DESCRIPTION
### Context
Some of the URLs in the admin tool are being changed.

### Changes proposed in this pull request
Update links to certain admin tool pages with content about first selecting the account you need, then going to the appropriate area of the admin tool.

I haven't described every step because it would make the user experience more complicated than necessary. I've written the content to take users far enough that the remaining steps should be self-explanatory through the admin tool UI design.

Do not merge until all the urls have been changed in the admin tool itself. (Redirects should mean user journeys continue to work in the meantime.)    