### PR TITLE
Fixed anchor link from API reference page

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -192,7 +192,7 @@ These error descriptions are intended for developers, not your users.
 | Search payments | P0498 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Cancel payment | P0500 | `paymentId` not found | No payment matched the `paymentId` you provided. |
 | Cancel payment | P0501 | Cancellation failed | Cancelling the payment failed. Contact us, quoting the error code. |
-| Cancel payment | P0502 | Payment cannot be cancelled | You can only cancel a payment if [the payment has a `cancel` field](/making_payments/#find-out-if-you-can-cancel-a-payment). |
+| Cancel payment | P0502 | Payment cannot be cancelled | You can only cancel a payment if [the payment has a `cancel` field](/making_payments/#check-if-you-can-cancel-a-payment). |
 | Cancel payment | P0598 | Downstream system error | Internal error with GOV.UK Pay. Contact us, quoting the error code. |
 | Create refund | P0600 | `paymentId` not found | No payment matched the `paymentId` you provided. |
 | Create refund | P0601 | Missing mandatory attribute | The request you sent is missing a required attribute. |


### PR DESCRIPTION
### Context
I changed the name of a heading and forgot to fix an anchor link on another page.

### Changes proposed in this pull request
Fixed the anchor link on the API reference page.

### Guidance to review
