### PR TITLE
Add table row header markup

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -88,42 +88,42 @@ If something went wrong, `message` is a description of what went wrong.
   <th nowrap><code>finished</code></th>
   </tr>
   <tr>
-    <td> created </td>
+    <th scope="row"> created </td>
     <td> Payment created using the API. Your user has not yet visited <code>next_url</code>. </td>
     <td> false </td>
   </tr>
   <tr>
-    <td> started </td>
+    <th scope="row"> started </td>
     <td> Your user has visited <code>next_url</code> and is entering payment details. </td>
     <td> false </td>
   </tr>
   <tr>
-    <td> submitted </td>
+    <th scope="row"> submitted </td>
     <td> Your user has submitted payment details, and gone through authentication if required.<br>The PSP has authorised the payment, but the user has not yet selected <b>Confirm</b>. </td>
     <td> false </td>
   </tr>
   <tr>
-    <td> capturable </td>
+    <th scope="row"> capturable </td>
     <td> The payment is a <a href="/delayed_capture/#delay-taking-a-payment" target="blank">delayed capture</a>, and your user has submitted payment details and selected <b>Confirm</b>. </td>
     <td> false </td>
   </tr>
   <tr>
-    <td> success </td>
+    <th scope="row"> success </td>
     <td> Your user successfully completed the payment by selecting <b>Confirm</b>. <br>The user is redirected to an appropriate payment confirmation page.</td>
     <td> true </td>
   </tr>
   <tr>
-    <td> failed </td>
+    <th scope="row"> failed </td>
     <td> Your user attempted to make a payment but the payment did not complete. <br>GOV.UK Pay shows an appropriate screen for the failure.<br>Check the <a href="#errors-caused-by-payment-statuses">payment status error code</a> for more information.</td>
     <td> true </td>
   </tr>
   <tr>
-    <td> cancelled </td>
+    <th scope="row"> cancelled </td>
     <td> Your service cancelled the payment using an API call or the GOV.UK Pay admin tool. </td>
     <td> true </td>
   </tr>
   <tr>
-    <td> error </td>
+    <th scope="row"> error </td>
     <td> Something went wrong with GOV.UK Pay or the underlying payment service provider. Payment fails safely with no money taken. <br><br>
       The user will see a screen stating "We're experiencing technical problems. No money has been taken from your account. Cancel and go back to try the payment again."
     <td> true </td>

--- a/source/contribute/index.html.md.erb
+++ b/source/contribute/index.html.md.erb
@@ -17,17 +17,17 @@ GOV.UK Pay’s main application code is public and freely available under an MIT
 
 | Component | Description | Use |
 | --- | --- | --- |
-| [pay-adminusers](https://github.com/alphagov/pay-adminusers) | GOV.UK Pay identity and service management component. | Used by pay-selfservice to allow users to authenticate and configure GOV.UK Pay. |
-| [pay-cardid](https://github.com/alphagov/pay-cardid) | GOV.UK Pay card type identification Service. | Used by pay-frontend to validate card details and autocomplete card brand. |
-| [pay-connector](https://github.com/alphagov/pay-connector) | GOV.UK Pay payments connector. | Used by other services to configure payment gateways and handle transactions. |
-| [pay-frontend](https://github.com/alphagov/pay-frontend) | GOV.UK Pay frontend payments application. | Collects payment details from our users. |
-| [pay-publicapi](https://github.com/alphagov/pay-publicapi) | GOV.UK Pay public API endpoint. | Used by partner services to manage payments, generate reporting and configure their accounts. |
-| [pay-publicauth](https://github.com/alphagov/pay-publicauth) | GOV.UK Pay API authentication service. | Used by pay-publicapi to validate API tokens and by pay-selfservice to manage API tokens. |
-| [pay-selfservice](https://github.com/alphagov/pay-selfservice) | GOV.UK Pay self service application. | Used by authenticated users of our partner services to administer their accounts. |
-| [pay-products](https://github.com/alphagov/pay-products) | Application that manages products that integrate with GOV.UK Pay using Java (Dropwizard). | Manages products that a Government Service would like to take payments for. These products are integrated with GOV.UK Pay so that a user can make payments using a provided URL. |
-| [pay-products-ui](https://github.com/alphagov/pay-products-ui) | User interface app for product payments integrated with GOVUK Pay. | Starts payment journeys for payment links. Optionally allows users to enter payment amount and reference. |
-| [pay-direct-debit-connector](https://github.com/alphagov/pay-direct-debit-connector) | The GOVUK Pay direct debit connector. | Interfaces with Direct Debit providers. |
-| [pay-direct-debit-frontend](https://github.com/alphagov/pay-direct-debit-frontend) | The GOVUK Pay direct debit frontend. | Collects Direct Debit information from our users. |
-| [pay-ledger](https://github.com/alphagov/pay-ledger) | A Dropwizard app for the Pay Ledger microservice. | Stores all historic payments and refunds after this information has been processed by Card Connector. |
+|# [pay-adminusers](https://github.com/alphagov/pay-adminusers) | GOV.UK Pay identity and service management component. | Used by pay-selfservice to allow users to authenticate and configure GOV.UK Pay. |
+|# [pay-cardid](https://github.com/alphagov/pay-cardid) | GOV.UK Pay card type identification Service. | Used by pay-frontend to validate card details and autocomplete card brand. |
+|# [pay-connector](https://github.com/alphagov/pay-connector) | GOV.UK Pay payments connector. | Used by other services to configure payment gateways and handle transactions. |
+|# [pay-frontend](https://github.com/alphagov/pay-frontend) | GOV.UK Pay frontend payments application. | Collects payment details from our users. |
+|# [pay-publicapi](https://github.com/alphagov/pay-publicapi) | GOV.UK Pay public API endpoint. | Used by partner services to manage payments, generate reporting and configure their accounts. |
+|# [pay-publicauth](https://github.com/alphagov/pay-publicauth) | GOV.UK Pay API authentication service. | Used by pay-publicapi to validate API tokens and by pay-selfservice to manage API tokens. |
+|# [pay-selfservice](https://github.com/alphagov/pay-selfservice) | GOV.UK Pay self service application. | Used by authenticated users of our partner services to administer their accounts. |
+|# [pay-products](https://github.com/alphagov/pay-products) | Application that manages products that integrate with GOV.UK Pay using Java (Dropwizard). | Manages products that a Government Service would like to take payments for. These products are integrated with GOV.UK Pay so that a user can make payments using a provided URL. |
+|# [pay-products-ui](https://github.com/alphagov/pay-products-ui) | User interface app for product payments integrated with GOVUK Pay. | Starts payment journeys for payment links. Optionally allows users to enter payment amount and reference. |
+|# [pay-direct-debit-connector](https://github.com/alphagov/pay-direct-debit-connector) | The GOVUK Pay direct debit connector. | Interfaces with Direct Debit providers. |
+|# [pay-direct-debit-frontend](https://github.com/alphagov/pay-direct-debit-frontend) | The GOVUK Pay direct debit frontend. | Collects Direct Debit information from our users. |
+|# [pay-ledger](https://github.com/alphagov/pay-ledger) | A Dropwizard app for the Pay Ledger microservice. | Stores all historic payments and refunds after this information has been processed by Card Connector. |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -17,10 +17,10 @@ How quickly we respond depends on the type of your incident.
 
 | Classification | Type | Example | Initial response time | Update frequency |
 | :--- | :--- | :--- | :--- | :--- |
-| P1 | Critical | No one in your team can log in, a significant number of your users are not able to make a payment or you have reasons to believe sensitive data has been leaked | 30 minutes (at any time) | Every hour |
-| P2 | Major | Elevated error rate, mostly up, noticeably degraded service, upstream vulnerabilities or complete component failure | 60 minutes (during office hours) | Every 2 hours |
-| P3 | Significant | Users experiencing intermittent or degraded service due to platform issue | 1 working day | Every 2 working days |
-| P4 | Minor | Component failure that is not immediately service impacting | 2 working days | Weekly |
+|# P1 | Critical | No one in your team can log in, a significant number of your users are not able to make a payment or you have reasons to believe sensitive data has been leaked | 30 minutes (at any time) | Every hour |
+|# P2 | Major | Elevated error rate, mostly up, noticeably degraded service, upstream vulnerabilities or complete component failure | 60 minutes (during office hours) | Every 2 hours |
+|# P3 | Significant | Users experiencing intermittent or degraded service due to platform issue | 1 working day | Every 2 working days |
+|# P4 | Minor | Component failure that is not immediately service impacting | 2 working days | Weekly |
 
 ### During office hours
 


### PR DESCRIPTION
**Do not merge until repo has been updated to govuk_tech_docs v2.2.0+**

### Context
The updated Tech Docs Template gem adds the [govspeak feature that lets you add row heading markup to tables](https://www.gov.uk/guidance/content-design/tables#use-headers).

### Changes proposed in this pull request
Make relevant tables accessible by adding row heading markup.

I've excluded tables where:
- there are only 2 columns
- the first column does not have row headings

### Guidance to review
Please check affected tables have row heading markup in generated HTML.