### PR TITLE
Clarifies date formatting for refund dates and settled dates.

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -305,7 +305,7 @@ that’s not `null`, you can cancel the payment. For example:
 
 ```
 "cancel": {
-  "href": "https://publicapi.payments.service.gov.uk/v1/payments/{paymentId}/cancel",
+  "href": "https://publicapi.payments.service.gov.uk/v1/payments/{PAYMENT_ID}/cancel",
   "method": "POST"
 }
 ```

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -305,7 +305,7 @@ that’s not `null`, you can cancel the payment. For example:
 
 ```
 "cancel": {
-  "href": "https://publicapi.payments.service.gov.uk/v1/payments/{PAYMENT_ID}/cancel",
+  "href": "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93/cancel",
   "method": "POST"
 }
 ```

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -291,7 +291,7 @@ All dates are in Coordinated Universal Time (UTC).
 
 Dates must be in [ISO
 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
-You must include a date value, a time value expressed in at least hours and minutes, and a time zone designation. For example, `2019-09-20T13:30Z`.
+You must include a date value, a time value precise to at least hours and minutes, and a time zone designation. For example, `2019-09-20T13:30Z`.
 
 ### Filter refunds by when your PSP took refunds
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -287,8 +287,11 @@ You can use the following query parameters to filter refunds by date:
 * `from_date`, which is the start date to search, inclusive
 * `to_date`, which is the end date to search, exclusive
 
+All dates are in Coordinated Universal Time (UTC).
+
 Dates must be in [ISO
-8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard). For example `2019-09-20T13:30:00Z`.
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+You must include a date value, a time value expressed in at least hours and minutes, and a time zone designation. For example, `2019-09-20T13:30Z`.
 
 ### Filter refunds by when your PSP took refunds
 
@@ -301,11 +304,10 @@ All dates are in Coordinated Universal Time (UTC).
 
 For example, to list all the refunds your PSP took on 16 June 2020:
 
-```
-GET /v1/refunds?from_settled_date=2020-06-16&to_settled_date=2020-06-16
-```
+`GET /v1/refunds?from_settled_date=2020-06-16&to_settled_date=2020-06-16`
 
-These query parameters take inputs based on a subset of the [ISO 8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard). For example, a valid input would be `2015-08-13`.
+Dates must be in [ISO 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+You must include a date value only. For example, `2015-08-13`.
 
 ### Splitting results into pages
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -290,8 +290,13 @@ You can use the following query parameters to filter refunds by date:
 All dates are in Coordinated Universal Time (UTC).
 
 Dates must be in [ISO
-8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
-You must include a date value, a time value precise to at least hours and minutes, and a time zone designation. For example, `2019-09-20T13:30Z`.
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard) and include a:
+
+* date
+* time in hours and minutes - seconds are optional
+* time zone designation 
+
+For example, `2019-09-20T13:30Z`.
 
 ### Filter refunds by when your PSP took refunds
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -294,7 +294,7 @@ Dates must be in [ISO
 
 * date
 * time in hours and minutes - seconds are optional
-* time zone designation 
+* time zone designation
 
 For example, `2019-09-20T13:30Z`.
 
@@ -311,8 +311,8 @@ For example, to list all the refunds your PSP took on 16 June 2020:
 
 `GET /v1/refunds?from_settled_date=2020-06-16&to_settled_date=2020-06-16`
 
-Dates must be in [ISO 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
-You must include a date value only. For example, `2015-08-13`.
+Dates must be in [ISO 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
+and include a date value only. For example, `2015-08-13`.
 
 ### Splitting results into pages
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -398,8 +398,13 @@ You can use the following query parameters to filter payments by date:
 All dates are in Coordinated Universal Time (UTC).
 
 Dates must be in [ISO
-8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
-You must include a date value, a time value precise to at least hours and minutes, and a time zone designation. For example, `2019-09-20T13:30Z`.
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard) and include a:
+
+* date
+* time in hours and minutes - seconds are optional
+* time zone designation
+
+For example, `2019-09-20T13:30Z`.
 
 #### Filter payments by when your PSP sent payments to your bank account
 
@@ -414,8 +419,8 @@ For example, to list all the payments your PSP sent to you on 16 June 2020:
 
 `GET /v1/payments?from_settled_date=2020-06-16&to_settled_date=2020-06-16`
 
-Dates must be in [ISO 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
-You must include a date value only. For example, `2015-08-13`.
+Dates must be in [ISO 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard)
+and include a date value only. For example, `2015-08-13`.
 
 If your PSP has not sent this payment to your bank account yet, the payment will not be in the response.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -395,9 +395,11 @@ You can use the following query parameters to filter payments by date:
 * `from_date` - the start date for payments to be searched, inclusive
 * `to_date` - the end date for payments to be searched, exclusive
 
-These take inputs based on a subset of [the ISO
-8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
-For example, a valid input would be `2015-08-13T12:35:00Z`.
+All dates are in Coordinated Universal Time (UTC).
+
+Dates must be in [ISO
+8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+You must include a date value, a time value precise to at least hours and minutes, and a time zone designation. For example, `2019-09-20T13:30Z`.
 
 #### Filter payments by when your PSP sent payments to your bank account
 
@@ -410,11 +412,10 @@ All dates are in Coordinated Universal Time (UTC).
 
 For example, to list all the payments your PSP sent to you on 16 June 2020:
 
-```
-GET /v1/payments?from_settled_date=2020-06-16&to_settled_date=2020-06-16
-```
+`GET /v1/payments?from_settled_date=2020-06-16&to_settled_date=2020-06-16`
 
-These query parameters take inputs based on a subset of the [ISO 8601 standard](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard). For example, a valid input would be `2015-08-13`.
+Dates must be in [ISO 8601 format](https://www.gov.uk/government/publications/open-standards-for-government/date-times-and-time-stamps-standard).
+You must include a date value only. For example, `2015-08-13`.
 
 If your PSP has not sent this payment to your bank account yet, the payment will not be in the response.
 


### PR DESCRIPTION
### Context
In a previous Pay tech docs fact check, Steven F. pointed out that ISO 8601 has different levels of precision when specifying times and dates. We currently do not outline the level of precision that the Pay API requires.

### Changes proposed in this pull request
This PR explains the level of date and time precision required for the `from_date`, `to_date`, `from_settled_date`, and `to_settled_date` query parameters require. It also changes the formatting of an example API call to match other call examples in the documentation.

### Guidance to review
For pre-i:

- I'm not sure if I describe the level of accuracy required as well as I could in line 294