### PR TITLE
PP-7675 Fix urls and add journey to requesting Stripe test account

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -16,7 +16,7 @@ determines if actions are treated as test payments, or processed as real payment
 The API is based on REST principles. It returns data in JSON format, and uses
 standard HTTP error response codes.
 
-You can [get started with the API quickly](/quick_start_guide/#quick-start). Make sure you enter your test API key to avoid generating real payments.
+You can [get started with the API quickly](/quick_start_guide/#quick-start). Make sure you enter an API key from a test account to avoid generating real payments.
 
 When we add new properties to the JSON responses, the GOV.UK Pay API version number will not change. You should develop your service to ignore properties it does not understand.
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -57,8 +57,10 @@ allows you to:
 
 You'll be able to generate API keys for 2 different accounts. These are your:
 
-- test account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
+- test ('sandbox') account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
 - live account, for taking payments from your users after you [switch to live](/switching_to_live)
+
+If your PSP is Stripe, you can also ask us for a test Stripe account so you can see [transaction fees](/reporting/#psp-fees) and [how long it takes to receive money](/reporting/#checking-when-your-payment-service-provider-psp-took-a-payment).
 
 When you've signed up for a test account, follow these instructions to get started
 with our API and make a test API call.
@@ -81,7 +83,7 @@ Make sure you [keep your API keys safe](/security/#securing-your-developer-keys)
 
 You can make test API calls to GOV.UK Pay with your test API key.
 
-You can use API testing tools such as <a href="https://www.getpostman.com/" target="_blank">Postman</a> or <a href="https://insomnia.rest/" target="_blank">Insomnia REST</a> to make test API calls.
+You can use API testing tools such as <a href="https://www.getpostman.com/">Postman</a> or <a href="https://insomnia.rest/">Insomnia REST</a> to make test API calls.
 
 This section shows an example API call and request body, to make a new payment
 for a passport application:

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -60,7 +60,7 @@ You'll be able to generate API keys for 2 different accounts. These are your:
 - test ('sandbox') account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
 - live account, for taking payments from your users after you [switch to live](/switching_to_live)
 
-If your PSP is Stripe, you can also ask us for a test Stripe account so you can see how [transaction fees](/reporting/#psp-fees) and payments to your bank account work.
+If your payment service provider (PSP) is Stripe, you can also ask us for a test Stripe account so you can see how [transaction fees](/reporting/#psp-fees) and payments to your bank account work.
 
 When you've signed up for a test account, follow these instructions to get started
 with our API and make a test API call.

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -60,7 +60,7 @@ You'll be able to generate API keys for 2 different accounts. These are your:
 - test ('sandbox') account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
 - live account, for taking payments from your users after you [switch to live](/switching_to_live)
 
-If your PSP is Stripe, you can also ask us for a test Stripe account so you can see [transaction fees](/reporting/#psp-fees) and [how long it takes to receive money](/reporting/#checking-when-your-payment-service-provider-psp-took-a-payment).
+If your PSP is Stripe, you can also ask us for a test Stripe account so you can see how [transaction fees](/reporting/#psp-fees) and payments to your bank account work.
 
 When you've signed up for a test account, follow these instructions to get started
 with our API and make a test API call.

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -105,7 +105,7 @@ It may take up to 30 minutes for the status to change. Do not check the status m
 
 |status|Meaning|
 |---|---|
-|submitted|We've submitted your refund request to your PSP. Refunds do not have a `submitted` status if you're using your test account.|
+|submitted|We've submitted your refund request to your PSP. Refunds do not have a `submitted` status if you're using your test ('sandbox') account.|
 |success|Your PSP has successfully processed the refund.|
 |error|Your PSP could not process the refund, usually because your user's payment card is cancelled or expired, or you do not have enough money in your account to refund your user.|
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -149,7 +149,9 @@ Where:
 The response will not contain a `fee` or `net_amount` parameter if either:
 
 - your PSP is SmartPay, Worldpay or ePDQ - we do not deduct these PSPs' transaction fees
-- you're [using a test API key](/quick_start_guide/#test-the-api) - we do not deduct fees from test payments
+- you're using an API key from your test ('sandbox') account - we do not deduct fees from payments in this account
+
+To test transaction fees, you can request a test Stripe account by selecting your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 
 You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see transaction fee information or export the information in a CSV file.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -151,7 +151,7 @@ The response will not contain a `fee` or `net_amount` parameter if either:
 - your PSP is SmartPay, Worldpay or ePDQ - we do not deduct these PSPs' transaction fees
 - you're using an API key from your test ('sandbox') account - we do not deduct fees from payments in this account
 
-To test transaction fees, you can request a test Stripe account by selecting your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+To test transaction fees, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 
 You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) to see transaction fee information or export the information in a CSV file.
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -134,7 +134,7 @@ You make a real payment using either:
 
 1. After you've confirmed the payment, check you received a [confirmation email](/payment_flow/#confirmation-email).
 
-1. Check the payment appears in [your transactions](https://selfservice.payments.service.gov.uk/all-service-transactions) in the GOV.UK Pay admin tool.
+1. Check the payment appears in [your live transactions](https://selfservice.payments.service.gov.uk/all-service-transactions/live) in the GOV.UK Pay admin tool.
 
 1. Select the payment and check you can refund it. It may take up to 20 minutes for the __Refund payment__ button to appear.
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -33,10 +33,10 @@ You can also:
 
 You cannot use 3D Secure with test accounts.
 
-If you use Stripe, you can request a test Stripe account by selecting your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see:
+If your PSP is Stripe, you can request a test Stripe account by selecting your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see how the following work:
 
 - [transaction fees](/reporting/#psp-fees)
-- [how long it takes to receive money](/reporting/#checking-when-your-payment-service-provider-psp-took-a-payment)
+- payments to your bank account
 
 ## Performance testing
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -33,6 +33,11 @@ You can also:
 
 You cannot use 3D Secure with test accounts.
 
+If you use Stripe, you can request a test Stripe account by selecting your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see:
+
+- [transaction fees](/reporting/#psp-fees)
+- [how long it takes to receive money](/reporting/#checking-when-your-payment-service-provider-psp-took-a-payment)
+
 ## Performance testing
 
 You must [contact us](/support_contact_and_more_information) to get written approval before you do any performance testing.
@@ -47,28 +52,44 @@ You must use mock email addresses when doing automated testing. If you are testi
 
 You can enter any valid value for other payment fields. For example, the card expiry date can be any date in the future.
 
-### Mock card numbers
+### Mock card numbers
 
 Mock card numbers do not work with your live account.
+
+#### If you're using a test ('sandbox') account
 
 |Testing action |Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |
 |Successful payment | 4444333322221111 | Visa | Credit |
-||4242424242424242| Visa | Credit |
-||4000056655665556| Visa | Debit |
-||4988080000000000| Visa | Debit - corporate |
-||4000160000000004| Visa | Debit - prepaid |
-||4131840000000003| Visa | Debit - corporate prepaid |
-||4000620000000007| Visa | Credit - corporate |
-||4000000000000010| Visa | Credit or debit |
-||5101110000000004| Mastercard | Credit |
-||5105105105105100| Mastercard | Debit |
-||5200828282828210| Mastercard | Debit |
-||371449635398431| American Express | Credit |
-||3566002020360505| JCB | Credit |
-||6011000990139424| Discover | Credit |
-||36148900647913| Diners Club | Credit |
+|Successful payment |4242424242424242| Visa | Credit |
+|Successful payment |4000056655665556| Visa | Debit |
+|Successful payment |4988080000000000| Visa | Debit - corporate |
+|Successful payment |4000160000000004| Visa | Debit - prepaid |
+|Successful payment |4131840000000003| Visa | Debit - corporate prepaid |
+|Successful payment |4000620000000007| Visa | Credit - corporate |
+|Successful payment |4000000000000010| Visa | Credit or debit |
+|Successful payment |5101110000000004| Mastercard | Credit |
+|Successful payment |5105105105105100| Mastercard | Debit |
+|Successful payment |5200828282828210| Mastercard | Debit |
+|Successful payment |371449635398431| American Express | Credit |
+|Successful payment |3566002020360505| JCB | Credit |
+|Successful payment |6011000990139424| Discover | Credit |
+|Successful payment |36148900647913| Diners Club | Credit |
 |Card type not accepted |6759649826438453|Maestro| Debit |
+|Card declined|4000000000000002|Visa| Credit or debit |
+|Card expired|4000000000000069|Visa| Credit or debit |
+|Invalid CVC code|4000000000000127|Visa| Credit or debit |
+|General error|4000000000000119|Visa| Credit or debit |
+
+#### If you're using a test Stripe account
+
+|Testing action |Card number | Card brand | Card type |
+| -------- | ------- | ------- | ------- |
+|Successful payment |4242424242424242| Visa | Credit |
+|Successful payment |4000056655665556| Visa | Debit |
+|Successful payment |5105105105105100| Mastercard | Debit |
+|Successful payment |5200828282828210| Mastercard | Debit |
+|Successful payment |371449635398431| American Express | Credit |
 |Card declined|4000000000000002|Visa| Credit or debit |
 |Card expired|4000000000000069|Visa| Credit or debit |
 |Invalid CVC code|4000000000000127|Visa| Credit or debit |

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -33,7 +33,7 @@ You can also:
 
 You cannot use 3D Secure with test accounts.
 
-If your PSP is Stripe, you can request a test Stripe account by selecting your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see how the following work:
+If your PSP is Stripe, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see how the following work:
 
 - [transaction fees](/reporting/#psp-fees)
 - payments to your bank account

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -33,7 +33,7 @@ You can also:
 
 You cannot use 3D Secure with test accounts.
 
-If your PSP is Stripe, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see how the following work:
+If your payment service provider (PSP) is Stripe, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see how the following work:
 
 - [transaction fees](/reporting/#psp-fees)
 - payments to your bank account


### PR DESCRIPTION
### Context
Users can request test Stripe accounts to see:

- transaction fees
- payments to your bank account

### Changes proposed in this pull request

- Update references to 'test' accounts if we mean specifically a sandbox or a Stripe test account
- Add a journey to request a test Stripe account on appropriate pages 
- Add mock card numbers for Stripe test accounts

### Guidance to review
Please check if factually correct