### PR TITLE
PP-6741 - Standardises formatting of all API parameter placeholders

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -42,7 +42,7 @@ When you make an API call, you need to use an “Authorization” HTTP header to
 provide your API key, with a “Bearer” prefix. For example:
 
 ```text
-Authorization: Bearer <YOUR-API-KEY-HERE>
+Authorization: Bearer {YOUR-API-KEY}
 ```
 
 ## Payment status lifecycle

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -42,7 +42,7 @@ When you make an API call, you need to use an “Authorization” HTTP header to
 provide your API key, with a “Bearer” prefix. For example:
 
 ```text
-Authorization: Bearer {YOUR-API-KEY}
+Authorization: Bearer {YOUR_API_KEY}
 ```
 
 ## Payment status lifecycle

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -50,7 +50,7 @@ responses to API calls. For example:
 * `GET /v1/payments`
 * `GET /v1/payments/{PAYMENT_ID}`
 
-Replace ``{PAYMENT_ID}`` with the ID of the payment that you want to see the capture URL for.
+Replace ``{PAYMENT_ID}`` with the ID of the payment you want to see the capture URL for.
 
 The `"__links"` object will contain:
 

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -22,7 +22,7 @@ __Confirm__ on the __Confirm your details__ page:
 
 - the [payment status](/api_reference/#payment-status-lifecycle) will change to `capturable`
 - your service can call the
-`POST /v1/payments/{paymentId}/capture` endpoint to send a delayed capture
+`POST /v1/payments/{PAYMENT_ID}/capture` endpoint to send a delayed capture
 request
 
 There are 7 possible responses:
@@ -47,14 +47,16 @@ payment confirmation email to your user once we've received and processed your s
 If a payment is available for capture, you can see its capture URL in
 responses to API calls. For example:
 
-* `GET /v1/payments/{paymentID}`
 * `GET /v1/payments`
+* `GET /v1/payments/{PAYMENT_ID}`
 
-The `"__links"` object will contain:`
+Replace ``{PAYMENT_ID}`` with the ID of the payment that you want to see the capture URL for.
+
+The `"__links"` object will contain:
 
 ```
 "capture": {
-"href": "https://publicapi.payments.service.gov.uk/v1/payments/<PAYMENT-ID>/capture",
+"href": "https://publicapi.payments.service.gov.uk/v1/payments/{PAYMENT_ID}/capture",
     "method": "POST"
     }
 ```

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -294,7 +294,7 @@ A `204` response indicates success. Any other response indicates an error.
 
 ### Check if you can cancel a payment
 
-Use a GET request against a single payment to check if you can cancel it:
+Use a `GET` request against a single payment to check if you can cancel that payment:
 
 `GET /v1/payments/{PAYMENT_ID}`
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -298,7 +298,7 @@ Use a `GET` request against a single payment to check if you can cancel that pay
 
 `GET /v1/payments/{PAYMENT_ID}`
 
-Replace `{PAYMENT_ID}` with the ID of the payment that you are checking.
+Replace `{PAYMENT_ID}` with the ID of the payment you are checking.
 
 If the JSON response body contains a `"cancel"` field (in the `_links` object)
 that’s not `null`, you can cancel the payment. For example:

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -208,7 +208,7 @@ You can use the `href` and `chargeTokenId` to make a `POST` API request to `next
 
 #### provider_id
 
-`provider_id` is the unique ID that your PSP generated for this payment.
+`provider_id` is the unique ID your PSP generated for this payment.
 
 #### state
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -34,7 +34,7 @@ For example:
   "description": "Pay your council tax",
   "return_url": "https://your.service.gov.uk/completed",
   "delayed_capture": false,
-  "metadata": { 
+  "metadata": {
     "ledger_code": "AB100",
     "an_internal_reference_number": 200
   },
@@ -196,7 +196,7 @@ The `_links` object also includes a `next_url_post` object,  For example:
 ```
 
 You can use the `href` and `chargeTokenId` to make a `POST` API request to `next_url`, instead of a `GET` API request.
- 
+
 #### created_date
 
 `created_date` is when you created the payment, in [ISO
@@ -208,7 +208,7 @@ You can use the `href` and `chargeTokenId` to make a `POST` API request to `next
 
 #### provider_id
 
-`provider_id` is the unique ID that your PSP generated for this payment. 
+`provider_id` is the unique ID that your PSP generated for this payment.
 
 #### state
 
@@ -286,15 +286,19 @@ Your user can select a link on the payment page to cancel a payment that’s in
 progress. Alternatively, a service can make the following API call for a given
 `paymentId`:
 
-`POST /v1/payments/paymentId/cancel`
+`POST /v1/payments/{PAYMENT_ID}/cancel`
+
+Replace `{PAYMENT_ID}` with the ID of the payment that you are cancelling.
 
 A `204` response indicates success. Any other response indicates an error.
 
-### Find out if you can cancel a payment
+### Check if you can cancel a payment
 
-Use a GET request against a single payment to find out if you can cancel it:
+Use a GET request against a single payment to check if you can cancel it:
 
-`GET /v1/payments/paymentId`
+`GET /v1/payments/{PAYMENT_ID}`
+
+Replace `{PAYMENT_ID}` with the ID of the payment that you are checking.
 
 If the JSON response body contains a `"cancel"` field (in the `_links` object)
 that’s not `null`, you can cancel the payment. For example:

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -288,7 +288,7 @@ progress. Alternatively, a service can make the following API call for a given
 
 `POST /v1/payments/{PAYMENT_ID}/cancel`
 
-Replace `{PAYMENT_ID}` with the ID of the payment that you are cancelling.
+Replace `{PAYMENT_ID}` with the ID of the payment you are cancelling.
 
 A `204` response indicates success. Any other response indicates an error.
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -116,7 +116,7 @@ Use the `status` field to [check the status of a refund](#checking-the-status-of
 
 Replace:
 
-* `{PAYMENT_ID}` with the ID of the payment that you are checking
+* `{PAYMENT_ID}` with the ID of the payment you are checking
 * `{REFUND_ID}` with the ID of the refund that you are checking
 
 Example response:

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -56,7 +56,9 @@ For a completed £90 payment where £30 has already been refunded:
 
 ## Creating a refund
 
-`POST /v1/payments/PAYMENT-ID/refunds`
+`POST /v1/payments/{PAYMENT_ID}/refunds`
+
+Replace `{PAYMENT_ID}` with the ID of the payment that you are refunding.
 
 If the `status` in the `refund_summary` object is `available`, you can create a refund with the GOV.UK Pay API.
 
@@ -110,7 +112,12 @@ Use the `status` field to [check the status of a refund](#checking-the-status-of
 
 ## Checking the status of a refund
 
-`GET /v1/payments/PAYMENT-ID/refunds/REFUND-ID`
+`GET /v1/payments/{PAYMENT_ID}/refunds/{REFUND_ID}`
+
+Replace:
+
+* `{PAYMENT_ID}` with the ID of the payment that you are checking
+* `{REFUND_ID}` with the ID of the refund that you are checking
 
 Example response:
 
@@ -183,7 +190,9 @@ You can use the GOV.UK API to:
 
 ## Get all refunds for a single payment
 
-`GET /v1/payments/PAYMENT-ID/refunds`
+`GET /v1/payments/{PAYMENT_ID}/refunds`
+
+Replace `{PAYMENT_ID}` with the ID of the payment you are getting the refunds for.
 
 Example response:
 
@@ -218,7 +227,7 @@ Example response:
 
 ## Searching refunds
 
-`GET /v1/refunds?<QUERYPARAMETERS>`
+`GET /v1/refunds?{QUERY_PARAMETERS}`
 
 An example search request:
 
@@ -252,7 +261,7 @@ Example search response:
     {
       "refund_id": "efj6834secviyyxe8vs861pg3j",
       ...
-    }    
+    }
   ],
   "_links": {
     "prev_page": {

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -58,7 +58,7 @@ For a completed £90 payment where £30 has already been refunded:
 
 `POST /v1/payments/{PAYMENT_ID}/refunds`
 
-Replace `{PAYMENT_ID}` with the ID of the payment that you are refunding.
+Replace `{PAYMENT_ID}` with the ID of the payment you are refunding.
 
 If the `status` in the `refund_summary` object is `available`, you can create a refund with the GOV.UK Pay API.
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -117,7 +117,7 @@ Use the `status` field to [check the status of a refund](#checking-the-status-of
 Replace:
 
 * `{PAYMENT_ID}` with the ID of the payment you are checking
-* `{REFUND_ID}` with the ID of the refund that you are checking
+* `{REFUND_ID}` with the ID of the refund you are checking
 
 Example response:
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -273,7 +273,7 @@ Use the following API call to get a list of a payment’s events:
 
 `GET /v1/payments/{PAYMENT_ID}/events`
 
-Replace `{PAYMENT_ID}` with the ID of the payment that you are getting the events of.
+Replace `{PAYMENT_ID}` with the ID of the payment you are getting the events of.
 
 The API will respond with an `events` object. For each change to the payment's state, the `events` object includes:
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -56,7 +56,9 @@ You can use the GOV.UK Pay API to:
 
 ## Get information about a single payment
 
-`GET /v1/payments/{paymentId}`
+`GET /v1/payments/{PAYMENT_ID}`
+
+Replace `{PAYMENT_ID}` with the ID of the payment you are getting information about.
 
 Example response:
 
@@ -269,7 +271,9 @@ You can also sign in to the [GOV.UK Pay admin tool](https://selfservice.payments
 
 Use the following API call to get a list of a payment’s events:
 
-`GET /v1/payments/{paymentId}/events`
+`GET /v1/payments/{PAYMENT_ID}/events`
+
+Replace `{PAYMENT_ID}` with the ID of the payment that you are getting the events of.
 
 The API will respond with an `events` object. For each change to the payment's state, the `events` object includes:
 


### PR DESCRIPTION
### Context
Previously, there were 5 different formats for parameter placeholders in the Pay tech docs. This PR standardises the formatting of these.

### Changes proposed in this pull request

- Standardises API parameter placeholders to `{CAPITAL_LETTERS}` format.
- Adds additional clarification after placeholders with 'Replace `{PLACEHOLDER_NAME}` with...' sentences.

### Guidance to review

#### Pre-i'er / 2i'er:

- Do the clarification sentences ('Replace `{PLACEHOLDER_NAME}` with...') read okay? The wording on some of them was tricky.

#### Devs:

- Do the examples still make sense? Especially the query parameters placeholder in _Refund a payment_ -> _Searching refunds_ 
- Have I broken anything?