### PR TITLE
PP-7591 - Adds a link to API standards iteration guidance

### DIFF
--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -7,7 +7,10 @@ weight: 190
 
 # Stay up to date
 
-The GOV.UK Pay API follows the [Semantic Versioning 2.0.0 system](https://semver.org/).
+The GOV.UK Pay API follows the [API data and technical standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards#when-iterating-your-api)
+to protect your services from disruption when we update.
+
+We follow the [Semantic Versioning 2.0.0 system](https://semver.org/).
 
 The number in the URL reflects the major version number. For example `/v1/payments/`.
 
@@ -26,6 +29,6 @@ releases will be marked with full version numbers.
 If you want to update to our latest API, make sure you test your code before
 committing to the change.
 
-We’ll support each version of the early beta GOV.UK Pay API for at least 1
+We’ll support each version of the GOV.UK Pay API for at least 1
 month after we issue an upgrade notice. As the API matures, we may increase
 this support period to 3 or 6 months.

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 190
 
 # Stay up to date
 
-The GOV.UK Pay API follows the Central Digital and Data Office's [API data and technical standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards#when-iterating-your-api).
+The GOV.UK Pay API follows the Central Digital and Data Office's [API data and technical standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards).
 Our API updates are backwards compatible wherever possible to prevent disruption to your services.
 Where backwards compatible changes are not possible, we consult with services to minimise disruption.
 

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -7,8 +7,9 @@ weight: 190
 
 # Stay up to date
 
-The GOV.UK Pay API follows the [API data and technical standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards#when-iterating-your-api)
-to protect your services from disruption when we update.
+The GOV.UK Pay API follows the Central Digital and Data Office's [API data and technical standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards#when-iterating-your-api).
+Our API updates are backwards compatible wherever possible to prevent disruption to your services.
+Where backwards compatible changes are not possible, we consult with services to minimise disruption.
 
 We follow the [Semantic Versioning 2.0.0 system](https://semver.org/).
 


### PR DESCRIPTION
### Context
There have been [several enquiries](https://payments-platform.atlassian.net/browse/PP-7591) about whether we follow the API standards and how likely it is that GOV.UK Pay integrations could break when we update the API. 

### Changes proposed in this pull request
This PR adds a link to the section of the API standard around iteration. It also updates some outdated wording left over from when the Pay API was in beta.

### Guidance to review
My questions are:

- Is just linking to the 'Iteration' section of the standards enough?
- Do we need to provide any more information around what adherence to the API standards entails?