### PR TITLE
Updated Pay docs accessibility statement to reflect TDT update.

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GOV.UK Pay's technical documentation
-last_reviewed_on: 2021-07-16
+last_reviewed_on: 2021-10-06
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -23,11 +23,7 @@ We’ve also made the website text as simple as possible to understand.
 
 ## How accessible this website is
 
-We know some parts of this website are not fully accessible with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard as there are issues caused by our Technical Documentation Template.
-
-#### Non-complicance with the accessibility regulations
-
-Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#how-accessible-this-website-is).
+The GOV.UK Pay technical documentation is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## Feedback and contact information
 
@@ -47,14 +43,10 @@ The Equality and Human Rights Commission (EHRC) is responsible for enforcing the
 
 GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-## Compliance status
-
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
-
 ## How we tested this website
 
-We last tested this website for accessibility issues in March 2021.
+We last tested this website for accessibility issues in October 2021.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 3 September 2020. It was last reviewed on 29 July 2021.
+This statement was prepared on 3 September 2020. It was last reviewed on 6 October 2021.


### PR DESCRIPTION
### Context
Previous WCAG guideline updates made the [Tech Docs Template](https://tdt-documentation.london.cloudapps.digital/#technical-documentation-template) inaccessible. The inaccessible elements [have since been fixed](https://github.com/alphagov/tech-docs-gem/releases/tag/v3.0.0), so the Pay documentation is now accessible.

### Changes proposed in this pull request
Updates GOV.UK Pay technical documentation's accessibility statement to reflect its full compliance.
