### PR TITLE
PP-7672 Add sending IP address to SmartPay

### DIFF
--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -68,7 +68,7 @@ If you think you’re receiving fraudulent payments, you can:
 - [delay capture of payments](/delayed_capture/#delay-taking-a-payment) if you need time to do your own anti-fraud checks
 - check your payment service provider's (PSP's) security settings, or [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
 
-You can also set up your account to make 'risk management' fraud checks if your PSP is:
+You can also set up your account to make risk management fraud checks if your PSP is:
 
 - [Worldpay](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2)
 - [SmartPay](https://docs.adyen.com/risk-management)

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -68,7 +68,12 @@ If you think you’re receiving fraudulent payments, you can:
 - [delay capture of payments](/delayed_capture/#delay-taking-a-payment) if you need time to do your own anti-fraud checks
 - check your payment service provider's (PSP's) security settings, or [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
 
-If your PSP is Worldpay, you can also set up your account to [make 'risk management' fraud checks](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2). If you do this, you must [contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/) and ask us to send your user's IP address to Worldpay during each payment, or your payments may stop working.
+You can also set up your account to make 'risk management' fraud checks if your PSP is:
+
+- [Worldpay](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2)
+- [SmartPay](https://help.barclaycard.co.uk/smartpaysecure/setting-up-product/configure-fraud-checks)
+
+If you make risk management fraud checks, you must [contact us](/support_contact_and_more_information/) and ask us to send your user's IP address to your PSP during each payment, or your payments may stop working.
 
 ## Cloud security principles
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -71,7 +71,7 @@ If you think you’re receiving fraudulent payments, you can:
 You can also set up your account to make 'risk management' fraud checks if your PSP is:
 
 - [Worldpay](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2)
-- [SmartPay](https://help.barclaycard.co.uk/smartpaysecure/setting-up-product/configure-fraud-checks)
+- [SmartPay](https://docs.adyen.com/risk-management)
 
 If you make risk management fraud checks, you must [contact us](/support_contact_and_more_information/) and ask us to send your user's IP address to your PSP during each payment, or your payments may stop working.
 


### PR DESCRIPTION
### Context
Users are able to make 'risk management' fraud checks if their PSP is Smartpay.

### Changes proposed in this pull request
Add Smartpay to the docs on [preventing fraudulent payments through risk management](https://docs.payments.service.gov.uk/security/#preventing-fraudulent-payments).

### Guidance to review
Please check if factually correct.

Do not merge until PP-7672 technical change has been made.