### PR TITLE
Updated BYOC dates in Go Live docs

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -49,9 +49,9 @@ You can connect your live account to:
 - [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe), GOV.UK Pay's current PSP
 - [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay) using a contract through Government Banking or your own Worldpay contract
 
-You cannot use your own Worldpay contract after 31 July 2021. You must either switch to GOV.UK Pay’s PSP or a contract through Government Banking. [Contact us](/support_contact_and_more_information/) as soon as possible if you need to switch.
+You can only use your own Worldpay contract until 31 December 2021. You must switch to GOV.UK Pay’s PSP or a contract through Government Banking by this date. [Contact us](/support_contact_and_more_information/) as soon as possible if you need to switch.
 
-Until 31 July 2021, we also support connecting your live account to [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq). You can only connect new live accounts to ePDQ if you connected another live account to ePDQ before 1 August 2020.
+Until 31 December 2021, we also support connecting your live account to [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq). You can only connect new live accounts to ePDQ if you connected another live account to ePDQ before 1 August 2020.
 
 If either GOV.UK Pay's or Government Banking's PSP changes, we'll work with you to move you to the new PSP.
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -49,7 +49,7 @@ You can connect your live account to:
 - [Stripe](/switching_to_live/set_up_a_live_stripe_account/#connect-your-live-account-to-stripe), GOV.UK Pay's current PSP
 - [Worldpay](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay) using a contract through Government Banking or your own Worldpay contract
 
-You can only use your own Worldpay contract until 31 December 2021. You must switch to GOV.UK Pay’s PSP or a contract through Government Banking by this date. [Contact us](/support_contact_and_more_information/) as soon as possible if you need to switch.
+You can use your own Worldpay contract until 31 December 2021. By this date, you must have switched to GOV.UK Pay’s PSP or a contract through Government Banking. [Contact us](/support_contact_and_more_information/) as soon as possible if you need to switch.
 
 Until 31 December 2021, we also support connecting your live account to [ePDQ](/switching_to_live/set_up_a_live_epdq_account/#connect-your-live-account-to-epdq). You can only connect new live accounts to ePDQ if you connected another live account to ePDQ before 1 August 2020.
 


### PR DESCRIPTION
### Context
The BYOC deadline has changed from 31 July 2021 to 31 December 2021. 

### Changes proposed in this pull request

- Updates the dates for the BYOC deadline
- Normalises the formatting of the dates