### PR TITLE
PP-7883 Move API browser content into tech docs

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -20,14 +20,11 @@ You can [get started with the API quickly](/quick_start_guide/#quick-start). Mak
 
 When we add new properties to the JSON responses, the GOV.UK Pay API version number will not change. You should develop your service to ignore properties it does not understand.
 
-## API browser and Swagger file
+## Swagger file
 
-For more detailed information on each API action, you can:
+For more detailed information on each API action, you can look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">API Swagger file</a>.
 
-- open the <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a>
-- look at the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">API Swagger file</a>
-
-You can also generate a client library from the Swagger file using the <a href="http://editor.swagger.io/" target="blank">Swagger editor</a>. This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
+You can also generate a client library from the Swagger file using [Swagger editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
 ## Allowing traffic to our API
 
@@ -50,14 +47,39 @@ Authorization: Bearer <YOUR-API-KEY-HERE>
 
 ## Payment status lifecycle
 
-The following table summarises the payment status lifecycle and the possible outcomes, excluding for delayed capture payments.
+You can [get information about a payment](/reporting/#get-information-about-a-single-payment) using the API and see the payment's `state` in the API response.
 
+For example:
 
-You can check the status of a payment using the <a
-href="https://govukpay-api-browser.cloudapps.digital/#get-a-payment"
-target="blank">Find payment by ID</a> API call.
+```json
+{
+  "amount": 2000,
+  "state": {
+      "status": "failed",
+      "finished": true,
+      "message": "Payment expired",
+      "code": "P0020"
+  }
+  ...
+}
+```
 
-A successful response includes ``status`` and ``finished`` values:
+You can also use the GOV.UK Pay admin tool.
+
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
+2. Select an account.
+3. Select __Transactions__.
+4. Use the __Payment status__ dropdown to find payments with error statuses. For example, “Declined”.
+
+### code
+
+If something went wrong, `code` is an [API error code](/api_reference/#api-error-codes).
+
+### message
+
+If something went wrong, `message` is a description of what went wrong.
+
+### status and finished
 
 <table style="width:100%">
   <tr>
@@ -108,11 +130,11 @@ A successful response includes ``status`` and ``finished`` values:
   </tr>
 </table>
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
+## Error codes
 
-## HTTP status codes
+### HTTP status codes
 
-The GOV.UK Pay uses standard HTTP response code conventions:
+GOV.UK Pay uses standard HTTP response code conventions:
 
 * 100 codes are informational
 * 200 codes indicate success
@@ -121,8 +143,6 @@ The GOV.UK Pay uses standard HTTP response code conventions:
 * 500 codes indicate a server-side error
 
 Common status codes are:
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 | Common status code| Meaning|
 |-------------------|--------|
@@ -137,9 +157,19 @@ Common status codes are:
 | 429 | Too many requests. Request rate is above the rate limit. |
 | Any 500 error | Something is wrong with GOV.UK Pay. [Contact us](/support_contact_and_more_information/). |
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
+### API error codes
 
-## API error codes
+Example error response:
+
+```json
+{
+  "field": "amount",
+  "code": "P0102",
+  "description": "Invalid attribute value: amount. Must be less than or equal to 10000000"
+}
+```
+
+These error descriptions are intended for developers, not your users.
 
 ### Errors caused by an API call
 
@@ -185,19 +215,6 @@ Common status codes are:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-The general format of JSON error response bodies is:
-
-```javascript
-{
-  "code": "PXXXX",
-  "description": "Message explaining the error"
-}
-```
-
-These error descriptions are intended for developers, not your users.
-
-Some errors may contain additional fields , such as `field`.
-
 #### Fix a P0920 API error
 
 If you receive a P0920 API error code, our firewall blocked your request.
@@ -212,8 +229,6 @@ To fix a P0920 API error, make sure your API request:
 
 ### Errors caused by payment statuses
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
 | Error code | Meaning | Cause |
 |------------|---------|-------|
 | P0010 | Payment method rejected | Payment rejected due to payment method selected, or payment information entered. For example, failed fraud check, a 3D Secure authentication failure, or your user has insufficient funds in account. |
@@ -221,39 +236,6 @@ To fix a P0920 API error, make sure your API request:
 | P0030 | Payment cancelled by your user | Your user selected **Cancel payment** during the payment journey. If the payment was already authorised, GOV.UK Pay will send a cancellation to the payment provider. |
 | P0040 | Payment was cancelled by your service | Your service cancelled the payment. |
 | P0050 | Payment provider returned an error | Multiple possible causes, for example a configuration problem with the payment provider, or incorrect credentials. [Contact us](/support_contact_and_more_information/), quoting the error code. |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
-You can see which payments have status-related error codes using the GOV.UK
-Pay admin tool or directly using the API.
-
-#### Use the admin tool
-
-1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
-
-2. Select an account.
-
-3. Select __Transactions__.
-
-4. Use the __Payment status__ dropdown to find payments with error statuses. For example, “Declined”.
-
-#### Use the API
-
-You can [get information about a payment](/reporting/#get-information-about-a-single-payment) using the API and see the payment's `state` in the API response.
-
-For example:
-
-```
-{
-  "amount": 2000,
-  "state": {
-      "status": "failed",
-      "finished": true,
-      "message": "Payment expired",
-      "code": "P0020"
-  },
-}
-```
 
 ## Rate limits
 

--- a/source/custom_metadata/index.html.md.erb
+++ b/source/custom_metadata/index.html.md.erb
@@ -43,9 +43,6 @@ The API response will include your metadata.
 
 You cannot add or change metadata keys or values after you've created the payment request.
 
-Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#newpayment" target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
-
 ## Getting a payment's metadata
 
 When you [get information about a single payment](/reporting/#get-information-about-a-single-payment) or [generate a list of payments](/reporting/#search-payments), the API response will include the `metadata` object.

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -27,10 +27,6 @@ __Confirm__ on the __Confirm your details__ page:
 `POST /v1/payments/{paymentId}/capture` endpoint to send a delayed capture
 request
 
-Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#capturepayment"
-target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
-
 There are 7 possible responses:
 
 |Status code | Meaning |

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -115,7 +115,6 @@ The GOV.UK Pay API offers a set of operations to conduct and report on
 payments. For more information:
 
 - read our [API reference](/api_reference)
-- use the <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a>
 - look at the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>
 
 ## When to release your service to your users

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -82,7 +82,7 @@ If you need to take payments above the maximum amount, either:
 
 #### delayed_capture
 
-You can use the `delayed_capture` parameter to [control how long it takes GOV.UK Pay to take ('capture') a payment](/delayed_capture/#delay-taking-a-payment).
+You can use this field to [delay taking a payment](/delayed_capture/#delay-taking-a-payment).
 
 #### description
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -33,10 +33,30 @@ For example:
   "reference" : "12345",
   "description": "Pay your council tax",
   "return_url": "https://your.service.gov.uk/completed"
+  "delayed_capture": false,
+  "metadata": { 
+    "ledger_code": "AB100",
+    "an_internal_reference_number": 200
+  },
+  "email": "sherlock.holmes@example.com",
+  "prefilled_cardholder_details": {
+    "cardholder_name": "Sherlock Holmes",
+    "billing_address": {
+        "line1": "221 Baker Street",
+        "line2": "Flat b",
+        "postcode": "NW1 6XE",
+        "city": "London",
+        "country": "GB"
+    }
+  }
+  "language": "en",
+  ...
 }
 ```
 
-### amount
+### API call parameters
+
+#### amount
 
 `amount` is the amount in pence. In the example, the payment is for £145.
 
@@ -60,7 +80,29 @@ If you need to take payments above the maximum amount, either:
 - [contact us](/support_contact_and_more_information/)
 - [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) if you are using Government Banking's contracted PSP, which is currently Worldpay
 
-### reference
+#### delayed_capture
+
+You can use the `delayed_capture` parameter to [control how long it takes GOV.UK Pay to take ('capture') a payment](/delayed_capture/#delay-taking-a-payment).
+
+#### description
+
+`description` is a human-readable description of the payment. This is shown to your user on the payment pages and to your staff on the GOV.UK Pay admin tool.
+
+The description must be no longer than 255 characters, and must not contain URLs.
+
+#### email and prefilled_cardholder_details
+
+You can use the `email` and `prefilled_cardholder_details` parameters to [prefill some of the fields on the **Enter card details** page](/optional_features/prefill_user_details/#prefill-payment-fields).
+
+#### language
+
+You can use the `language` field to [use Welsh on your payment pages](/optional_features/welsh_language/#use-welsh-on-your-payment-pages).
+
+#### metadata
+
+You can use the `metadata` parameter to [add custom metadata](/custom_metadata/#add-custom-metadata).
+
+#### reference
 
 `reference` is the reference number you wish to associate with this payment.
 
@@ -71,14 +113,7 @@ The reference number does not need to be unique, and must not:
 
 The format is variable. If you have an existing format, you can keep using it if your values are no longer than 255 characters.
 
-
-### description
-
-`description` is a human-readable description of the payment. This is shown to your user on the payment pages and to your staff on the GOV.UK Pay admin tool.
-
-The description must be no longer than 255 characters, and must not contain URLs.
-
-### return_url
+#### return_url
 
 This is a URL that your service hosts for your user to return to, after their payment journey on GOV.UK Pay ends.
 
@@ -87,36 +122,95 @@ HTTP with test accounts.
 
 The URL must be no longer than 2,000 characters, and must not be JSON-encoded because backslashes are invalid characters in the API.
 
-Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">GOV.UK Pay API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more
-information.
-
 ## Receiving the API response
 
-The response to the ‘Create new payment’ API call will include the URL for the
-payment. You can get this from either:
+Example response:
+
+```json
+{
+  "created_date": "2020-03-03T16:17:19.554Z",
+  "state": {
+    "status": "created",
+    "finished": false,
+  },
+  "_links": {
+    "self": {
+      "href": "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93",
+      "method": "GET"
+   },
+    "next_url": {
+      "href": "https://publicapi.payments.service.gov.uk/secure/bb0a272c-8eaf-468d-b3xf-ae5e000d2231",
+      "method": "GET"
+    },
+    ...
+  },
+  "amount": 14500,
+  "reference" : "12345",
+  "description": "Pay your council tax",
+  "return_url": "https://your.service.gov.uk/completed",
+  "payment_id": "hu20sqlact5260q2nanm0q8u93",
+  "payment_provider": "worldpay",
+  "provider_id": "10987654321",
+  ...
+}
+```
+
+The response to the ‘Create new payment’ API call will include the URL for the payment. You can get this from either:
 
 * the `Location` response header
 * the `self` section of `_links` in the JSON body
 
-The URL contains the GOV.UK Pay `paymentId`, which is automatically
-generated and identifies the payment. A GET request to this URL
-will return information about the payment and its status.
+The URL contains the GOV.UK Pay `paymentId`, which is automatically generated and identifies the payment. A GET request to this URL will return information about the payment and its status.
 
-Your service will need to store the `paymentId` (or the full URL) for each new
-payment you create. This is so you can check the status of these payments
-later.
+Your service will need to store the `paymentId` (or the full URL) for each new payment you create. This is so you can check the status of these payments later.
 
 Read more about [reporting](/reporting/#report-on-a-payment) and [payment flow](/payment_flow/#how-gov-uk-pay-works).
-
-An example URL:
-`https://publicapi.payments.service.gov.uk/v1/payments/{paymentId}`
 
 The response will also include the ``next_url`` to which you should direct your
 user to complete their payment.
 
 <%= warning_text('Do not expose the `next_url` to anyone other than your paying user. Anyone in possession of the `next_url` could hijack your user’s payment.') %>
+
+### API response fields
+
+#### \_links
+
+The `_links` object includes `href` and `method` fields that you can use to make API requests related to the payment. Use the fields in:
+
+- `self` to [get information about the payment](/reporting/)
+- `events` to [get the payment's events](/reporting/#get-a-payment-s-events)
+- `refunds` to [get all refunds for the payment](/refunding_payments/#get-all-refunds-for-a-single-payment)
+- `cancel` to [cancel the payment](/making_payments/#cancel-a-payment-that-s-in-progress)
+
+The `_links` object also includes a `next_url_post` URL, for example:
+
+```json
+"next_url_post": {
+  "type": "application/x-www-form-urlencoded",
+  "params": "\"description\":\"This is a value for a parameter called description\"",
+  "href": "https://publicapi.payments.service.gov.uk/secure/bb0a272c-8eaf-468d-b3xf-ae5e000d2231",
+  "method": "POST"
+},
+```
+
+To help you test your integration, you can automatically complete the **Enter card details** payment page by making a `POST` API request to the `next_url_post` URL with a `params` object.
+ 
+#### created_date
+
+`created_date` is when you created the payment, in [ISO
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+
+#### payment_provider
+
+`payment_provider` is the name of your payment service provider (PSP), or `sandbox` if you're using a test ('sandbox') account.
+
+#### provider_id
+
+`provider_id` is the unique id that your PSP generated for this payment. 
+
+#### state
+
+Use `state` to see the [status of the payment](/api_reference/#payment-status-lifecycle).
 
 ## Track the progress of a payment
 
@@ -195,8 +289,6 @@ progress. Alternatively, a service can make the following API call for a given
 `POST /v1/payments/paymentId/cancel`
 
 A `204` response indicates success. Any other response indicates an error.
-
-See the <a href="https://govukpay-api-browser.cloudapps.digital/#cancel-a-payment" target="blank">GOV.UK Pay API browser</a> for more details.
 
 ### Find out if you can cancel a payment
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -208,7 +208,7 @@ You can use the `href` and `chargeTokenId` to make a `POST` API request to `next
 
 #### provider_id
 
-`provider_id` is the unique id that your PSP generated for this payment. 
+`provider_id` is the unique ID that your PSP generated for this payment. 
 
 #### state
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -182,18 +182,20 @@ The `_links` object includes `href` and `method` fields that you can use to make
 - `refunds` to [get all refunds for the payment](/refunding_payments/#get-all-refunds-for-a-single-payment)
 - `cancel` to [cancel the payment](/making_payments/#cancel-a-payment-that-s-in-progress)
 
-The `_links` object also includes a `next_url_post` URL, for example:
+The `_links` object also includes a `next_url_post` object,  For example:
 
 ```json
 "next_url_post": {
-  "type": "application/x-www-form-urlencoded",
-  "params": "\"description\":\"This is a value for a parameter called description\"",
-  "href": "https://publicapi.payments.service.gov.uk/secure/bb0a272c-8eaf-468d-b3xf-ae5e000d2231",
-  "method": "POST"
+   "type": "application/x-www-form-urlencoded",
+   "params": {
+       "chargeTokenId": "bb0a272c-8eaf-468d-b3xf-ae5e000d2231"
+   },
+   "href": "https://www.pymnt.uk/secure",
+   "method": "POST"
 },
 ```
 
-To help you test your integration, you can automatically complete the **Enter card details** payment page by making a `POST` API request to the `next_url_post` URL with a `params` object.
+You can use the `href` and `chargeTokenId` to make a `POST` API request to `next_url`, instead of a `GET` API request.
  
 #### created_date
 

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -41,10 +41,6 @@ All the parameters in `billing_address` are optional, and these parameters' valu
 
 If you include the `country` parameter, it must be an <a href="https://www.iso.org/obp/ui/#search/code/" target="_blank">ISO 3166-1 alpha-2 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'United Kingdom'.
 
-Refer to the <a
-href="https://govukpay-api-browser.cloudapps.digital/#newpayment"
-target="blank">API browser</a> or the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a> for more information.
-
 ## Data collected by your GOV.UK Pay admin account
 
 After your user completes their payment, your GOV.UK Pay account will collect your user's:

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -30,10 +30,6 @@ payment failure states are from API responses. Once your service
 knows the [state of a payment](/payment_flow/#check-the-status-of-a-payment), it should direct your user appropriately. For
 example if your user's payment expires, you may want your service to return your user to the start of their payment journey.
 
-See the <a
-href="https://govukpay-api-browser.cloudapps.digital/" target="blank">GOV.UK Pay API
-browser</a> for more details.
-
 In very rare cases, GOV.UK Pay is unable to redirect payments. You should
 [contact us](/support_contact_and_more_information/) if this
 happens.

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -34,7 +34,7 @@ If you want to build a technical integration between your service and the GOV.UK
 
 You can refer to the [GOV.UK Service Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have) for more information.
 
-Visit our <a href="https://govukpay-api-browser.cloudapps.digital/" target="blank">API browser</a> or look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>
+You can generate a client library from [our Swagger file](https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json) using [Swagger Editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
 See the [documentation on integrating with the API](/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api) for more information.
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -37,6 +37,14 @@ For a completed £90 payment where £30 has already been refunded:
 }
 ```
 
+### amount_available
+
+`amount_available` is how much you can refund in pence. The amount includes any [transaction fees](/reporting/#psp-fees) and [corporate card fees](/corporate_card_surcharges/#add-corporate-card-fees).
+
+### amount_submitted
+
+`amount_submitted` is how much you've already refunded.
+
 ### status
 
 |Status|Meaning|
@@ -45,14 +53,6 @@ For a completed £90 payment where £30 has already been refunded:
 |unavailable|You cannot refund the payment, usually because the payment failed.|
 |available|You can refund the payment. Check how much you can refund in `amount_available`.|
 |full|You cannot refund the payment because you've already refunded the full amount.|
-
-### amount_available
-
-`amount_available` is how much you can refund in pence. The amount includes any [transaction fees](/reporting/#psp-fees) and [corporate card fees](/corporate_card_surcharges/#add-corporate-card-fees).
-
-### amount_submitted
-
-`amount_submitted` is how much you've already refunded.
 
 ## Creating a refund
 
@@ -95,13 +95,44 @@ Example response:
 
 If GOV.UK Pay could not successfully create the refund, the JSON response will contain an [API error code](/api_reference/#api-error-codes) and a description of the error.
 
+### created_date
+
+`created_date` is when you created the refund, in [ISO
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+
+### refund_id
+
+`refund_id` is the unique id that GOV.UK Pay generated for this refund.
+
+### status
+
+Use the `status` field to [check the status of a refund](#checking-the-status-of-a-refund).
+
 ## Checking the status of a refund
 
 `GET /v1/payments/PAYMENT-ID/refunds/REFUND-ID`
 
-The JSON response will include a `status` field.
+Example response:
 
-It may take up to 30 minutes for the status to change. Do not check the status more than once every 5 minutes.
+```json
+{
+  "amount": 2000,
+  "created_date": "2019-09-19T16:53:03.213Z",
+  "refund_id": "j6se0f2o427g28g8yg3u3i",
+  "status": "success",
+  "settlement_summary": {
+    "settled_date": "2019-09-21"
+  }
+}
+```
+
+### settlement_summary
+
+If your payment service provider (PSP) is Stripe, you can use the `settlement_summary` object to [check when Stripe took the refund](#where-your-psp-takes-the-refund-amount-from).
+
+### status
+
+It may take up to 30 minutes for the `status` field to change. Do not check the status more than once every 5 minutes.
 
 |status|Meaning|
 |---|---|
@@ -125,14 +156,14 @@ If your PSP is Stripe, you can see when Stripe took the refund when you make an 
 
 Example response:
 
-```
+```json
 "settlement_summary": {
   ...
-  "settled_date": "2016-01-22",
+  "settled_date": "2019-09-21",
 }
 ```
 
-settled_date will be either:
+`settled_date` will be either:
 
 - the date Stripe took the refund from the payments that Stripe sent to your bank account
 - missing if Stripe has not yet taken the refund
@@ -167,12 +198,18 @@ Example response:
         "created_date": "2019-09-19T16:52:07.855Z",
         "amount": 120,
         "status": "success"
+        "settlement_summary": {
+          "settled_date": "2019-09-21"
+        }
       },
       {
         "refund_id": "9rwjbdcpjd54ol1btog2a8zowh",
         "created_date": "2019-09-20T20:46:01.121Z",
         "amount": 60,
         "status": "success"
+        "settlement_summary": {
+          "settled_date": "2019-09-21"
+        }
       }
     ]
   }
@@ -187,6 +224,52 @@ An example search request:
 
 `GET
 /v1/refunds?from_date=2019-09-20T13:30:00Z&to_date=2019-09-22T15:00:00Z`
+
+Example search response:
+
+```json
+{
+  "total": 100,
+  "count": 20,
+  "page": 2,
+  "results": [
+    {
+      "refund_id": "act4c33g40j3edfmi8jknab84x",
+      "created_date": "2017-01-10T16:52:07.855Z",
+      "amount": 120,
+      "status": "success",
+      "settlement_summary": {
+        "settled_date": "2017-01-11"
+      }
+      "_links": {
+        "payment": {
+            "href": "https://publicapi.payments.service.gov.uk/v1/payments/5chu1yzxglqajfv97ous23s22i",
+            "method": "GET"
+        }
+      ...
+      }
+    },
+    {
+      "refund_id": "efj6834secviyyxe8vs861pg3j",
+      ...
+    }    
+  ],
+  "_links": {
+    "prev_page": {
+      "href": "https://publicapi.payments.service.gov.uk/v1/refunds?display_size=20&page=1",
+      "method": "GET"
+    },
+    "next_page": {
+      "href": "https://publicapi.payments.service.gov.uk/v1/refunds?display_size=20&page=3",
+      "method": "GET"
+    }
+    ...
+  }
+  ...
+}
+```
+
+The `_links` object includes a `payment` URL and method that you can use to get information about the payment the refund is for.
 
 ### Filtering by date
 
@@ -235,3 +318,11 @@ You could then get a single page of these refunds by running:
 /v1/refunds?from_date=2019-09-20T13:30:00Z&to_date=2019-09-22T15:00:00Z&display_size=500&page=2`
 
 This would return refunds 501 to 1000.
+
+The API response includes a `_links` object, which includes `href` and `method` fields you can use to move between pages. Use the fields in:
+
+- `self` to run the same search again
+- `first_page` to get the first page of results
+- `last_page` to get the last page
+- `prev_page` to get the previous page
+- `next_page` to get the next page

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -102,7 +102,7 @@ If GOV.UK Pay could not successfully create the refund, the JSON response will c
 
 ### refund_id
 
-`refund_id` is the unique id that GOV.UK Pay generated for this refund.
+`refund_id` is the unique ID that GOV.UK Pay generated for this refund.
 
 ### status
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -114,8 +114,7 @@ Example response:
 }
 ```
 
-You know that your user can continue their journey
-through your service if in the `state` object the:
+Your user can continue their journey through your service if, in the `state` object, the:
 
 - `status` field is `success`
 - `finished` field is `true`
@@ -158,7 +157,7 @@ payment journey, the `card_details` section contains the information they entere
 
 #### corporate_card_surcharge
 
-`corporate_card_surcharge` shows the surcharge amount if you've [set up adding corporate card fees](/corporate_card_surcharges/#add-corporate-card-fees).
+`corporate_card_surcharge` shows the surcharge amount in pence if you've [set up adding corporate card fees](/corporate_card_surcharges/#add-corporate-card-fees).
 
 #### created_date
 
@@ -195,7 +194,7 @@ You can use `refund_summary` to [check if you can refund a payment](/refunding_p
 
 #### return_url 
 
-`return_url` is the URL that your service hosted for your user to return to, after their payment journey on GOV.UK Pay ended.
+`return_url` is the URL that your service hosts for your user to return to, after their payment journey on GOV.UK Pay ended.
 
 #### settlement_summary
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -63,7 +63,7 @@ Example response:
 ```json
 {
   "created_date": "2019-07-11T10:36:26.988Z",
-  "amount": 4000,
+  "amount": 3750,
   "state": {
     "status": "success",
     "finished": true,
@@ -94,7 +94,7 @@ Example response:
   "payment_id": "hu20sqlact5260q2nanm0q8u93",
   "refund_summary": {
     "status": "available",
-    "amount_available": 4000,
+    "amount_available": 3750,
     "amount_submitted": 0
   },
   "settlement_summary": {

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -94,7 +94,7 @@ Example response:
   "payment_id": "hu20sqlact5260q2nanm0q8u93",
   "refund_summary": {
     "status": "available",
-    "amount_available": 3750,
+    "amount_available": 4000,
     "amount_submitted": 0
   },
   "settlement_summary": {
@@ -182,7 +182,7 @@ If you use GOV.UK’s Payment Service Provider (PSP), `net_amount` is the amount
 
 #### payment_id
 
-`payment_id` is the unique id that GOV.UK Pay automatically generated for this payment.
+`payment_id` is the unique ID that GOV.UK Pay automatically generated for this payment.
 
 #### payment_provider
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -58,48 +58,155 @@ You can use the GOV.UK Pay API to:
 
 `GET /v1/payments/{paymentId}`
 
-See the <a href="https://govukpay-api-browser.cloudapps.digital/#getpayment" target="blank">GOV.UK Pay API browser</a> for more details
+Example response:
 
-If the payment exists, the JSON response body to this
-API call contains a `state` field. You can use this information when
-designing a service.
-
-For example, the response for a successful payment contains:
-
-```JSON
-"state": {
-  "status": "success",
-  "finished": true
-},
-```
-
-With a successful payment, you know that your user can continue their journey
-through your service.
-
-For a valid request, the JSON response body to this API call also contains
-other useful information. For example, if your user has gone far enough in their
-payment journey, the `card_details` section contains information that they
-have entered when making a payment:
-
-```JSON
-"card_details": {
-  "card_type": "debit",
-  "card_brand": "visa",
-  "last_digits_card_number": "1111",
-  "first_digits_card_number": "100002",
-  "cardholder_name": "Sherlock Holmes",
-  "expiry_date": "12/21",
-  "billing_address": {
-    "line1": "221 Baker Street",
-    "line2": "Flat b",
-    "postcode": "NW16XE",
-    "city": "London",
-    "country": "GB"
-  }
+```json
+{
+  "created_date": "2019-07-11T10:36:26.988Z",
+  "amount": 4000,
+  "state": {
+    "status": "success",
+    "finished": true,
+  },
+  "description": "Pay your council tax",
+  "reference": "12345",
+  "language": "en",
+  "metadata": { 
+    "ledger_code": "AB100",
+    "an_internal_reference_number": 200
+  },
+  "email": "sherlock.holmes@example.com",
+  "card_details": {
+    "card_brand": "Visa",
+    "card_type": "debit",
+    "last_digits_card_number": "1234",
+    "first_digits_card_number": "123456",
+    "expiry_date": "04/24",
+    "cardholder_name": "Sherlock Holmes",
+    "billing_address": {
+        "line1": "221 Baker Street",
+        "line2": "Flat b",
+        "postcode": "NW1 6XE",
+        "city": "London",
+        "country": "GB"
+    }
+  },  
+  "payment_id": "hu20sqlact5260q2nanm0q8u93",
+  "refund_summary": {
+    "status": "available",
+    "amount_available": 4000,
+    "amount_submitted": 0
+  },
+  "settlement_summary": {
+    "capture_submit_time": "2019-07-12T17:15:000Z",
+    "captured_date": "2019-07-12",
+    "settled_date": "2019-07-12"
+  },
+  "delayed_capture": false,
+  "moto": false,
+  "corporate_card_surcharge": 250,
+  "total_amount": 4000,
+  "fee": 200,
+  "net_amount": 3800,
+  "payment_provider": "worldpay",
+  "provider_id": "10987654321",
+  "return_url": "https://your.service.gov.uk/completed"
 }
 ```
 
-The `card_type` is `null` if we did not recognise which type of card your user made the payment with.
+You know that your user can continue their journey
+through your service if in the `state` object the:
+
+- `status` field is `success`
+- `finished` field is `true`
+
+### API response parameters
+
+#### \_links
+  
+The `_links` object includes `href` and `method` fields that you can use to make API requests related to the payment. Use:
+
+- `events` to [get the payment's events](/reporting/#get-a-payment-s-events)
+- `refunds` to [get all refunds for the payment](/refunding_payments/#get-all-refunds-for-a-single-payment)
+- `cancel` to [cancel the payment](/making_payments/#cancel-a-payment-that-s-in-progress)
+
+#### card_details
+
+If your user has gone far enough in their
+payment journey, the `card_details` section contains the information they entered when they made the payment. All the fields are strings.
+
+`billing_address` will be `null` if you've [disabled collecting your users’ billing addresses](/integrate_with_govuk_pay/#collecting-your-users-39-billing-addresses).
+
+`expiry_date` is in `MM/YY` format, for example `04/24`.
+
+`card_brand` is one of the following:
+
+- `American Express`
+- `Diners Club`
+- `Discover`
+- `Jcb`
+- `Maestro`
+- `Mastercard`
+- `Union Pay`
+- `Visa`
+
+`card_type` is one of the following:
+
+- `credit`
+- `debit`
+- `null` - if we did not recognise which type of card your user made the payment with, or your user used [Google Pay](/digital_wallets/#restrictions).
+
+#### corporate_card_surcharge
+
+`corporate_card_surcharge` shows the surcharge amount if you've [set up adding corporate card fees](/corporate_card_surcharges/#add-corporate-card-fees).
+
+#### created_date
+
+`created_date` is when you created the payment, in [ISO
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+
+#### delayed_capture
+
+`delayed_capture` is `true` if you're [controlling how long it takes GOV.UK Pay to take ('capture') a payment](/delayed_capture/#delay-taking-a-payment).
+
+#### fee
+
+If you use GOV.UK’s Payment Service Provider (PSP), `fee` is the [PSP transaction fee](https://docs.payments.service.gov.uk/reporting/#psp-fees) that we took from the amount your user paid.
+
+#### moto
+
+`moto` is `true` if you [took the payment over the phone](/moto_payments/#take-a-payment-over-the-phone-moto-payments).
+
+#### net_amount
+
+If you use GOV.UK’s Payment Service Provider (PSP), `net_amount` is the amount that will be paid into your account after we take the [PSP transaction fee](https://docs.payments.service.gov.uk/reporting/#psp-fees). 
+
+#### payment_id
+
+`payment_id` is the unique id that GOV.UK Pay automatically generated for this payment.
+
+#### payment_provider
+
+`payment_provider` is the name of your payment service provider (PSP), or `sandbox` if you're using a test ('sandbox') account.
+
+#### refund_summary
+
+You can use `refund_summary` to [check if you can refund a payment](/refunding_payments/#check-if-you-can-refund-a-payment).
+
+#### return_url 
+
+`return_url` is the URL that your service hosted for your user to return to, after their payment journey on GOV.UK Pay ended.
+
+#### settlement_summary
+
+Use `settlement_summary` to check when your payment service provider (PSP):
+
+- [took the payment from your user's account](#checking-when-your-payment-service-provider-psp-took-a-payment)
+- [sent a payment to your bank account](/integrate_with_govuk_pay/#checking-when-your-psp-sent-a-payment), if your PSP is Stripe
+  
+#### state
+
+Use `state` to see the [status of the payment](/api_reference/#payment-status-lifecycle).
 
 ### Checking when your Payment Service Provider (PSP) took a payment
 
@@ -112,7 +219,7 @@ The response contains:
 
 For example:
 
-```JSON
+```json
 "settlement_summary": {
   "capture_submit_time": "2016-01-21T17:15:000Z",
   "captured_date": "2016-01-21"
@@ -163,43 +270,43 @@ Use the following API call to get a list of a payment’s events:
 
 The API will respond with an `events` object. For each change to the payment's state, the `events` object includes:
 
-- when the `state` changed
+- an `updated` field that shows when the [`state`](/api_reference/#payment-status-lifecycle) changed, in [ISO
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
 - what the `state` was updated to
 
 The response starts with the oldest `state`.
 
 For example:
 
-```JSON
+```json
 {
-    "events": [
-        {
-            "payment_id": "9co6rdsak0btz4wuxac0a29i4a",
-            "state": {
-                "status": "created",
-                "finished": false
-            },
-            "updated": "2019-07-11T10:36:26.988Z",
-        },
-        {
-            "payment_id": "9co6rdsak0btz4wuxac0a29i4a",
-            "state": {
-                "status": "failed",
-                "finished": true,
-                "message": "Payment expired",
-                "code": "P0020"
-            },
-            "updated": "2019-07-11T12:11:35.849Z",
-        }
-    ],
+  "payment_id": "9co6rdsak0btz4wuxac0a29i4a",
+  "events": [
+      {
+          "payment_id": "9co6rdsak0btz4wuxac0a29i4a",
+          "updated": "2019-07-11T10:36:26.988Z",
+          "state": {
+              "status": "created",
+              "finished": false
+          },
+      },
+      {
+          "payment_id": "9co6rdsak0btz4wuxac0a29i4a",
+          "updated": "2019-07-11T12:11:35.849Z",
+          "state": {
+              "status": "failed",
+              "finished": true,
+              "message": "Payment expired",
+              "code": "P0020"
+          },
+      }
+  ],
 }
 ```
 
 ## Search payments
 
 `GET /v1/payments`
-
-See the <a href="https://govukpay-api-browser.cloudapps.digital/#searchpayments" target="blank">GOV.UK Pay API browser</a> for more details.
 
 Do not search payments using the API to check a payment's status during [payment flow](/payment_flow). The payment status field in the search results does not immediately update and so may not be up to date.
 
@@ -219,23 +326,58 @@ Some of the query parameters you can use to search for payments are:
 * `first_digits_card_number` - exact match only
 * `last_digits_card_number` - exact match only
 
+Example search response:
+
+```json
+{
+  "total": 100,
+  "count": 20,
+  "page": 2,
+  "results": [
+    {
+      "amount": 1200,
+      "description": "Pay your council tax",
+      "reference": "12345",
+      ...
+    },
+    {
+      "amount": 600,
+      "description": "Pay your council tax",
+      "reference": "678910",
+      ...
+    },
+  ],
+  "_links": {
+    "prev_page": {
+      "href": "https://publicapi.payments.service.gov.uk/v1/payments?display_size=20&page=1",
+      "method": "GET"
+    },
+    "next_page": {
+      "href": "https://publicapi.payments.service.gov.uk/v1/payments?display_size=20&page=3",
+      "method": "GET"
+    }
+    ...
+  }
+  ...
+}
+```
+
 If you search for a specific payment, all criteria you use must match. Otherwise, that payment will not be returned in the results.
 
 If your request has no query parameters, the API will return all payments.
 
 #### Search by card brand
 
-
 |`card_brand` to search for|`card_brand` in API response|
 |---|---|
-|`visa`|`Visa`|
-|`master-card`|`Mastercard`|
-|`maestro`|`Maestro`|
 |`american-express`|`American Express`|
 |`diners-club`|`Diners Club`|
 |`discover`|`Discover`|
 |`jcb`|`Jcb`|
+|`maestro`|`Maestro`|
+|`master-card`|`Mastercard`|
 |`unionpay`|`Union Pay`|
+|`visa`|`Visa`|
 
 `card_brand` is case insensitive. You cannot search for partial values of `card_brand`.
 
@@ -287,3 +429,11 @@ If there were 1543 payments in the response, you could paginate this as follows:
 /v1/payments?from_date=2018-10-01T13:30:00Z&to_date=2018-10-14T15:00:00Z&display_size=500&page=2`
 
 This would return payments 501-1000.
+
+The API response includes a `_links` object, which includes `href` and `method` fields you can use to move between pages. Use the fields in:
+
+- `self` to run the same search again
+- `first_page` to get the first page of results
+- `last_page` to get the last page
+- `prev_page` to get the previous page
+- `next_page` to get the next page

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -11,7 +11,7 @@ The GOV.UK Pay API follows the [Semantic Versioning 2.0.0 system](https://semver
 
 The number in the URL reflects the major version number. For example `/v1/payments/`.
 
-The version number in the [API browser](https://govukpay-api-browser.cloudapps.digital/) and the [API Swagger file](https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json) has the full MAJOR.MINOR.PATCH version number. For example `v1.0.3`.
+Our [API Swagger file](https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json) has the full MAJOR.MINOR.PATCH version number. For example `v1.0.3`.
 
 When we add new properties to the JSON responses, the GOV.UK Pay API version
 number will not change. You should develop your service to ignore properties


### PR DESCRIPTION
### Context
Our API browser has accessibility issues, so we're moving relevant content into our public tech docs (and redirecting the API browser to tech docs).

### Changes proposed in this pull request
I've moved as many API browser examples, parameters and descriptions into the tech docs content as I can.

A few things worth bearing in mind:

- I've removed or restructured some content where it overlapped or duplicated the content I've brought over from the API browser (most notably on the API reference page)
- In the interests of avoiding duplication and overlong pages, I've sometimes left out fields from API responses where they're implied or obvious - for example in the 'Get information a payment' API response example, I mostly haven't included the fields that users supplied themselves as parameters in their original 'make a payment' request.
- I've removed all references to the API browser from the docs, and only kept references to the Swagger file where it's useful for integration needs.
- On affected pages, I've made sure parameters are listed in alphabetical order in the content.
- I've made some tweaks to unaffected but related sections where I've seen them (for example adding `json` to code samples so they have syntax highlighting).

### Guidance to review
Please check if factually correct (especially the request and response examples).