### PR TITLE
Updates docs for prepaid credit and debit cards.

### DIFF
--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -14,14 +14,13 @@ set this up for you.
 Each surcharge is a flat amount added to a payment. If you’d like to discuss
 adding surcharges as percentages, please contact us.
 
-You can set a different surcharge for each of the following 4 corporate card types:
+You can set a different surcharge for each of the following 3 corporate card types:
 
 * non-prepaid credit cards
 * non-prepaid debit cards
-* prepaid credit cards
-* prepaid debit cards
+* prepaid debit and credit cards
 
-In a payment journey, when your user enters a card number the GOV.UK Pay platform checks to determine if it’s one of the 4 corporate card types. If a surcharge is applicable, the platform will inform them that a surcharge of a certain amount will be added to the total.
+In a payment journey, when your user enters a card number the GOV.UK Pay platform checks to determine if it’s one of the 3 corporate card types. If a surcharge is applicable, the platform will inform them that a surcharge of a certain amount will be added to the total.
 
 We will not apply a surcharge if we cannot tell if the card is:
 


### PR DESCRIPTION
### Context
PP-8785 merges corporate card charges for prepaid credit and debit cards. Instead of setting separate charges for prepaid credit and prepaid debit cards, there is now just one prepaid fee.

### Changes proposed in this pull request

- Merges prepaid credit and debit card references.
- Changes references to '4 types' of charge to '3 types'. 

### Guidance to review
Is there anything missing?