### PR TITLE
PP-8614 - Documentation for 3DS details in Reporting API

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -94,6 +94,12 @@ Example response:
     }
   },
   "payment_id": "hu20sqlact5260q2nanm0q8u93",
+  "authorisation_summary": {
+    "three_d_secure": {
+      "required": true,
+      "version": "2.2.0"
+    }
+  }
   "refund_summary": {
     "status": "available",
     "amount_available": 4000,
@@ -130,6 +136,18 @@ The `_links` object includes `href` and `method` fields that you can use to make
 - `events` to [get the payment's events](/reporting/#get-a-payment-s-events)
 - `refunds` to [get all refunds for the payment](/refunding_payments/#get-all-refunds-for-a-single-payment)
 - `cancel` to [cancel the payment](/making_payments/#cancel-a-payment-that-s-in-progress)
+
+#### authorisation_summary
+
+If the [payment was authenticated with 3D Secure (3DS)](https://docs.payments.service.gov.uk/set_up_3dsecure), `authorisation_summary` contains information about the authentication.
+
+`required` is `true` if the payment was authenticated using 3DS.
+
+`version` is the version of 3DS that was used to authenticate the payment. It can be:
+
+* `2.2.0`
+* `2.1.0`
+* `1.0.2`
 
 #### card_details
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -97,7 +97,6 @@ Example response:
   "authorisation_summary": {
     "three_d_secure": {
       "required": true,
-      "version": "2.2.0"
     }
   }
   "refund_summary": {
@@ -143,11 +142,7 @@ If the [payment was authenticated with 3D Secure (3DS)](https://docs.payments.se
 
 `required` is `true` if the payment was authenticated using 3DS.
 
-`version` is the version of 3DS that was used to authenticate the payment. It can be:
-
-* `2.2.0`
-* `2.1.0`
-* `1.0.2`
+`authorisation_summary` is only available for payments created on or after 1 September 2021.
 
 #### card_details
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -138,9 +138,9 @@ The `_links` object includes `href` and `method` fields that you can use to make
 
 #### authorisation_summary
 
-If the [payment was authenticated with 3D Secure (3DS)](https://docs.payments.service.gov.uk/set_up_3dsecure), `authorisation_summary` contains information about the authentication.
+If the [payment was authenticated with 3D Secure (3DS)](https://docs.payments.service.gov.uk/set_up_3dsecure), `authorisation_summary` and `three_d_secure` contain information about the authentication.
 
-`required` is `true` if the payment was authenticated using 3DS.
+`required` is `true` if 3D Secure authentication was required for the payment.
 
 `authorisation_summary` is only available for payments created on or after 1 September 2021.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -140,7 +140,7 @@ The `_links` object includes `href` and `method` fields that you can use to make
 
 If the [payment was authenticated with 3D Secure (3DS)](https://docs.payments.service.gov.uk/set_up_3dsecure), `authorisation_summary` and `three_d_secure` contain information about the authentication.
 
-`required` is `true` if 3D Secure authentication was required for the payment.
+`required` is `true` if the payment required 3D Secure authentication.
 
 `authorisation_summary` is only available for payments created on or after 1 September 2021.
 

--- a/source/set_up_3dsecure/index.html.md.erb
+++ b/source/set_up_3dsecure/index.html.md.erb
@@ -69,4 +69,6 @@ Smartpay does not apply any SCA exemptions to transactions.
 
 ## Further information
 
-For more information on SCA including payment exemptions, [see the GOV.UK Pay page on SCA](https://www.payments.service.gov.uk/3d-secure-2/).
+You can use our [reporting API to check the 3DS status of a payment](/reporting/#authorisation-summary).
+
+For more information on SCA, including payment exemptions, [see the GOV.UK Pay page on SCA](https://www.payments.service.gov.uk/3d-secure-2/).


### PR DESCRIPTION
## Context
It is now possible to view 3D Secure authentication details about a payment through the Pay Reporting API.

## Changes proposed in this pull request
This PR makes the following changes:

- Adds `authorisation_summary` object to the API response example on the 'Report on a payment' page
- Adds definitions of `authorisation_summary`, including `required` and `version` objects
- Adds a link to the 'Report on a payment' page to the 'Set up SCA' page

## Guidance to review

### Questions for the SME:

- Is the `authorisation_summary` definition accurate?
- Has `authorisation_summary` been added to the correct part of the response example?
- Do the `version` values (`2.2.0`, `2.1.0`, `1.0.2`) need their own definitions?

### Questions for 2i reviewer:

- I switch between 'authorisation' and 'authentication' a bit. 'Authorise' is how Pay refer to it, but 'authenticate' is how 3DS is referred to elsewhere. Is this switching okay? 
- Do I introduce the possible `version` values appropriately?