### PR TITLE
PP-8220 - Switching PSP guidance

### DIFF
--- a/source/switch_payment_service_provider/index.html.md.erb
+++ b/source/switch_payment_service_provider/index.html.md.erb
@@ -1,0 +1,36 @@
+---
+title: Switch payment service provider (PSP)
+last_reviewed_on: 2021-07-07
+review_in: 6 months
+weight: 165
+---
+
+#Switch payment service provider (PSP)
+
+You can switch payment service provider (PSP) through the GOV.UK Pay admin tool. Read our [guidance about choosing a PSP](https://www.payments.service.gov.uk/payment-service-provider/).
+
+You can switch to:
+
+* Stripe, GOV.UK Pay's PSP
+* Worldpay, Government Banking's PSP — this option is only for central government or health sector organisations
+
+GOV.UK Pay has created:
+
+* [guidance for switching to Stripe](switch_psp_to_stripe/#switch-payment-service-provider-to-stripe)
+* [guidance for switching to Worldpay](switch_psp_to_worldpay/#switch-payment-service-provider-to-worldpay)
+
+Admin users can switch a service to Stripe in the GOV.UK Pay admin tool. Email GOV.UK Pay support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) if you have questions about using Stripe.
+
+Switching to Worldpay can take up to 6 weeks, whilst Government Banking creates your Worldpay account. After this, admin users can switch services to Worldpay in the GOV.UK Pay admin tool. Email Government Banking at [serviceteam.gbs@hmrc.gov.uk](mailto:serviceteam.gbs@hmrc.gov.uk) if you have questions about using Worldpay.
+
+You do not need any technical knowledge to switch PSP.
+
+##Understand what the switch affects
+
+The switch is just a change of PSP. Your users will not be made aware of any changes in your service.
+
+Users making payments during the switching period are not affected. Your existing PSP will still process active payments.
+
+The switching process is the same whether your service integrates with GOV.UK Pay’s API or uses payment links. Switching does not need any code changes. Your existing API keys remain valid.
+
+You may need to make changes to your financial reporting if you switch from Stripe to Worldpay as [Stripe offers additional reporting data](https://docs.payments.service.gov.uk/reporting/#report-on-a-payment).

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -109,7 +109,7 @@ You have now switched PSP to Stripe. Stripe will process new payments.
 
 After you switch to Stripe, you can still refund old payments through your old PSP.
 
-GOV.UK Pay will maintain the old PSP integration for up to 3 months after the PSP took the last payment to allow your service to process refunds through your old PSP.
+For now, GOV.UK Pay will maintain an integration with your old PSP to allow your service to process refunds through your old PSP. However, if your contract with your old PSP expires, or your old PSP stops operating, it will not be possible to refund payments through GOV.UK Pay.
 
 If you cannot refund a payment through your old PSP, find an alternative like a cheque or bank transfer.
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -53,7 +53,7 @@ You need to repeat the following process for each service you want to switch.
 
 To test the integration between Stripe and GOV.UK Pay, you need to make a live payment. This step makes sure you have integrated your GOV.UK Pay and Stripe accounts correctly.
 
-The live payment is £2.00 and is refundable (minus the transaction fee).
+The live payment is £2.00 and is refundable. Your new Stripe account will be debited a small transaction fee.
 
 1. Select **Provide your bank details**.
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -1,0 +1,116 @@
+---
+title: Switch payment service provider to Stripe
+last_reviewed_on: 2021-07-07
+review_in: 6 months
+weight: 167
+---
+
+# Switch payment service provider to Stripe
+
+This guidance tells you how to switch your payment service provider (PSP) to Stripe.
+
+You must be a GOV.UK Pay admin user to switch PSP. To check if you are an admin user for a service:
+
+1. Select **View team members** or **Manage team members** next to the service on the **Overview** page.
+
+2. If your email address is listed under **Administrators**, you are an admin user.
+
+## Prepare to switch to Stripe
+
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:mailto:govuk-pay-support@digital.cabinet-office.gov.uk) asking to switch your PSP to Stripe on all services for your organisation, or list out specific services.
+
+The GOV.UK Pay support team will confirm when we’ve enabled the switch PSP feature for your service.
+
+To switch to Stripe, you’ll need:
+
+* the name, date of birth, and home address of your organisation’s [‘responsible person’](https://www.payments.service.gov.uk/what-being-a-responsible-person-means/)
+* your bank details
+* your VAT number
+* your company registration number (if your organisation has one)
+* a debit or credit card to make a refundable payment to test your service
+
+Before switching, read the:
+
+* [GOV.UK Pay contract](https://selfservice.payments.service.gov.uk/policy/download/contract-for-non-crown-bodies) (if you are a non-Crown organisation)
+* [Memorandum of Understanding](https://selfservice.payments.service.gov.uk/policy/download/memorandum-of-understanding-for-crown-bodies) (if you are a Crown organisation)
+* [Stripe Connected Account Agreement](https://selfservice.payments.service.gov.uk/policy/download/stripe-connected-account-agreement).
+
+To get to the **Switch payment service provider** page:
+
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+
+2. Select the service you want to switch from the **Overview** page - services you can switch are labelled **LIVE - SWITCH PSP**
+
+3. On your service dashboard, select the ‘**...how to switch to Worldpay link**’ in the banner at the top of the page, or select **Settings** in the navigation.
+
+4. In **Settings**, select **Switch PSP** from the side navigation.
+
+## Switch to Stripe
+
+You need to repeat the following process for each service you want to switch.
+
+### Provide your details and test the integration with Stripe
+
+To test the integration between Stripe and GOV.UK Pay, you need to make a live payment. This step makes sure you have integrated your GOV.UK Pay and Stripe accounts correctly.
+
+The live payment is £2.00 and is refundable (minus the transaction fee).
+
+1. Select **Provide your bank details**.
+
+2. Enter your sort code and account number.
+
+3. Select **Save and continue** to return to the **Switch payment service provider (PSP)** page.
+
+4. Select **Provide details about your responsible person**.
+
+5. Complete the **Name**, **Home address**, and **Date of birth** sections.
+
+6. Select **Save and continue**.
+
+7. Select **Provide your organisation’s VAT number**.
+
+8. Enter your organisation’s VAT number.
+
+9. Select **Save and continue**.
+
+10. Select **Provide your company’s registration number**.
+
+11. If your organisation has a company registration number, select **Yes** and enter your company registration number.
+
+12. If your organisation does not have a company registration number, select **No**.
+
+13. Select **Save and continue**.
+
+14. Select **Make a live payment to test your Stripe PSP** - you will need a debit or credit card for this step.
+
+15. Select **Continue to live payment**.
+
+16. Enter your card details.
+
+17. Select **Continue**. You’ll be returned to the **Switch payment service provider** page.
+
+A **Success** banner confirms the payment and you can also find it in the **Transactions** list.
+
+If your service uses the GOV.UK Pay API for reporting, you may want to check the test transaction appears correctly in your systems.
+
+<%= warning_text('Your existing PSP is still processing this service’s payments. You have not switched your PSP yet.') %>
+
+### Switch PSP to Stripe
+
+You’re ready to switch once you’ve provided your details in the GOV.UK Pay admin tool, and made a live payment to test the integration.
+
+Users making payments as you switch are unaffected. Your old PSP will process their payments.
+
+To switch, select **Switch to Stripe**. A **Success** banner confirms the switch.
+
+You have now switched PSP to Stripe. Stripe will process new payments.
+
+## Refund payments after switching to Stripe
+
+After you switch to Stripe, you can still refund old payments through your old PSP.
+
+GOV.UK Pay will maintain the old PSP integration for up to 3 months after the PSP took the last payment to allow your service to process refunds through your old PSP.
+
+If you cannot refund a payment through your old PSP, find an alternative like a cheque or bank transfer.
+
+Refund payments by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login), selecting your service, and choosing the **Transactions** tab. Alternatively, you can use [the GOV.UK Pay API](https://docs.payments.service.gov.uk/refunding_payments/#refund-a-payment).

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -25,7 +25,7 @@ To set up a Worldpay account, email Government Banking at [serviceteam.gbs@hmrc.
 
 You need to configure your Worldpay account to use it with GOV.UK Pay. You only need to configure your Worldpay account once.
 
-### Switch to Production Mode for your merchant code
+### Switch to Production Mode in Worldpay
 
 Worldpay uses the term ‘production’ for live accounts.
 
@@ -69,7 +69,7 @@ You’ll need your XML password to switch PSP.
 
 You must set up your Worldpay ‘Merchant Channels’ so Worldpay can notify GOV.UK Pay about payment events.
 
-#### Set up ‘Merchant Channels’
+#### Set up your Worldpay ‘Merchant Channels’
 
 In your Worldpay account, select **Integration** then the **Merchant Channel** tab.
 
@@ -88,7 +88,7 @@ In the **http** row, set:
 * **Method** to **POST**
 * **Client certificate** to **no**
 
-#### Set up 'Merchant Channel Events'
+#### Set up your Worldpay 'Merchant Channel Events'
 
 In your Worldpay account, select **Integration** then the **Merchant Channel** tab.
 

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -143,7 +143,7 @@ You need to repeat the following process for each service you want to switch to 
 
 To test the integration between Worldpay and GOV.UK Pay, you need to make a live payment. This step makes sure you have integrated your GOV.UK Pay and Worldpay accounts correctly.
 
-The live payment is £2.00 and is refundable (minus the transaction fee).
+The live payment is £2.00 and is refundable. Your new Worldpay account will be debited a small transaction fee.
 
 1. Select **Link your Worldpay account with GOV.UK Pay**.
 

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -1,0 +1,186 @@
+---
+title: Switch payment service provider to Worldpay
+last_reviewed_on: 2021-07-07
+review_in: 6 months
+weight: 166
+---
+
+# Switch payment service provider to Worldpay
+
+This guidance explains how to switch your payment service provider (PSP) to Worldpay.
+
+You must be a GOV.UK Pay admin user to switch PSP. To check if you are an admin user for a service:
+
+1. Select **View team members** or **Manage team members** next to the service on the **Overview** page.
+
+2. If your email address is listed under **Administrators**, you are an admin user.
+
+## Set up a Worldpay account
+
+To set up a Worldpay account, email Government Banking at [serviceteam.gbs@hmrc.gov.uk](mailto:serviceteam.gbs@hmrc.gov.uk).
+
+<%= warning_text('It can take up to 6 weeks for Government Banking to set up your Worldpay account. You should complete this step as soon as possible.')%>
+
+## Configure your Worldpay account
+
+You need to configure your Worldpay account to use it with GOV.UK Pay. You only need to configure your Worldpay account once.
+
+### Switch to Production Mode for your merchant code
+
+Worldpay uses the term ‘production’ for live accounts.
+
+Sign in to your [Worldpay account](https://secure.worldpay.com/sso/public/auth/login.html) and select your merchant code.
+
+If **Test Mode** is at the bottom of the left-hand menu, select **Test Mode** to switch to **Production Mode**.
+
+### Set your XML password
+
+1. In your Worldpay account, select Account.
+
+2. Choose the Profile tab.
+
+3. If you’re asked for your merchant code, enter it.
+
+4. If you see a checkbox called Disabled Original XML Username, check the checkbox.
+
+5. Select Save Profile.
+
+6. If you have not set your XML password for this merchant code before, select the pencil icon next to XML Password and enter a password.
+
+7. Confirm your password by selecting Add new password, then OK.
+
+8. Save the new password by selecting the pencil icon again, then Complete, then OK.
+
+If you’ve set your XML password before but cannot remember it, you can set a new password. If you set a new password, you must add it to your other services that use this Worldpay account, or they’ll stop working.
+
+You’ll need your XML password to switch PSP.
+
+### Disable Capture delay
+
+1. In your Worldpay account, select **Account**.
+
+2. Choose the **Profile** tab.
+
+3. Go to the **Payment service**.
+
+4. Set **Capture delay (days)** to **Off** (not **0**).
+
+### Set up Worldpay 'Merchant Channels'
+
+You must set up your Worldpay ‘Merchant Channels’ so Worldpay can notify GOV.UK Pay about payment events.
+
+#### Set up ‘Merchant Channels’
+
+In your Worldpay account, select **Integration** then the **Merchant Channel** tab.
+
+Make the following changes in both the **Merchant Channels (Production)** and **Merchant Channels (Test)** sections.
+
+Set **Active** to:
+
+* **no** in the **email** row
+* **yes** in the **http** row
+* **no** in the **shopper email** row
+
+In the **http** row, set:
+
+* **Content** to **xml**
+* **Address** to `https://notifications.payments.service.gov.uk/v1/api/notifications/worldpay`
+* **Method** to **POST**
+* **Client certificate** to **no**
+
+#### Set up 'Merchant Channel Events'
+
+In your Worldpay account, select **Integration** then the **Merchant Channel** tab.
+
+In both the **Merchant Channel Events (Production)** and **Merchant Channel Events (Test)** sections, select the following in the http row.
+
+* **SHOPPER_REDIRECTED**
+* **SENT_FOR_AUTHORISATION**
+* **AUTHORISED**
+* **ERROR**
+* **CANCELLED**
+* **CAPTURED**
+* **CAPTURE_FAILED**
+* **SETTLED**
+* **SETTLED_BY_MERCHANT**
+* **SENT_FOR_REFUND**
+* **REFUNDED**
+* **REFUNDED_BY_MERCHANT**
+* **REFUSED**
+* **REFUSED_BY_BANK** (production only)
+* **REFUND_FAILED**
+
+## Prepare to switch to Worldpay
+
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:mailto:govuk-pay-support@digital.cabinet-office.gov.uk) asking to switch PSP to Worldpay on all services for your organisation, or list out specific services.
+
+The GOV.UK Pay support team will confirm when we’ve enabled the switch PSP feature for your service.
+
+To switch to Worldpay, you’ll need:
+
+* your **Merchant Code** - found in your Worldpay account in the left-side navigation
+* your **New Username** - found in your Worldpay account under **Account**, then **Profile**
+* your **XML password** - found in your Worldpay account under **Account**, then **Profile**
+* a debit or credit card - to make a refundable payment to test your service
+
+<%= warning_text('For security reasons, copy and paste your details directly from the Worldpay admin tool into GOV.UK Pay. Do not store these details in an unsecure way, such as in plain text documents or written on paper.') %>
+
+To get to the **Switch payment service provider** page:
+
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+
+2. Select the service you want to switch from the **Overview** page - services you can switch are labelled **LIVE - SWITCH PSP**.
+
+3. On your service dashboard, select the ‘**...how to switch to Worldpay link**’ in the banner, or select **Settings** in the navigation.
+
+4. In **Settings**, select **Switch PSP** from the side navigation.
+
+## Switch to Worldpay
+
+You need to repeat the following process for each service you want to switch to Worldpay.
+
+### Link your Worldpay account to GOV.UK Pay and test it
+
+To test the integration between Worldpay and GOV.UK Pay, you need to make a live payment. This step makes sure you have integrated your GOV.UK Pay and Worldpay accounts correctly.
+
+The live payment is £2.00 and is refundable (minus the transaction fee).
+
+1. Select **Link your Worldpay account with GOV.UK Pay**.
+
+2. Using your [Worldplay credentials you configured earlier](#configure-your-worldpay-account), enter your **Merchant Code**, **New Username** and **XML Password**.
+
+3. Select **Save credentials**. If your credentials are correct, GOV.UK Pay will return you to the **Switch Payment Service Provider** page. If your credentials are not correct, you’ll need to re-enter them.
+
+4. Select **Make a live payment to test your Worldpay PSP** - you need a debit or credit card for this step.
+
+5. Select **Continue to live payment**.
+
+6. Enter your card details.
+
+7. Select **Continue**. You'll be returned to the **Switch Payment Service Provider** page.
+
+A **Success** banner confirms the payment and you can also find it in the **Transactions** list.
+
+If your service uses the GOV.UK Pay API for reporting, you may want to check the test transaction appears correctly in your systems.
+
+<%= warning_text('Your existing PSP is still processing this service’s payments. You have not switched your PSP yet.') %>
+
+### Switch PSP to Worldpay
+
+Once you’ve successfully linked your Worldpay account with GOV.UK Pay and made a live payment to test the integration, you’re ready to switch your PSP to Worldpay.
+
+To switch, select **Switch to Worldpay** on the **Switch payment service provider (PSP)** page. A **Success** banner confirms the switch.
+
+You have now switched PSP to Worldpay. Worldpay will process any new payments.
+
+Users making payments as you switch are unaffected. Your old PSP will process their payments.
+
+## Refund payments after switching to Worldpay
+
+After you switch to Worldpay, you can still refund old payments through your old PSP.
+
+GOV.UK Pay will maintain the old PSP integration for 3 months after taking the last payment to allow your service to process refunds through your old PSP.
+
+If you cannot refund a payment through your old PSP, use an alternative like a cheque or bank transfer.
+
+Refund payments by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login), selecting your service, and choosing the **Transactions** tab. Alternatively, you can use the [GOV.UK Pay API](https://docs.payments.service.gov.uk/refunding_payments/#refund-a-payment).

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -179,7 +179,7 @@ Users making payments as you switch are unaffected. Your old PSP will process th
 
 After you switch to Worldpay, you can still refund old payments through your old PSP.
 
-GOV.UK Pay will maintain the old PSP integration for 3 months after taking the last payment to allow your service to process refunds through your old PSP.
+For now, GOV.UK Pay will maintain an integration with your old PSP to allow your service to process refunds through your old PSP. However, if your contract with your old PSP expires, or your old PSP stops operating, it will not be possible to refund payments through GOV.UK Pay.
 
 If you cannot refund a payment through your old PSP, use an alternative like a cheque or bank transfer.
 


### PR DESCRIPTION
### Context
Services can no switch their payment service provider (PSP) to Worldpay or Stripe.

### Changes proposed in this pull request
Added a new section and 3 new pages to the documentation. A top-level page with information about switching in general, then a page of guidance each for Stripe and Worldpay.