### PR TITLE
Corrected an inconsistent reference to Pay

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -23,7 +23,7 @@ software](https://www.gov.uk/service-manual/making-software/deployment.html)
 
 ## Decide how you want to take payments
 
-There are 2 ways you can take payments with Pay:
+There are 2 ways you can take payments with GOV.UK Pay:
 
 * integrate with the GOV.UK Pay API
 * set up a payment link


### PR DESCRIPTION
### Context
Pay should be referred to as 'GOV.UK Pay'.

### Changes proposed in this pull request
Change one reference of 'Pay' to 'GOV.UK Pay'
