### PR TITLE
PP-8398 - Updated MOTO page to include telephone payment link guidance

### DIFF
--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -185,7 +185,7 @@ To take a telephone payment, open the service that has an associated telephone p
 
 ### Create a MOTO payment using the GOV.UK Pay API
 
-Before you create a MOTO payment, you must have [set up MOTO payments](#set-up-a-moto-payments).
+Before you create a MOTO payment, you must have [set up MOTO payments](#set-up-moto-payments).
 
 Follow these steps to create and complete the MOTO payment using the GOV.UK Pay API.
 

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -53,7 +53,7 @@ You'll be using one of the following PSPs:
 
 1. You need to process MOTO payments on a separate MOTO merchant code (if your PSP is Worldpay) or PSPID (if your PSP is ePDQ) to the one you use for online payments. If you do not already have a merchant code for MOTO payments, ask for one by contacting ePDQ, or Government Banking if you use Worldpay. You’ll use this merchant code when you [connect your new service to your PSP](https://docs.payments.service.gov.uk/switching_to_live/#go-live).
 
-1. Complete your [Payment Card Industry Data Security Standards (PCI DSS) Self Assessment Questionnaire](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance)
+1. Complete your [Payment Card Industry Data Security Standards (PCI DSS) Self Assessment Questionnaire](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance).
 
 1. Send your completed PCI DSS questionnaire and your service name to [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
@@ -67,7 +67,7 @@ You can still [take online payments](https://docs.payments.service.gov.uk/making
 
 #### Set up MOTO payments on a live account with Stripe
 
-1. Complete your [PCI DSS Self-Assessment Questionnaire](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance)
+1. Complete your [PCI DSS Self-Assessment Questionnaire](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance).
 
 1. Send your completed PCI DSS questionnaire and your service name to [govuk-pay-support@digital.cabinet-office.gov.uk] (mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
@@ -128,7 +128,7 @@ These optional details can help to guide your call centre agent through the tele
 
 For example, ‘Remind the paying user that we are recording this call for quality and training purposes.’
 
-Call centre agents see these extra details at the start of the telephone payment process.
+Call centre agents can see these extra details at the start of the telephone payment process.
 
 Paying users will not be able to see this ‘Details’ description.
 
@@ -138,7 +138,7 @@ The name of the reference is the name your service uses for unique payment refer
 
 For example, the name of the reference could be ‘Invoice number’ or ‘Customer ID’.
 
-Call centre agents see this name next to the input field when they are entering the user’s reference.
+Call centre agents can see this name next to the input field when they are entering the user’s reference.
 
 ##### Reference hint text (optional)
 
@@ -189,7 +189,7 @@ Before you create a MOTO payment, you must have [set up MOTO payments](#set-up-m
 
 Follow these steps to create and complete the MOTO payment using the GOV.UK Pay API.
 
-1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO service in **Services** in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+1. If your PSP is Worldpay or ePDQ, go to **Services** in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) to make sure you're using an API key from your MOTO service.
 
 2. [Create a payment](/making_payments/#creating-a-payment) with the GOV.UK Pay API, and include `“moto”: true` in the request body.
 

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Take a payment over the phone ('MOTO' payments)
-last_reviewed_on: 2021-06-23
+last_reviewed_on: 2021-08-10
 review_in: 6 months
 weight: 52
 ---
 
 # Take a payment over the phone (‘MOTO’ payments)
 
-We can set up your GOV.UK Pay account so you can fill in GOV.UK Pay payment pages with your users’ details.
+GOV.UK Pay can set up your GOV.UK Pay account so you can fill in GOV.UK Pay payment pages with your users’ details.
 
 This means you can take payments:
 
@@ -16,74 +16,188 @@ This means you can take payments:
 
 These payments are also known as Mail Order / Telephone Order (MOTO) payments.
 
-You cannot take MOTO payments:
+There are 2 ways to take MOTO payments through GOV.UK Pay. You can:
 
-- if your payment service provider (PSP) is Smartpay
-- through a [payment link](https://www.payments.service.gov.uk/govuk-payment-pages/)
+- integrate with the GOV.UK Pay API
+- use telphone payment links
 
-[Contact us](/support_contact_and_more_information/) if you'd like us to investigate taking MOTO payments through payment links.
+You cannot take MOTO payments if your payment service provider (PSP) is Smartpay.
 
 ## Set up MOTO payments
 
+Before you can take payments over the phone, you need to set up MOTO payments.
+
 You can set up MOTO payments on a test account or a live account.
 
-MOTO payment screens are the same as online payment screens, excluding the following:
+MOTO payment screens are the same as online payment screens, except they do not have a section for billing addresses. [3D Secure](https://docs.payments.service.gov.uk/set_up_3dsecure/#set-up-strong-customer-authentication-3ds1-and-3ds2) does not apply to MOTO payments.
 
-- MOTO payments screens do not have a section for billing address
-- [Strong Customer Authentication](/set_up_3dsecure/#set-up-strong-customer-authentication-3ds1-and-3ds2) does not apply to MOTO payments
+### Set up MOTO payments on a test account
 
-## Set up MOTO payments on a test account
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) and ask us to enable MOTO payments on your test account.
 
-[Contact GOV.UK Pay support](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to ask us to enable MOTO payments on your test account.
+You do not need to provide any supporting information at this time.
 
-You do not need to provide us with any supporting information at this time.
+### Set up MOTO payments on a live account
 
-## Set up MOTO payments on a live account
+How you set up MOTO payments on a live account differs depending on what PSP you use.
 
-How you set up MOTO payments on a live account differs depending on what payment service provider (PSP) you use.
+You'll be using one of the following PSPs:
 
-### Set up MOTO payments on a live account with Worldpay or ePDQ
+- Worldpay
+- ePDQ
+- Stripe
 
-If you use Worldpay or ePDQ, you must:
+#### Set up MOTO payments on a live account with Worldpay or ePDQ
 
-- use a service for MOTO payments that’s separate to your online payments service
-- process MOTO payments on a specific MOTO merchant code
+1. Create a new MOTO service that is separate from your online payments service - to do this, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk) and select **Add a new service**.
 
-1. Create a separate MOTO payments service if you do not have one already by signing in to your [GOV.UK Pay account](https://selfservice.payments.service.gov.uk/), then selecting __Add a new service__ to add a new service for MOTO payments to your account.
+1. You need to process MOTO payments on a separate MOTO merchant code (if your PSP is Worldpay) or PSPID (if your PSP is ePDQ) to the one you use for online payments. If you do not already have a merchant code for MOTO payments, ask for one by contacting ePDQ, or Government Banking if you use Worldpay. You’ll use this merchant code when you [connect your new service to your PSP](https://docs.payments.service.gov.uk/switching_to_live/#go-live).
 
-1. If you do not already have a MOTO merchant code, ask for a new code by contacting your PSP or Government Banking as required. You will use this merchant code when you [connect your new service to your PSP](/switching_to_live/#go-live).
+1. Complete your [Payment Card Industry Data Security Standards (PCI DSS) Self Assessment Questionnaire](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance)
 
-1. Send your [PCI DSS Self Assessment Questionnaire](/security/#payment-card-industry-pci-compliance) and service name to [GOV.UK Pay support](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+1. Send your completed PCI DSS questionnaire and your service name to [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-We review your PCI DSS compliance as you may have additional PCI Compliance responsibilities for MOTO payments compared to online payments.
+1. GOV.UK Pay will review your PCI DSS compliance as you may have additional PCI compliance responsibilities for MOTO payments compared to online payments.
 
-When we’re satisfied that you’ve met your PCI DSS compliance responsibilities, we will enable MOTO payments in your service. You can then take MOTO payments.
+1. When GOV.UK Pay is satisfied you’ve met your PCI DSS compliance responsibilities, we’ll enable MOTO payments in your service. We’ll email you to let you know we’ve enabled MOTO payments.
 
-### Set up MOTO payments on a live account with Stripe
+1. You can now [take MOTO payments through the GOV.UK Pay API](#create-a-moto-payment-using-the-gov-uk-pay-api). If you do not have a technical team to help you integrate with our API, you’ll need to [set up a telephone payment link instead](#set-up-a-telephone-payment-link-optional).
 
-Send your [PCI DSS Self Assessment Questionnaire](/security/#payment-card-industry-pci-compliance) and service name to [GOV.UK Pay support](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+You can still [take online payments](https://docs.payments.service.gov.uk/making_payments/) through your non-MOTO service.
 
-We review your PCI DSS compliance as you may have additional PCI Compliance responsibilities for MOTO payments compared to online payments.
+#### Set up MOTO payments on a live account with Stripe
 
-When we’re satisfied that you’ve met your PCI DSS compliance responsibilities, we will enable MOTO payments in your service. You can then take MOTO payments.
+1. Complete your [PCI DSS Self-Assessment Questionnaire](https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance)
 
-## Create a MOTO payment
+1. Send your completed PCI DSS questionnaire and your service name to [govuk-pay-support@digital.cabinet-office.gov.uk] (mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-Follow these steps to create and complete the MOTO payment.
+1. GOV.UK Pay will review your PCI DSS compliance as you may have additional PCI compliance responsibilities for MOTO payments compared to online payments.
 
-1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO service in [your services](https://selfservice.payments.service.gov.uk/my-services).
+1. When GOV.UK Pay is satisfied you’ve met your PCI DSS compliance responsibilities, we’ll enable MOTO payments in your service. We’ll email you to let you know we’ve enabled MOTO payments.
 
-2. [Create a payment](/making_payments/#creating-a-payment) with the GOV.UK Pay API, and include `moto: true` in the request body.
+1. You can now [take MOTO payments through the GOV.UK Pay API](#create-a-moto-payment-using-the-gov-uk-pay-api). If you do not have a technical team to help you integrate with our API, you’ll need to [set up a telephone payment link instead](#set-up-a-telephone-payment-link-optional).
+
+You can still [take online payments](https://docs.payments.service.gov.uk/making_payments/) through your non-MOTO service.
+
+### Set up a telephone payment link (optional)
+
+Telephone payment links allow you to take payments over the phone without having to integrate with the GOV.UK Pay API. Your call centre agents take calls from paying users and process payments through the GOV.UK Pay admin tool. The agent takes:
+
+- the user's payment reference
+- the payment amount
+- the user's card details
+
+Before you set up a telephone payment link, you must have [set up MOTO payments on your account](#set-up-moto-payments).
+
+You can only have one telephone payment link for each MOTO service.
+
+GOV.UK Pay is still developing telephone payment links and this functionality may change depending on user feedback.
+
+To set up a telephone payment link:
+
+1. Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) and request access to telephone payment links for your MOTO service.
+
+1. Give GOV.UK Pay the details of the telephone payment link when we ask you.
+
+#### Provide telephone payment link details
+
+The GOV.UK Pay support team will request details to create your telephone payment link. These details display as static text every time a call centre agent uses the payment link. Because you can only have one telephone payment link for each service, these details should be applicable to any payment you’ll take with this link.
+
+GOV.UK Pay will request:
+
+- [a payment description](#payment-description)
+- [details](#details-optional) (optional)
+- [the name of the reference](#name-of-the-reference)
+- [reference hint text](#reference-hint-text-optional) (optional)
+
+After you provide the telephone payment link details, we’ll notify you when we’ve created the telephone payment link for your service.
+
+##### Payment description
+
+The payment description explains the purpose of the payment. This description should help the paying user understand what they are paying for.
+
+For example, ‘Pay your council tax.’
+
+Call centre agents can see the payment description while taking the payment.
+
+Paying users can see this description in the payment confirmation email.
+
+##### Details (optional)
+
+These optional details can help to guide your call centre agent through the telephone payment. You can use ‘Details’ to remind your call centre agents to say or ask for certain things.
+
+For example, ‘Remind the paying user that we are recording this call for quality and training purposes.’
+
+Call centre agents see these extra details at the start of the telephone payment process.
+
+Paying users will not be able to see this ‘Details’ description.
+
+##### Name of the reference
+
+The name of the reference is the name your service uses for unique payment references.
+
+For example, the name of the reference could be ‘Invoice number’ or ‘Customer ID’.
+
+Call centre agents see this name next to the input field when they are entering the user’s reference.
+
+##### Reference hint text (optional)
+
+Reference hint text is guidance that call centre agents can give to the paying user to help them find their unique payment reference.
+
+For example, ‘Your customer ID is an 8 digit number. You can find it on any letter from Leeds City Council.’
+
+Call centre agents can see this hint text when they are entering the customer’s reference.
+
+Paying users will not be able to see the reference hint text.
+
+#### Assign user roles to access a telephone payment link
+
+Once GOV.UK Pay has created your telephone payment link, you can assign 2 new roles to your call centre agents in the GOV.UK Pay admin tool:
+
+- **View and take telephone payments**
+- **View, refund and take telephone payments**
+
+Users with these roles can take telephone payments from the service dashboard in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). Users with **View, refund and take telephone payments** can also refund telephone payments.
+
+Assign these roles to your call centre agents to begin taking telephone payments. To assign the roles, select **Manage team members** for your MOTO service in the GOV.UK Pay admin tool.
+
+## Take a MOTO payment
+
+There are 2 ways to take payments over the phone through GOV.UK Pay. You can:
+
+- [take a MOTO payment using a telephone payment link](#take-a-moto-payment-using-a-telephone-payment-link)
+- [create a MOTO payment using the GOV.UK Pay API] (#create-a-moto-payment-using-the-gov-uk-pay-api)
+
+### Take a MOTO payment using a telephone payment link
+
+For your service to take a payment using a telephone payment link, you must have set up:
+
+- [MOTO payments](#set-up-moto-payments)
+- [a telephone payment link](#set-up-a-telephone-payment-link-optional)
+
+Users with one of the following roles can use the GOV.UK Pay admin tool to take a telephone payment:
+
+- **Administrator**
+- **View and take telephone payments**
+- **View, refund and take telephone payments**
+
+To take a telephone payment, open the service that has an associated telephone payment link in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) and select **Take a telephone payment**. Follow the instructions to take the payment.
+
+### Create a MOTO payment using the GOV.UK Pay API
+
+Before you create a MOTO payment, you must have [set up MOTO payments](#set-up-a-moto-payments).
+
+Follow these steps to create and complete the MOTO payment using the GOV.UK Pay API.
+
+1. If your PSP is Worldpay or ePDQ, make sure you're using an API key from your MOTO service in **Services** in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+
+2. [Create a payment](/making_payments/#creating-a-payment) with the GOV.UK Pay API, and include `“moto”: true` in the request body.
 
 3. Go to the [`next_url`](/payment_flow/#making-a-payment) included in the body of the response to your API call.
 
-4. Fill in your user’s information on the **Enter card details** page.
+4. Fill in your user’s information on the **Enter card details** page. The **Enter Card Details** page will not have a billing address field, even if you've enabled  billing address collection on your service.
 
-    The **Enter Card Details** page will not have a billing address field, even if you've enabled collecting billing addresses.
-
-5. Confirm the payment on the **Confirm your payment** page.
-
-    You will not need to do a 3D Secure confirmation.
+5. Confirm the payment on the **Confirm your payment** page. You will not need to do 3D Secure confirmation.
 
 If you're taking a payment by post, make sure you've collected your user's:
 
@@ -95,26 +209,17 @@ If you're taking a payment by post, make sure you've collected your user's:
 
 ## Hide users' card information
 
-When taking payments over the phone, you can hide the following sensitive user card information from your service team staff:
+When taking payments over the phone, you can hide the card information of paying users. When a call centre agent enters a user’s card information, the details are hidden like a password. This protects the paying user’s card information from anyone that can see the call centre agent’s screen. You can hide:
 
-- the full 16 digit card number
+- the card number
 - the card verification value (cvv) or card verification code (cvc)
 
-To hide or unhide this information, you must have admin permissions for your service.
+To hide or unhide this information, you must have the Administrator role for your MOTO service. To see if you are an admin for a service, select Manage team members from the Services screen.
 
 This change takes immediate effect, so you should tell your service team staff before changing these settings.
 
-1. Sign into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk).
 1. Select the account you want to change.
-1. Go to __Settings__ and then __Security__.
-1. Go to either __Hide card numbers__ or __Hide card security codes__ and select __Change__.
-1. Select either __Hidden__ or __Visible__ and then __Save changes__.
-
-## Create an online payment
-
-After we enable MOTO payments in your account, you can still create payments where your user fills in their details themselves.
-
-[Create a payment](/making_payments/#creating-a-payment) with the GOV.UK Pay API using:
-
-- `moto: false` in the request body
-- an API key from your normal service in [your services](https://selfservice.payments.service.gov.uk/my-services), if your PSP is Worldpay or ePDQ
+1. Go to Settings and then Security.
+1. Go to either Hide card numbers or Hide card security codes and select Change.
+1. Select either Hidden or Visible and then Save changes.

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -220,6 +220,6 @@ This change takes immediate effect, so you should tell your service team staff b
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk).
 1. Select the account you want to change.
-1. Go to Settings and then Security.
-1. Go to either Hide card numbers or Hide card security codes and select Change.
-1. Select either Hidden or Visible and then Save changes.
+1. Go to **Settings** and then **Security**.
+1. Go to either **Hide card numbers** or **Hide card security codes** and select **Change**.
+1. Select either **Hidden** or **Visible** and then **Save changes**.


### PR DESCRIPTION
### Context
Telephone payment links have been in private beta for a while. As they move into public beta, we need something in the documentation to explain them.

### Changes proposed in this pull request
This PR:

- restructures the existing telephone payments page into 'Set up MOTO payments' and 'Take a MOTO payment'
- adds guidance around setting up telephone payment links and using telephone payment links to take payments
- improves existing guidance on setting up and creating MOTO payments through the API
- makes new and existing email links more accessible

### Guidance to review
This content has already been reviewed by Alex Bishop (telephone payment links dev) and been through the tech writer 2i process.