### PR TITLE
PP-7528 Add deadline for teams' own Worldpay accounts

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -46,11 +46,14 @@ Once you have a GOV.UK Pay live account, you can connect that account to your pa
 You can connect your live account to:
 
 - [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe), GOV.UK Pay's current PSP
-- [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay), Government Banking's current PSP - if you're a central government or health sector organisation
+- [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay) using a contract through Government Banking or your own Worldpay contract
+
+You cannot use your own Worldpay contract after 31 July 2021. You must either switch to GOV.UK Pay’s PSP or a contract through Government Banking. [Contact us](/support_contact_and_more_information/#contact-us) as soon as possible if you need to switch.
+
+Until 31 July 2021, we also support connecting your live account to:
+
 - [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq) if you connected another live account to ePDQ before 1 August 2020
 - [SmartPay](/switching_to_live/set_up_a_live_smartpay_account/#connect-your-live-account-to-smartpay) if you connected another live account to SmartPay before 1 August 2020
-
-You will no longer be able to connect live accounts to ePDQ and SmartPay after 31 July 2021.
 
 If either GOV.UK Pay's or Government Banking's PSP changes, we'll work with you to move you to the new PSP.
 


### PR DESCRIPTION
### Context
We're missing content for users to tell them that you cannot use your own Worldpay contract after 31 July 2021.

### Changes proposed in this pull request
Add the content to the relevant [Go live section](https://docs.payments.service.gov.uk/switching_to_live/#2-connect-your-live-account-to-your-psp) and reorder the content so the options are clearer. 

### Guidance to review
Please check if factually correct