### PR TITLE
PP-7674 Update user journeys to reflect new admin page default

### DIFF
--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -43,4 +43,4 @@ You should [create a separate GOV.UK Pay service](https://selfservice.payments.s
 - give your staff members access to each service separately in the GOV.UK Pay admin tool
 - manage the settings for each service separately, for example which card types you accept
 
-You can still [view transactions for all your live services](https://selfservice.payments.service.gov.uk/all-service-transactions) together.
+You can still [view transactions for all your live services](https://selfservice.payments.service.gov.uk/all-service-transactions/live) together.

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -231,9 +231,11 @@ Pay admin tool or directly using the API.
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
-2. Select __Transactions__.
+2. Select an account.
 
-3. Use the __Payment status__ dropdown to find payments with error statuses. For example, “Declined”.
+3. Select __Transactions__.
+
+4. Use the __Payment status__ dropdown to find payments with error statuses. For example, “Declined”.
 
 #### Use the API
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -15,9 +15,13 @@ Digital wallet payments work with both [integrating with the GOV.UK Pay API](/in
 
 ## Enable Apple Pay
 
-Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
-In your __Settings__, select the __Digital wallet__ tab in __Card types__. In the next screen, enable Apple Pay.
+2. Select an account.
+
+3. Select __Settings__.
+
+4. Change the **Apple Pay** setting.
 
 You do not need to ask Worldpay to enable Apple Pay in your Worldpay account.
 
@@ -37,11 +41,13 @@ You get your Google Pay merchant ID from your Worldpay merchant admin interface.
 
 1. Copy the generated merchant ID.
 
-Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
-In your __Settings__, select the __Digital wallet__ tab in __Card types__. In the next screen, enable Google Pay.
+1. Select the account where you want to enable Google Pay.
 
-Enter the generated merchant ID and select __Submit__.
+1. Select **Settings**.
+
+1. Go to the **Google Pay** setting, select **On** and enter the merchant ID.
 
 ## Strong Customer Authentication (3D Secure)
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -191,7 +191,8 @@ If the mop-up job finds ‘stale’ incomplete payment journeys then it’s like
 
 ## Collecting your users' billing addresses
 
-You can enable or disable collecting your users’ billing addresses in your [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/login) __Settings__ screen.
+You can enable or disable collecting your users’ billing addresses by selecting an account in the [GOV.UK Pay admin
+tool](https://selfservice.payments.service.gov.uk/), then selecting **Settings**.
 
 This change can take up to 15 minutes to take effect.
 

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -49,7 +49,7 @@ If you use Worldpay or ePDQ, you must:
 - use a service for MOTO payments that’s separate to your online payments service
 - process MOTO payments on a specific MOTO merchant code
 
-1. Create a separate MOTO payments service if you do not have one already by signing in to your [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/) and going to __My services__. Select __Add a new service__ to add a new service for MOTO payments to your account.
+1. Create a separate MOTO payments service if you do not have one already by signing in to your [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/), then selecting __Add a new service__ to add a new service for MOTO payments to your account.
 
 1. If you do not already have a MOTO merchant code, ask for a new code by contacting your PSP or Government Banking as required. You will use this merchant code when you [connect your new service to your PSP](/switching_to_live/#go-live).
 
@@ -104,7 +104,8 @@ To hide or unhide this information, you must have admin permissions for your ser
 
 This change takes immediate effect, so you should tell your service team staff before changing these settings.
 
-1. Sign into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/). Make sure you are in the right service.
+1. Sign into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
+1. Select the account you want to change.
 1. Go to __Settings__ and then __Security__.
 1. Go to either __Hide card numbers__ or __Hide card security codes__ and select __Change__.
 1. Select either __Hidden__ or __Visible__ and then __Save changes__.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -14,7 +14,7 @@ You can also [create payment links in Welsh](https://www.payments.service.gov.uk
 To use Welsh, include `"language": "cy"` in the API request when you [create a new payment](/payment_flow/#making-a-payment). Your users will see Welsh text on the payment pages as they complete the [payment flow](/payment_flow).  If you do not specify a language,
 GOV.UK Pay will default to using English-language payment pages.
 
-Sign in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/login) to add a Welsh service name to your service.
+To add a Welsh service name to your service, sign in to the [GOV.UK admin tool](https://selfservice.payments.service.gov.uk/login) and select **Edit name**.
 
 If you add a Welsh service name to your service, your users will see this on Welsh-language
 payment pages instead of the English service name.

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -73,7 +73,9 @@ with our API and make a test API call.
    tool](https://selfservice.payments.service.gov.uk/) with the test
    account login details you received.
 
-2. Select __API keys__, then generate a new key.
+2. Select your account.
+
+3. Select __API keys__, then generate a new key.
 
 Make sure you [keep your API keys safe](/security/#securing-your-developer-keys).
 
@@ -125,7 +127,7 @@ Submit the payment.
 
 ### View transactions at GOV.UK Pay admin tool
 
-Sign in to the [GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/) and select __Transactions__.
+Select an account in the [GOV.UK Pay admin
+tool](https://selfservice.payments.service.gov.uk/), then select __Transactions__.
 
 You can also view test transactions using the API.

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -124,7 +124,7 @@ If your PSP is Stripe, you should receive the payment in your bank account withi
 - 2 working days of `captured_date` if your user completed their payment during the week
 - 3 working days of `captured_date` if your user completed their payment at the weekend or on a bank holiday
 
-You can confirm when payments are paid into your bank account by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and going to __My Services__ > __View payments to your bank account__.
+You can confirm when payments are paid into your bank account by signing in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/) then selecting __View payments to your bank account__.
 
 If your PSP is Government Banking’s contracted PSP (currently Worldpay), SmartPay or ePDQ, contact your PSP to find out your payment times.
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -31,7 +31,7 @@ You'll need to tell us:
 - your organisation's name and address
 - if you’ll be using GOV.UK Pay’s PSP Stripe, or another PSP
 
-Select your test account from the [__My services__](https://selfservice.payments.service.gov.uk/my-services) page in the GOV.UK Pay admin tool, then select __Request a live account__.
+Select your test account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services), then select __Request a live account__.
 
 We'll respond within one working day, and we can usually activate your live account on the same day.
 


### PR DESCRIPTION
### Context
When users go to https://selfservice.payments.service.gov.uk/, they'll be taken to the My Services page (https://selfservice.payments.service.gov.uk/my-services) rather than an individual account dashboard.

### Changes proposed in this pull request
Update guidance on navigating from https://selfservice.payments.service.gov.uk/, so it matches the new journey.

As with https://github.com/alphagov/pay-tech-docs/pull/536, I haven't described every step because it would make the user experience more complicated than necessary. I've written the content to take users far enough (for example to the Settings page) that the remaining steps should be self-explanatory through the admin tool UI design 

Do not merge until the admin tool has been changed.

### Guidance to review
Please check if factually correct.