### PR TITLE
Updated 'Taking a payment' to make 'self' and 'next_url' differences more obvious.

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -159,7 +159,7 @@ There are two URLs in the `_links` object -- one in the `self` section and one i
 
 The URL in `self` is the unique URL for the new payment. You can also find this URL in the `Location` response header. A `GET` request to this URL returns information about the new payment and its status.
 
-`next_url` is the URL that the paying user will visit to make their payment. You should direct your users to this URL.
+The `next_url` is the URL that the paying user will visit to make their payment. You should direct your users to this URL.
 
 Your service needs to store the `self` URL or the `payment_id` for each new payment you create. This is so you can check on the status of these payments later.
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -155,19 +155,15 @@ Example response:
 }
 ```
 
-The response to the ‘Create new payment’ API call will include the URL for the payment. You can get this from either:
+There are two URLs in the `_links` object -- one in the `self` section and one in the `next_url` section.
 
-* the `Location` response header
-* the `self` section of `_links` in the JSON body
+The URL in `self` is the unique URL for the new payment. You can also find this URL in the `Location` response header. A `GET` request to this URL returns information about the new payment and its status.
 
-The URL contains the GOV.UK Pay `payment_id`, which is automatically generated and identifies the payment. A GET request to this URL will return information about the payment and its status.
+`next_url` is the URL that the paying user will visit to make their payment. You should direct your users to this URL.
 
-Your service will need to store the `payment_id` (or the full URL) for each new payment you create. This is so you can check the status of these payments later.
+Your service needs to store the `self` URL or the `payment_id` for each new payment you create. This is so you can check on the status of these payments later.
 
 Read more about [reporting](/reporting/#report-on-a-payment) and [payment flow](/payment_flow/#how-gov-uk-pay-works).
-
-The response will also include the ``next_url`` to which you should direct your
-user to complete their payment.
 
 <%= warning_text('Do not expose the `next_url` to anyone other than your paying user. Anyone in possession of the `next_url` could hijack your user’s payment.') %>
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -159,7 +159,7 @@ There are two URLs in the `_links` object -- one in the `self` section and one i
 
 The URL in `self` is the unique URL for the new payment. You can also find this URL in the `Location` response header. A `GET` request to this URL returns information about the new payment and its status.
 
-The `next_url` is the URL that the paying user will visit to make their payment. You should direct your users to this URL.
+The `next_url` is the URL the paying user will visit to make their payment. You should direct your users to this URL.
 
 Your service needs to store the `self` URL or the `payment_id` for each new payment you create. This is so you can check on the status of these payments later.
 


### PR DESCRIPTION
### Context
As [highlighted by Jon in a JIRA ticket](https://payments-platform.atlassian.net/browse/PP-6747?atlOrigin=eyJpIjoiMmM1NDY0YzA0MmFiNDE0ZjkxYjQxMWExYjhiYTVmNTQiLCJwIjoiaiJ9), the [current documentation](https://docs.payments.service.gov.uk/making_payments/#receiving-the-api-response) doesn't make it obvious what the differences are between the URLs in the `self` section and `next_url` section of the API response after creating a new payment.

For context, the `self` URL is a unique URL for the payment that API users can use to get information about the payment. The `next_url` URL is where paying users will go to make their payment.

### Changes proposed in this pull request
Clarify the differences between `self` and `next_url`.

### Guidance to review

* Is 'section' the right wording here?
* Does this make the differences between the two URLs clear?
* Can it be cut down any further?