### PR TITLE
Minor fixes to Stripe and Worldpay switching guidance

### DIFF
--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -41,7 +41,7 @@ To get to the **Switch payment service provider** page:
 
 2. Select the service you want to switch from the **Overview** page - services you can switch are labelled **LIVE - SWITCH PSP**
 
-3. On your service dashboard, select the ‘**...how to switch to Worldpay link**’ in the banner at the top of the page, or select **Settings** in the navigation.
+3. On your service dashboard, select the ‘**...how to switch to Stripe**' link in the banner at the top of the page, or select **Settings** in the navigation.
 
 4. In **Settings**, select **Switch PSP** from the side navigation.
 

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -131,7 +131,7 @@ To get to the **Switch payment service provider** page:
 
 2. Select the service you want to switch from the **Overview** page - services you can switch are labelled **LIVE - SWITCH PSP**.
 
-3. On your service dashboard, select the ‘**...how to switch to Worldpay link**’ in the banner, or select **Settings** in the navigation.
+3. On your service dashboard, select the ‘**...how to switch to Worldpay**' link in the banner, or select **Settings** in the navigation.
 
 4. In **Settings**, select **Switch PSP** from the side navigation.
 


### PR DESCRIPTION
### Context
The switching PSP guidance had the following issues:

* Formatting was incorrect for both Stripe and Worldpay UI text.
* Stripe guidance referred to a Worldpay link

### Changes proposed in this pull request
Corrects formatting and wording errors.