### PR TITLE
Remove redundant header link

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -8,7 +8,6 @@ service_link: https://www.payments.service.gov.uk/
 
 # Links to show on right-hand-side of header
 header_links:
-  About: https://www.payments.service.gov.uk/#main
   Get started: https://www.payments.service.gov.uk/getstarted/
   Features: https://www.payments.service.gov.uk/using-govuk-pay/
   Documentation: /

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -8,8 +8,8 @@ service_link: https://www.payments.service.gov.uk/
 
 # Links to show on right-hand-side of header
 header_links:
-  Get started: https://www.payments.service.gov.uk/getstarted/
   Features: https://www.payments.service.gov.uk/using-govuk-pay/
+  Get started: https://www.payments.service.gov.uk/getstarted/
   Documentation: /
   Support: https://www.payments.service.gov.uk/support/
   Sign In: https://selfservice.payments.service.gov.uk/login


### PR DESCRIPTION
### Context
The 'About' link in the header is causing an accessibility issue, because (despite the #about anchor), it goes to the same page as the GOV.UK logo.

### Changes proposed in this pull request
Remove the 'About' link

### Guidance to review
Please check it looks ok.