### PR TITLE
Clarified payment link functionality after switching PSP.

### DIFF
--- a/source/switch_payment_service_provider/index.html.md.erb
+++ b/source/switch_payment_service_provider/index.html.md.erb
@@ -31,6 +31,6 @@ The switch is just a change of PSP. Your users will not be made aware of any cha
 
 Users making payments during the switching period are not affected. Your existing PSP will still process active payments.
 
-The switching process is the same whether your service integrates with GOV.UK Pay’s API or uses payment links. Switching does not need any code changes. Your existing API keys remain valid.
+The switching process is the same whether your service integrates with GOV.UK Pay’s API or uses payment links. Switching does not need any code changes. Your existing API keys remain valid. Your existing payment links continue to work with your new PSP.
 
 You may need to make changes to your financial reporting if you switch from Stripe to Worldpay as [Stripe offers additional reporting data](https://docs.payments.service.gov.uk/reporting/#report-on-a-payment).


### PR DESCRIPTION
FCDO were unsure about whether payment links would be affected by switching PSP. This PR clarifies the behaviour under the 'What the switch affects' heading.