### PR TITLE
PP-7744 - Adds information about agreeing to Pay's terms and conditions on the 'Go Live' page

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -26,10 +26,11 @@ Compared to your test account, your live account may have a:
 
 ## 1. Request a live GOV.UK Pay account
 
-You'll need to tell us:
+You'll need to:
 
-- your organisation's name and address
-- if you’ll be using GOV.UK Pay’s PSP Stripe, or another PSP
+- provide your organisation's name and address
+- tell us if you’ll be using GOV.UK Pay’s PSP Stripe, or another PSP
+- read and accept our legal terms
 
 Select your test ('sandbox') account or your test Stripe account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services), then select __Request a live account__.
 


### PR DESCRIPTION
### Context
When requesting a Live account for Pay, users need to provide details of their organisation, tell us which Payment Service Provider they'll be using, and agree to our terms and conditions. Currently the 'Go live' page in the Pay docs only lists the first two steps. This change adds the third step (agreeing to terms and conditions).

### Changes proposed in this pull request


### Guidance to review
