### PR TITLE
PP-8113 - Adds a link to authentication guidance to the Quick Start guide

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -81,6 +81,8 @@ with our API and make a test API call.
 
 Make sure you [keep your API keys safe](/security/#securing-your-developer-keys).
 
+Read more about [authenticating API calls](/api_reference/#authentication) to GOV.UK Pay with your API key.
+
 <%= warning_text('Only use a test API key on your test account. Do not use a live API key on your test account.') %>
 
 ### Make a test API call

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -81,13 +81,11 @@ with our API and make a test API call.
 
 Make sure you [keep your API keys safe](/security/#securing-your-developer-keys).
 
-Read more about [authenticating API calls](/api_reference/#authentication) to GOV.UK Pay with your API key.
-
 <%= warning_text('Only use a test API key on your test account. Do not use a live API key on your test account.') %>
 
 ### Make a test API call
 
-You can make test API calls to GOV.UK Pay with your test API key.
+You can make test API calls to GOV.UK Pay, using your test API key for [authentication](/api_reference/#authentication).
 
 You can use API testing tools such as <a href="https://www.getpostman.com/">Postman</a> or <a href="https://insomnia.rest/">Insomnia REST</a> to make test API calls.
 


### PR DESCRIPTION
### Context
The Quick Start featured guidance on how to get an API key but not what to do with it.

### Changes proposed in this pull request
This PR adds a link to the Authentication section of the API reference that explains how the API key should be used.

### Guidance to review
