### PR TITLE
PP-7896 - Changes Swagger file references to OpenAPI to reflect our m…

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -20,11 +20,11 @@ You can [get started with the API quickly](/quick_start_guide/#quick-start). Mak
 
 When we add new properties to the JSON responses, the GOV.UK Pay API version number will not change. You should develop your service to ignore properties it does not understand.
 
-## Swagger file
+## OpenAPI file
 
-For more detailed information on each API action, you can look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">API Swagger file</a>.
+For more detailed information on each API action, you can look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/openapi/publicapi_spec.json" target="blank">OpenAPI file</a>.
 
-You can also generate a client library from the Swagger file using [Swagger editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
+You can also generate a client library from our OpenAPI file using [Swagger Editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
 ## Allowing traffic to our API
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -105,8 +105,8 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 To change what appears on your users' bank statements, you can either:
 
-- if your PSP is Stripe, [contact us](/support_contact_and_more_information/#support) 
-- if you're using Government Banking's contracted PSP, [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk) 
+- if your PSP is Stripe, [contact us](/support_contact_and_more_information/#support)
+- if you're using Government Banking's contracted PSP, [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk)
 - contact your PSP directly
 
 ## The GOV.UK Pay API
@@ -115,7 +115,7 @@ The GOV.UK Pay API offers a set of operations to conduct and report on
 payments. For more information:
 
 - read our [API reference](/api_reference)
-- look at the <a href="https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json" target="blank">Swagger file</a>
+- look at our <a href="https://github.com/alphagov/pay-publicapi/blob/master/openapi/publicapi_spec.json" target="blank">OpenAPI file</a>
 
 ## When to release your service to your users
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -34,7 +34,7 @@ If you want to build a technical integration between your service and the GOV.UK
 
 You can refer to the [GOV.UK Service Manual](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team#roles-your-team-must-have) for more information.
 
-You can generate a client library from [our Swagger file](https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json) using [Swagger Editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
+You can generate a client library from [our OpenAPI file](https://github.com/alphagov/pay-publicapi/blob/master/openapi/publicapi_spec.json) using [Swagger Editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
 See the [documentation on integrating with the API](/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api) for more information.
 

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -11,7 +11,7 @@ The GOV.UK Pay API follows the [Semantic Versioning 2.0.0 system](https://semver
 
 The number in the URL reflects the major version number. For example `/v1/payments/`.
 
-Our [API Swagger file](https://github.com/alphagov/pay-publicapi/blob/master/swagger/swagger.json) has the full MAJOR.MINOR.PATCH version number. For example `v1.0.3`.
+Our [OpenAPI file](https://github.com/alphagov/pay-publicapi/blob/master/openapi/publicapi_spec.json) has the full MAJOR.MINOR.PATCH version number. For example `v1.0.3`.
 
 When we add new properties to the JSON responses, the GOV.UK Pay API version
 number will not change. You should develop your service to ignore properties


### PR DESCRIPTION
### Context
Swagger v2 is being deprecated in favour of OpenAPI v3 and the docs need to reflect this.

### Changes proposed in this pull request
References to the Swagger file are now OpenAPI references.

Swagger file links are now links to the OpenAPI spec.

### Guidance to review
