### PR TITLE
Redo content changes from PR 542

### DIFF
--- a/source/direct_debit/index.html.md.erb
+++ b/source/direct_debit/index.html.md.erb
@@ -1,18 +1,14 @@
 ---
 title: Take a Direct Debit payment
-last_reviewed_on: 2020-06-29
-review_in: 6 months
+last_reviewed_on: 2021-02-01
+review_in: 1 month
 weight: 53
 ---
 
 # Take a Direct Debit payment
 
-You can sign up for the Direct Debit pilot if you want to take recurring payments.
+You cannot take Direct Debit payments using GOV.UK Pay at the moment.
 
-You can take payments whenever you need to. You can take the same amount or a different amount each time.
+We'll be running research about Direct Debit payments in February and March 2021.
 
-You cannot automatically schedule payments. If you need to take regular payments, you should create your own scheduler to send API calls on a set schedule.
-
-Direct Debit is not currently available to central government departments in England or the NHS.
-
-[Contact us](/support_contact_and_more_information/) if you want to know more or to sign up for our pilot.
+[Contact us](/support_contact_and_more_information/#general-feedback) if you want to take part in our research.


### PR DESCRIPTION
The build for https://github.com/alphagov/pay-tech-docs/pull/542 failed because of an error resolving a merge conflict. We reverted that PR, and now this PR redoes the content changes.