### PR TITLE
PP-6802 Improve accounts page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.2.0)
-    ffi (1.14.2)
+    ffi (1.12.2)
     govuk_tech_docs (2.1.0)
       activesupport
       chronic (~> 0.10.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.2.0)
-    ffi (1.12.2)
+    ffi (1.14.2)
     govuk_tech_docs (2.1.0)
       activesupport
       chronic (~> 0.10.2)

--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -1,54 +1,59 @@
 ---
-title: Structuring your accounts
+title: Setting up multiple services
 last_reviewed_on: 2021-02-03
 review_in: 6 months
 weight: 40
 ---
 
-# Deciding whether to combine accounts and payments
+# Setting up multiple services
   
-You should set up your GOV.UK Pay services and payment service provider (PSP) accounts so you can more easily report on and reconcile your payments, and manage your services. 
+If you have more than one online service, you can set up your GOV.UK Pay account and payment service provider (PSP) accounts so it's easier to manage your payments and services.
 
-GOV.UK Pay services are free, and there's no limit to how many you can create. Your PSP may charge you for each PSP account you have.
+## Decide where to send users
 
-## Decide whether to combine your users' payments 
+You can send your users to make payments with either:
 
-Each GOV.UK Pay service you create can take payments for either:
+- a different GOV.UK Pay service for each of your services
+- a combined GOV.UK Pay service
 
-- one of your services
-- 2 or more of your services combined
+### Send your users to different GOV.UK Pay services
 
-### Take payments for one service
+Send your users to a different GOV.UK Pay service for each of your services if you need to do any of the following:
 
-If a GOV.UK Pay service takes payments for only one of your services, you can:
+- give each service its own name on the GOV.UK Pay payment pages
+- report on each service's payments separately
+- send each service's payments to different bank accounts
+- give your staff members access to each service separately in the GOV.UK Pay admin tool
 
-- give your service its own name on GOV.UK Pay's payment pages
-- report on your service's payments separately
-- send your service's payments to a dedicated bank account
-- give your staff members access to your service separately in the GOV.UK Pay admin tool
+To set up your services like this, [create a new GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each of your online services.
+
+GOV.UK Pay services are free, and there's no limit to how many you can create.
 
 To change a service's name, go to the [**My services** page in the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 
-### Take payments for 2 or more services combined
+### Send your users to a combined GOV.UK Pay service
 
-If a GOV.UK Pay service takes payments for 2 or more of your services combined:
+Send your users to a combined GOV.UK Pay service if you need to:
 
-- you can more easily report on all the services' payments together
-- you can more easily change a setting across all the services, for example which card types you accept
-- you may need to use a different [reference number](/making_payments/#reference) or add [custom metadata](/custom_metadata/#add-custom-metadata) for each of your services, so you can tell which service each payment comes from
-- you cannot give the services different names
-- you cannot send payments to different bank accounts
+- report on all the services' payments together
+- change settings easily across all the services, for example which card types you accept
 
-To set up your services like this, use the same API key to create a payment in all of your services that you want to combine.
+You will not be able to give the services different names or send payments to different bank accounts.
 
-## Decide whether to combine your bank payments
+You may need to use a different [reference number](/making_payments/#reference) or add [custom metadata](/custom_metadata/#add-custom-metadata) for each of your services, so you can tell which service each payment comes from.
 
-To help you reconcile payments, each PSP account you create can receive money from either:
+To set up a group of your services like this, use the same API key or payment link for all the services in the group.
 
-- one GOV.UK Pay service
-- 2 or more GOV.UK Pay services combined - unless you use Stripe
+## Decide where to send payments
 
-If you want one PSP account to recieve money from 2 or more GOV.UK Pay services, add the same merchant code to each GOV.UK Pay service when you [go live](/switching_to_live/#go-live).
+To help you reconcile payments, each GOV.UK Pay service can send payments to a:
+
+- separate PSP account and bank account
+- combined PSP account and back account - unless you use Stripe
+
+To set up a combined PSP account, add the same PSP merchant code to each GOV.UK Pay service when you [go live](/switching_to_live/#go-live).
+
+If you send payments to separate PSP accounts, your PSP may charge you for each PSP account you have.
 
 You cannot send money from one GOV.UK Pay service to different PSP accounts.
 

--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -1,92 +1,63 @@
 ---
-title: How accounts work
-last_reviewed_on: 2021-01-08
+title: Structuring your accounts
+last_reviewed_on: 2021-02-03
 review_in: 6 months
 weight: 40
 ---
 
-# How accounts work
+# Deciding whether to combine accounts and payments
+  
+You should set up your GOV.UK Pay services and payment service provider (PSP) accounts so you can more easily report on and reconcile your payments, and manage your services. 
 
-GOV.UK Pay does not limit how many services you can integrate with it and how many accounts you can have with us.
-GOV.UK Pay test and live accounts are free to create and maintain but your payment service provider may charge you for the underlying accounts.
+GOV.UK Pay services are free, and there's no limit to how many you can create. Your PSP may charge you for each PSP account you have.
 
-## Account structure examples
+## Decide whether to combine your users' payments 
 
-If you do integrate multiple services, you can treat them separately or as a
-combined single service within GOV.UK Pay and your payment service provider (PSP).
-This gives 3 possible account configurations.
+Each GOV.UK Pay service you create can take payments for either:
 
-As an example, take 2 services called ‘parking permits’ and ‘parking fines’:
+- one of your services
+- 2 or more of your services combined
 
-### Type 1 (GOV.UK Pay separate, PSP separate)
+### Take payments for one service
 
-<%= image_tag "/images/accountstructure_1.svg", { :alt => '' } %>
+If a GOV.UK Pay service takes payments for only one of your services, you can:
 
-The diagram show two services, ‘Parking permits’ and ‘Parking fines’, that are considered separate services by
-both GOV.UK Pay and the PSP.
+- give your service its own name on GOV.UK Pay's payment pages
+- report on your service's payments separately
+- send your service's payments to a dedicated bank account
+- give your staff members access to your service separately in the GOV.UK Pay admin tool
 
-If you use this account structure, you can:
+To change a service's name, go to the [**My services** page in the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 
-- give access for each service to different staff members
-- optionally use different service names on the GOV.UK Pay payment pages
-- send each service's payments to a different bank account
-- report separately on each of your services
+### Take payments for 2 or more services combined
 
-### Type 2 (GOV.UK Pay combined, PSP combined)
+If a GOV.UK Pay service takes payments for 2 or more of your services combined:
 
-<%= image_tag "/images/accountstructure_2.svg", { :alt => '' } %>
+- you can more easily report on all the services' payments together
+- you can more easily change a setting across all the services, for example which card types you accept
+- you may need to use a different [reference number](/making_payments/#reference) or add [custom metadata](/custom_metadata/#add-custom-metadata) for each of your services, so you can tell which service each payment comes from
+- you cannot give the services different names
+- you cannot send payments to different bank accounts
 
-The diagram shows two services, ‘Parking permits’ and ‘Parking fines’, that are considered a single combined
-service by GOV.UK Pay and the PSP.
+To set up your services like this, use the same API key to create a payment in all of your services that you want to combine.
 
-You may want to use this configuration if you want to simplify the administration of multiple services in GOV.UK Pay. For example, if you do not need reporting at an individual service level.
+## Decide whether to combine your bank payments
 
-The transactions from both services will appear in the same transactions list and CSV file. You may find it useful to use reference numbers to separate payments clearly, for example “parking_fine_1234” and “parking_permit_1234”.
+To help you reconcile payments, each PSP account you create can receive money from either:
 
-In this configuration, payments to services must go to the same bank account because
-they are a single service in the PSP. It is not possible to support multiple PSP accounts in a single GOV.UK Pay service.
+- one GOV.UK Pay service
+- 2 or more GOV.UK Pay services combined - unless you use Stripe
 
-### Type 3 (GOV.UK Pay separate, PSP combined)
+If you want one PSP account to recieve money from 2 or more GOV.UK Pay services, add the same merchant code to each GOV.UK Pay service when you [go live](/switching_to_live/#go-live).
 
-<%= image_tag "/images/accountstructure_3.svg", { :alt => '' } %>
+You cannot send money from one GOV.UK Pay service to different PSP accounts.
 
-The diagram shows two services, ‘Parking permits’ and ‘Parking fines’, that are considered separate services by
-GOV.UK Pay and as a single combined service in the PSP.
+Find out more about [reconciling payments](/integrate_with_govuk_pay/#finance-and-accounting-systems).
 
-You may want to use this configuration if you want to administrate multiple
-services individually in GOV.UK Pay. For example, if you want separate reporting for each service, or different service names on the payment pages.
-This option also allows you to give access for each service to different staff members.
+### Change which bank accounts your PSP sends money to
 
-In this configuration, payments for both services are settled to the same bank account because
-they go into a single account in the PSP.
+You can change which bank accounts your PSP sends money to by:
 
-## Managing settings in GOV.UK Pay services
-
-Each service defined in GOV.UK Pay has its own API key.
-
-Sign in to the [GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/) and go to the __Settings__
-page to change:
-
-* 3D Secure settings
-* the card types you accept
-* email notifications settings
-* billing address settings
-* account credentials
-
-You can also change the name of a service, including how it appears on payment
-pages. To do this, select __My services__ and then __Edit name__ for the
-service name you want to change.
-
-## Managing settings in PSP services
-
-Within each gateway account for the PSP, you can edit:
-
-* what appears on your users' bank statements
-* which of your bank accounts your revenue goes to
-
-You can either:
-
-- [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
-- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
-- contact your PSP directly
+- [contacting us](/support_contact_and_more_information/#support) if your PSP is Stripe
+- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you're using Government Banking's contracted PSP
+- contacting your PSP directly

--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -1,68 +1,17 @@
 ---
 title: Setting up multiple services
-last_reviewed_on: 2021-02-03
+last_reviewed_on: 2021-02-10
 review_in: 6 months
-weight: 40
+weight: 145
 ---
 
 # Setting up multiple services
-  
-If you have more than one online service, you can set up your GOV.UK Pay account and payment service provider (PSP) accounts so it's easier to manage your payments and services.
 
-## Decide where to send users
+If you have more than one online service, you can set up your GOV.UK Pay accounts and payment service provider (PSP) accounts so it's easier to manage your payments and services.
 
-You can send your users to make payments with either:
+You can set up:
 
-- a different GOV.UK Pay service for each of your services
-- a combined GOV.UK Pay service
-
-### Send your users to different GOV.UK Pay services
-
-Send your users to a different GOV.UK Pay service for each of your services if you need to do any of the following:
-
-- give each service its own name on the GOV.UK Pay payment pages
-- report on each service's payments separately
-- send each service's payments to different bank accounts
-- give your staff members access to each service separately in the GOV.UK Pay admin tool
-
-To set up your services like this, [create a new GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each of your online services.
-
-GOV.UK Pay services are free, and there's no limit to how many you can create.
-
-To change a service's name, go to the [**My services** page in the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
-
-### Send your users to a combined GOV.UK Pay service
-
-Send your users to a combined GOV.UK Pay service if you need to:
-
-- report on all the services' payments together
-- change settings easily across all the services, for example which card types you accept
-
-You will not be able to give the services different names or send payments to different bank accounts.
-
-You may need to use a different [reference number](/making_payments/#reference) or add [custom metadata](/custom_metadata/#add-custom-metadata) for each of your services, so you can tell which service each payment comes from.
-
-To set up a group of your services like this, use the same API key or payment link for all the services in the group.
-
-## Decide where to send payments
-
-To help you reconcile payments, each GOV.UK Pay service can send payments to a:
-
-- separate PSP account and bank account
-- combined PSP account and back account - unless you use Stripe
-
-To set up a combined PSP account, add the same PSP merchant code to each GOV.UK Pay service when you [go live](/switching_to_live/#go-live).
-
-If you send payments to separate PSP accounts, your PSP may charge you for each PSP account you have.
-
-You cannot send money from one GOV.UK Pay service to different PSP accounts.
+- [which bank accounts your payments go to](set_up_where_payments_go)
+- [how your services link to GOV.UK Pay services](set_up_where_services_link_to)
 
 Find out more about [reconciling payments](/integrate_with_govuk_pay/#finance-and-accounting-systems).
-
-### Change which bank accounts your PSP sends money to
-
-You can change which bank accounts your PSP sends money to by:
-
-- [contacting us](/support_contact_and_more_information/#support) if your PSP is Stripe
-- [contacting Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you're using Government Banking's contracted PSP
-- contacting your PSP directly

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -9,14 +9,14 @@ weight: 141
 
 To help you reconcile payments, you can send payments from your services to:
 
-- a combined bank account
+- the same bank account
 - different bank accounts
 
-GOV.UK Pay services are free, and there's no limit to how many you can create. Your payment service provider (PSP) may charge you for each PSP account you have.
+GOV.UK Pay services are free, and there's no limit to how many you can create. Your payment service provider (PSP) may charge you for each PSP account you have, unless you use GOV.UK Pay's PSP.
 
-## Send payments to a combined bank account
+## Send payments to the same bank account
 
-You can send payments from a group of your services to a combined bank account.
+You can send payments from a group of your services to the same bank account.
 
 1. [Create a GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each of your services.
 
@@ -25,7 +25,7 @@ You can send payments from a group of your services to a combined bank account.
 - the same bank account number - if you use Stripe
 - the same PSP merchant code
 
-You can also [create a single GOV.UK Pay service instead](/account_structure/set_up_where_services_link_to#link-your-services-to-a-combined-gov-uk-pay-service) if you need to easily manage the following across the whole group:
+You can also [create a single GOV.UK Pay service instead](/account_structure/set_up_where_services_link_to#link-your-services-to-a-single-gov-uk-pay-service) if you need to easily manage the following across the whole group:
 
 - your staff members' access in the GOV.UK Pay admin tool
 - your account settings, for example which card types you accept

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -1,0 +1,56 @@
+---
+title: Set up which bank accounts your payments go to
+last_reviewed_on: 2021-02-10
+review_in: 6 months
+weight: 141
+---
+
+# Set up which bank accounts your payments go to
+
+To help you reconcile payments, you can send payments from your services to:
+
+- a combined bank account
+- different bank accounts
+
+GOV.UK Pay services are free, and there's no limit to how many you can create. Your payment service provider (PSP) may charge you for each PSP account you have.
+
+## Send payments to a combined bank account
+
+You can send payments from a group of your services to a combined bank account.
+
+1. [Create a GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each of your services.
+
+2. When you [go live](/switching_to_live/#go-live), in each GOV.UK Pay service add either:
+
+- the same bank account number - if you use Stripe
+- the same PSP merchant code
+
+You can also [create a single GOV.UK Pay service instead](/account_structure/set_up_where_services_link_to#link-your-services-to-a-combined-gov-uk-pay-service) if you need to easily manage the following across the whole group:
+
+- your staff members' access in the GOV.UK Pay admin tool
+- your account settings, for example which card types you accept
+
+If you need to know which service each payment came from when you [report on payments](/reporting), you can:
+
+- add different [reference numbers](/making_payments/#reference)
+- add different [descriptions](/making_payments/#description)
+- use [custom metadata](/custom_metadata/#add-custom-metadata)
+
+## Send payments to different bank accounts
+
+If you need to send payments from your services to different bank accounts, you must create separate GOV.UK Pay services.
+
+You cannot send payments from one GOV.UK Pay service to more than one bank account.
+
+### If you use Stripe
+
+1. [Create a GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each bank account you want to use.
+2. Decide whether to [link one or more of your services to each GOV.UK Pay service](/account_structure/set_up_where_services_link_to) you created.
+3. When you [go live](/switching_to_live/#go-live), add the bank account number you want to use to each GOV.UK Pay service.
+
+### If you use Worldpay, ePDQ or SmartPay
+
+1. Create a new PSP merchant code for each bank account you want to use.
+2. [Create a GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each PSP merchant code.
+3. Decide whether to [link one or more of your services to each GOV.UK Pay service](/account_structure/set_up_where_services_link_to) you created.
+4. When you [go live](/switching_to_live/#go-live), add the PSP merchant code you want to use to each GOV.UK Pay service.

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -12,7 +12,9 @@ To help you reconcile payments, you can send payments from your services to:
 - the same bank account
 - different bank accounts
 
-GOV.UK Pay services are free, and there's no limit to how many you can create. Your payment service provider (PSP) may charge you for each PSP account you have, unless you use GOV.UK Pay's PSP.
+GOV.UK Pay services are free, and there's no limit to how many you can create.
+
+There's no charge for creating multiple payment service provider (PSP) accounts if you use GOV.UK Pay's PSP. Other PSPs may charge you for each PSP account you have.
 
 How you set up your services will affect how many separate [payouts](/integrate_with_govuk_pay/#receiving-payments) you receive in your bank account each day.
 

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -14,6 +14,8 @@ To help you reconcile payments, you can send payments from your services to:
 
 GOV.UK Pay services are free, and there's no limit to how many you can create. Your payment service provider (PSP) may charge you for each PSP account you have, unless you use GOV.UK Pay's PSP.
 
+How you set up your services will affect how many separate [payouts](/integrate_with_govuk_pay/#receiving-payments) you receive in your bank account each day.
+
 ## Send payments to the same bank account
 
 You can send payments from a group of your services to the same bank account.

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -16,8 +16,6 @@ GOV.UK Pay services are free, and there's no limit to how many you can create.
 
 There's no charge for creating multiple payment service provider (PSP) accounts if you use GOV.UK Pay's PSP. Other PSPs may charge you for each PSP account you have.
 
-How you set up your services will affect how many separate [payouts](/integrate_with_govuk_pay/#receiving-payments) you receive in your bank account each day.
-
 ## Send payments to the same bank account
 
 You can send payments from a group of your services to the same bank account.
@@ -29,10 +27,11 @@ You can send payments from a group of your services to the same bank account.
 - the same bank account number - if you use Stripe
 - the same PSP merchant code
 
-You can also [create a single GOV.UK Pay service instead](/account_structure/set_up_where_services_link_to#link-your-services-to-a-single-gov-uk-pay-service) if you need to easily manage the following across the whole group:
+You can also [create a single GOV.UK Pay service instead](/account_structure/set_up_where_services_link_to#link-your-services-to-a-single-gov-uk-pay-service) if you need to:
 
-- your staff members' access in the GOV.UK Pay admin tool
-- your account settings, for example which card types you accept
+- easily manage your staff members' access to the whole group in the GOV.UK Pay admin tool
+- easily manage your account settings for the whole group, for example which card types you accept
+- receive payments from the whole group in one [payout](/integrate_with_govuk_pay/#receiving-payments) - if your PSP is Stripe
 
 If you need to know which service each payment came from when you [report on payments](/reporting), you can:
 

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -11,7 +11,7 @@ Each GOV.UK Pay service can take payments from one or more of your services.
 
 GOV.UK Pay services are free, and there's no limit to how many you can create.
 
-## Link your services to a combined GOV.UK Pay service
+## Link your services to a single GOV.UK Pay service
 
 You can use one GOV.UK Pay service to take payments for a group of your services, if you need to easily manage the following across the whole group:
 
@@ -28,7 +28,6 @@ If you need to know which service each payment came from when you [report on pay
 - add different [reference numbers](/making_payments/#reference)
 - add different [descriptions](/making_payments/#description)
 - use [custom metadata](/custom_metadata/#add-custom-metadata)
-- use different API keys
 - use different [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
 
 ## Link your services to different GOV.UK Pay services
@@ -36,7 +35,8 @@ If you need to know which service each payment came from when you [report on pay
 You should [create a separate GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each of your services if you need to do any of the following:
 
 - give each service its own name on the GOV.UK Pay payment pages
-- report on each service's payments separately
 - [send each service's payments to different bank accounts](/account_structure/set_up_where_payments_go/#send-payments-to-different-bank-accounts)
 - give your staff members access to each service separately in the GOV.UK Pay admin tool
-- manage the settings for each service separately
+- manage the settings for each service separately, for example which card types you accept
+
+You can still [view transactions for all your live services](https://selfservice.payments.service.gov.uk/all-service-transactions) together.

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -1,0 +1,42 @@
+---
+title: Set up how your services link to GOV.UK Pay services
+last_reviewed_on: 2021-02-10
+review_in: 6 months
+weight: 142
+---
+
+# Set up how your services link to GOV.UK Pay services
+
+Each GOV.UK Pay service can take payments from one or more of your services.
+
+GOV.UK Pay services are free, and there's no limit to how many you can create.
+
+## Link your services to a combined GOV.UK Pay service
+
+You can use one GOV.UK Pay service to take payments for a group of your services, if you need to easily manage the following across the whole group:
+
+- your staff members' access in the GOV.UK Pay admin tool
+- your account settings, for example which card types you accept
+
+1. [Create one GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create).
+2. Use API keys or payment links from the GOV.UK Pay service in all of the services in your group.
+
+You will not be able to give your services different names or send payments to different bank accounts.
+
+If you need to know which service each payment came from when you [report on payments](/reporting), you can:
+
+- add different [reference numbers](/making_payments/#reference)
+- add different [descriptions](/making_payments/#description)
+- use [custom metadata](/custom_metadata/#add-custom-metadata)
+- use different API keys
+- use different [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
+
+## Link your services to different GOV.UK Pay services
+
+You should [create a separate GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create) for each of your services if you need to do any of the following:
+
+- give each service its own name on the GOV.UK Pay payment pages
+- report on each service's payments separately
+- [send each service's payments to different bank accounts](/account_structure/set_up_where_payments_go/#send-payments-to-different-bank-accounts)
+- give your staff members access to each service separately in the GOV.UK Pay admin tool
+- manage the settings for each service separately

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -21,7 +21,10 @@ You can use one GOV.UK Pay service to take payments for a group of your services
 1. [Create one GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create).
 2. Use API keys or payment links from the GOV.UK Pay service in all of the services in your group.
 
-You will not be able to give your services different names or send payments to different bank accounts.
+You will not be able to:
+
+- give your services different names - but you can still show your users a different [description](/making_payments/#description) for each service
+- send payments to different bank accounts
 
 If you need to know which service each payment came from when you [report on payments](/reporting), you can:
 

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -13,10 +13,11 @@ GOV.UK Pay services are free, and there's no limit to how many you can create.
 
 ## Link your services to a single GOV.UK Pay service
 
-You can use one GOV.UK Pay service to take payments for a group of your services, if you need to easily manage the following across the whole group:
+You can use one GOV.UK Pay service to take payments for a group of your services, if you need to:
 
-- your staff members' access in the GOV.UK Pay admin tool
-- your account settings, for example which card types you accept
+- easily manage your staff members' access to the whole group in the GOV.UK Pay admin tool
+- easily manage your account settings for the whole group, for example which card types you accept
+- receive payments from the whole group in one [payout](/integrate_with_govuk_pay/#receiving-payments) - if your PSP is Stripe
 
 1. [Create one GOV.UK Pay service](https://selfservice.payments.service.gov.uk/my-services/create).
 2. Use API keys or payment links from the GOV.UK Pay service in all of the services in your group.

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -70,13 +70,14 @@ If your PSP is Stripe:
 - the minimum payout is £1
 - money will reach your bank account within 2 working days of your user completing their payment
 - money will take 3 working days to reach your account if your user completed their payment at the weekend or on a bank holiday
+- you'll receive a separate payout for each GOV.UK Pay service you've set up
 
 If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see:
 
 - payments ('payouts') that Stripe has made to your bank account
 - which of your users' payments are in each payout
 
-If your PSP is Government Banking's contracted PSP (currently Worldpay), SmartPay or ePDQ, contact your PSP to find out your minimum payout and payment times.
+If your PSP is Government Banking's contracted PSP (currently Worldpay), SmartPay or ePDQ, contact your PSP to find out your minimum payout and payment times. You'll receive a separate payout for each merchant code you use.
 
 #### Checking when your PSP sent a payment
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -100,6 +100,14 @@ All dates are in Coordinated Universal Time (UTC).
 
 You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see your payout for each day, and which of your users’ payments are in each payout.
 
+### Changing your users' bank statements
+
+To change what appears on your users' bank statements, you can either:
+
+- [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
+- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you're using Government Banking's contracted PSP
+- contact your PSP directly
+
 ## The GOV.UK Pay API
 
 The GOV.UK Pay API offers a set of operations to conduct and report on

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -78,12 +78,6 @@ The format is variable. If you have an existing format, you can keep using it if
 
 The description must be no longer than 255 characters, and must not contain URLs.
 
-The `description` does not appear on your users' bank statements. To change your users' bank statements, you can either:
-
-- [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
-- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you're using Government Banking's contracted PSP
-- contact your PSP directly
-
 ### return_url
 
 This is a URL that your service hosts for your user to return to, after their payment journey on GOV.UK Pay ends.

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -78,6 +78,11 @@ The format is variable. If you have an existing format, you can keep using it if
 
 The description must be no longer than 255 characters, and must not contain URLs.
 
+The `description` does not appear on your users' bank statements. To change your users' bank statements, you can either:
+
+- [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
+- [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you're using Government Banking's contracted PSP
+- contact your PSP directly
 
 ### return_url
 


### PR DESCRIPTION
### Context
We've received requests from users who are confused about or need more help setting up multiple accounts.

### Changes proposed in this pull request
This improves the [How accounts work](https://docs.payments.service.gov.uk/account_structure/#how-accounts-work) tech docs page to better meet user needs.

I’ve aimed to:

- lead with the need for each type of setup, so users can more easily pick the approach that matches what they’re trying/need to do
- use language like “send your users…” and “send payments…” to make it easier to understand the flow of payments through accounts
- make the content more task-based (so it uses headings like ‘Decide where to…’ and now includes how to actually set up accounts in the different ways)

We’re a bit stuck with how the admin tool uses “accounts” and “services” to mean different things, but I’ve aimed to be consistent as possible here using:

- “online service” or “your service” for team services
- “GOV.UK Pay service”
- “PSP account”

I’ve removed the diagrams for now because I think they might be helping rather than hindering. I’m probably 50:50 on the diagrams though, so would be good to test without diagrams and see if there’s a need. 

I’ve been through some related Zendesk tickets to check that we’re using users’ language as far as possible, and we’re meeting needs around setting up multiple accounts.

I’ve removed some content that we felt didn’t belong on this page (including moving bank payment descriptions to the 'Take a payment' page), and tweaked content that we felt wasn’t clearly explained (although the ‘changing bank accounts’ content could be improved further I think).

### Guidance to review
Please check if factually correct.