### PR TITLE
PP-7852 Clarify you can go live from both types of test account

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -31,7 +31,7 @@ You'll need to tell us:
 - your organisation's name and address
 - if you’ll be using GOV.UK Pay’s PSP Stripe, or another PSP
 
-Select your test account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services), then select __Request a live account__.
+Select your test ('sandbox') account or your test Stripe account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services), then select __Request a live account__.
 
 We'll respond within one working day, and we can usually activate your live account on the same day.
 


### PR DESCRIPTION
### Context
Some users aren't sure which service to request a live account from.

### Changes proposed in this pull request
Clarify that you can go live from both types of test account.

### Guidance to review
Please check if factually correct.