### PR TITLE
PP-6479 Clarify support page and make it more consistent with product support page

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -135,7 +135,7 @@ Common status codes are:
 | 412 | Precondition failed, eg mismatch in expected refund amount available. |
 | 422 | Unprocessable entity obtained on a request validation. |
 | 429 | Too many requests. Request rate is above the rate limit. |
-| Any 500 error | Something is wrong with GOV.UK Pay. [Contact us](/support_contact_and_more_information/#contact-us). |
+| Any 500 error | Something is wrong with GOV.UK Pay. [Contact us](/support_contact_and_more_information/). |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
@@ -220,7 +220,7 @@ To fix a P0920 API error, make sure your API request:
 | P0020 | Payment expired | Payment was not confirmed and completed within 90 minutes of being created. If the payment was already authorised, GOV.UK Pay will send a cancellation to the payment provider. |
 | P0030 | Payment cancelled by your user | Your user selected **Cancel payment** during the payment journey. If the payment was already authorised, GOV.UK Pay will send a cancellation to the payment provider. |
 | P0040 | Payment was cancelled by your service | Your service cancelled the payment. |
-| P0050 | Payment provider returned an error | Multiple possible causes, for example a configuration problem with the payment provider, or incorrect credentials. [Contact us](/support_contact_and_more_information/#contact-us), quoting the error code. |
+| P0050 | Payment provider returned an error | Multiple possible causes, for example a configuration problem with the payment provider, or incorrect credentials. [Contact us](/support_contact_and_more_information/), quoting the error code. |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
@@ -269,6 +269,6 @@ many requests) and error code P0900. After a second, you’ll be able to retry
 your attempt in a reasonable way. For example, using exponential backoff.
 
 [Contact
-us](/support_contact_and_more_information/#contact-us)
+us](/support_contact_and_more_information/)
 if you would like to discuss rate limiting applied to your service account, or
 give us feedback.

--- a/source/block_prepaid_cards/index.html.md.erb
+++ b/source/block_prepaid_cards/index.html.md.erb
@@ -11,7 +11,7 @@ You can block users from paying with prepaid cards. You should only do this if u
 
 You cannot block most Mastercard prepaid cards, because we usually cannot tell if Mastercard cards are prepaid or not.
 
-[Contact us](/support_contact_and_more_information/#contact-us) and we’ll:
+[Contact us](/support_contact_and_more_information/) and we’ll:
 
 - tell you how to get permission from Visa first - if you want to block Visa cards
 - block prepaid cards on your account

--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -8,7 +8,7 @@ weight: 120
 # Add corporate card fees
 
 GOV.UK Pay supports adding a fee or 'surcharge' if your user pays with a corporate
-credit or debit card. You can [contact GOV.UK Pay support](/support_contact_and_more_information/#contact-us) to ask the team to
+credit or debit card. You can [contact GOV.UK Pay support](/support_contact_and_more_information/) to ask the team to
 set this up for you.
 
 Each surcharge is a flat amount added to a payment. If you’d like to discuss

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -40,7 +40,7 @@ There are 4 possible responses:
 |204| Your capture request succeeded. |
 |404| No payment matched the `paymentId` you provided. |
 |409| You cannot capture the payment because its `status` is not `capturable`. |
-|500| Something is wrong with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/#contact-us). |
+|500| Something is wrong with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/). |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 

--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -15,4 +15,4 @@ You cannot automatically schedule payments. If you need to take regular payments
 
 Direct Debit is not currently available to central government departments in England or the NHS.
 
-[Contact us](/support_contact_and_more_information/#contact-us) if you want to know more or to sign up for our pilot.
+[Contact us](/support_contact_and_more_information/) if you want to know more or to sign up for our pilot.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -19,7 +19,7 @@ You can read [non-technical information](https://www.payments.service.gov.uk/usi
 - using the Apple Pay and Google Pay digital wallets
 - security and compliance
 
-[Contact us](/support_contact_and_more_information/#contact-us) if you have any questions or feedback.
+[Contact us](/support_contact_and_more_information/) if you have any questions or feedback.
 
 ## How much GOV.UK Pay costs
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -57,7 +57,7 @@ Your PSP may set a lower maximum amount. Check with your PSP if you cannot make 
 
 If you need to take payments above the maximum amount, either:
 
-- [contact us](/support_contact_and_more_information/#contact-us)
+- [contact us](/support_contact_and_more_information/)
 - [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
 
 ### reference

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -21,7 +21,7 @@ You cannot take MOTO payments:
 - if your payment service provider (PSP) is Smartpay
 - through a [payment link](https://www.payments.service.gov.uk/govuk-payment-pages/)
 
-[Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to investigate taking MOTO payments through payment links.
+[Contact us](/support_contact_and_more_information/) if you'd like us to investigate taking MOTO payments through payment links.
 
 ## Set up MOTO payments
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -33,7 +33,7 @@ To set up custom branding, do the following.
 
 ## Send us your banner logo and banner colours
 
-[Send the GOV.UK Pay team](/support_contact_and_more_information/#contact-us):
+[Send the GOV.UK Pay team](/support_contact_and_more_information/):
 
   - an image of your banner logo
   - the colours of your banner background and border

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 103
 
 # Use your own payment failure pages
 
-You can [contact us](/support_contact_and_more_information/#contact-us) to set
+You can [contact us](/support_contact_and_more_information/) to set
 this feature up for your service.
 
 If you do not use your own payment failure pages, your users will see standard
@@ -35,7 +35,7 @@ href="https://govukpay-api-browser.cloudapps.digital/" target="blank">GOV.UK Pay
 browser</a> for more details.
 
 In very rare cases, GOV.UK Pay is unable to redirect payments. You should
-[contact us](/support_contact_and_more_information/#contact-us) if this
+[contact us](/support_contact_and_more_information/) if this
 happens.
 
 ## Expired payments

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -26,4 +26,4 @@ payment pages, you may also want to use Welsh text in the
 
 GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, disable GOV.UK Pay sending emails by [selecting an account in the GOV.UK admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
 
-[Contact us](/support_contact_and_more_information/#contact-us) if you'd like us to develop a feature to automatically translate emails into Welsh.
+[Contact us](/support_contact_and_more_information/) if you'd like us to develop a feature to automatically translate emails into Welsh.

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -68,7 +68,7 @@ If you think you’re receiving fraudulent payments, you can:
 - [delay capture of payments](/delayed_capture/#delay-taking-a-payment) if you need time to do your own anti-fraud checks
 - check your payment service provider's (PSP's) security settings, or [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
 
-If your PSP is Worldpay, you can also set up your account to [make 'risk management' fraud checks](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2). If you do this, you must [contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) and ask us to send your user's IP address to Worldpay during each payment, or your payments may stop working.
+If your PSP is Worldpay, you can also set up your account to [make 'risk management' fraud checks](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2). If you do this, you must [contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/) and ask us to send your user's IP address to Worldpay during each payment, or your payments may stop working.
 
 ## Cloud security principles
 

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -9,45 +9,32 @@ weight: 220
 
 You can get notifications about GOV.UK Pay’s status to your email, phone, RSS reader or website, by subscribing on our [status page](https://payments.statuspage.io/#).
 
-## Incident severity
+After you contact us, the GOV.UK Pay team will contact you using the Zendesk ticketing system.
 
-GOV.UK Pay incident severities are defined as follows:
+## Report an incident
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
+How quickly we respond depends on the type of your incident.
 
-| Classification | AKA | Example | Initial response time | Update Time |
+| Classification | Type | Example | Initial response time | Update frequency |
 | :--- | :--- | :--- | :--- | :--- |
-| P1 | Critical Incident | complete outage; substantial degradation of service; significant security issue; significant availability issue  | 30 minutes (at any time) | 1hr |
-| P2 | Major Incident | elevated error rate; mostly up; noticeably degraded service; upstream vulnerabilities; complete component failure | 60 minutes (in waking hours) | 2hrs |
-| P3 | Significant | Users experiencing intermittent or degraded service due to platform issue | 1 business day or next working day | 2 business days |
-| P4 | Minor | Component failure that is not immediately service impacting | 2 business days | weekly |
+| P1 | Critical | No one in your team can log in, a significant number of your users are not able to make a payment or you have reasons to believe sensitive data has been leaked | 30 minutes (at any time) | Every hour |
+| P2 | Major | Elevated error rate, mostly up, noticeably degraded service, upstream vulnerabilities or complete component failure | 60 minutes (during office hours) | Every 2 hours |
+| P3 | Significant | Users experiencing intermittent or degraded service due to platform issue | 1 working day | Every 2 working days |
+| P4 | Minor | Component failure that is not immediately service impacting | 2 working days | Weekly |
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
+### During office hours
 
-## Hours of service
+We support all incidents from 9.30am to 5.30pm, Monday to Friday.
 
-In-hours support is from Monday-Friday 9:30am-5:30pm and covers all ticket priorities (P1-4).
-
-Out-of-hours support covers P1 support tickets only, during:
-
-* Monday-Friday 5:30pm-9:30am
-* Saturday-Sunday and bank holidays 24x7
-
-## Contact us
-
-If you raise a support request, the GOV.UK Pay team will contact you using the
-Zendesk ticketing system.
-
-### P1 support queries (critical incidents)
-
-For P1 support requests, you will receive instructions from us when you
-sign on as a partner.
-
-### P2-P4 support queries (non-critical incidents)
-
-For all non-P1 support requests, contact us via email at
+Email us at
 [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-### General feedback
+### Out of hours support
 
-If you have any feedback or questions, please email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+We offer 24 hour online support for P1 (critical) incidents only.
+
+You can find the emergency contact details in your GOV.UK Pay contract or Memorandum of Understanding (MoU), and in the go live email we sent you.
+
+## General feedback
+
+If you have any feedback or questions, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -38,3 +38,5 @@ You can find the emergency contact details in your GOV.UK Pay contract or Memora
 ## General feedback
 
 If you have any feedback or questions, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+
+We’ll reply within 2 working days, or one working day if you're [making a request to to go live](/switching_to_live/).

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -17,7 +17,7 @@ You must:
 - read about [Payment Service Provider (PSP) fees](/reporting/#psp-fees) (Stripe only)
 - have a secure domain for your service, because you must use HTTPS for the `return_url` when you [create a payment](/making_payments/#creating-a-payment) in a live service (does not apply if you use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/))
 - sign up for updates on the [GOV.UK Pay status page](https://payments.statuspage.io), so you get a notification when there's an incident
-- know how to [contact us](/support_contact_and_more_information/#contact-us) to report an incident or if you need help going live
+- know how to [contact us](/support_contact_and_more_information/) to report an incident or if you need help going live
 
 Compared to your test account, your live account may have a:
 
@@ -48,7 +48,7 @@ You can connect your live account to:
 - [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe), GOV.UK Pay's current PSP
 - [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay) using a contract through Government Banking or your own Worldpay contract
 
-You cannot use your own Worldpay contract after 31 July 2021. You must either switch to GOV.UK Pay’s PSP or a contract through Government Banking. [Contact us](/support_contact_and_more_information/#contact-us) as soon as possible if you need to switch.
+You cannot use your own Worldpay contract after 31 July 2021. You must either switch to GOV.UK Pay’s PSP or a contract through Government Banking. [Contact us](/support_contact_and_more_information/) as soon as possible if you need to switch.
 
 Until 31 July 2021, we also support connecting your live account to:
 


### PR DESCRIPTION
### Context
A fact check on the Support page highlighted some areas for clarification.

### Changes proposed in this pull request
I've borrowed content from the [product support page](https://www.payments.service.gov.uk/support/) to make it clearer how to contact us in an emergency.

I've also taken the opportunity to:

- restructure the page with fewer headings so it's easier to understand (this is especially important given that this page will be used in emergencies), and closer to the product support page
- make the P1 (critical) description match the product support page, to avoid confusion through inconsistency
- fix ambiguities and style issues across the page as a whole
- make improvements to the incident table - the style is now closer to the GOV.UK style already used by the GDS Way incident table

I haven't added clarification that the contact email isn't for end users. We've researched and tried a similar approach on other products but it doesn't seem to reduce accidental emails from end users who should be contacting the relevant department.

### Guidance to review
Please check if factually correct.