### PR TITLE
Fix broken links to Pay contract

### DIFF
--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -33,9 +33,9 @@ To switch to Stripe, you’ll need:
 
 Before switching, read the:
 
-* [GOV.UK Pay contract](https://selfservice.payments.service.gov.uk/policy/download/contract-for-non-crown-bodies) (if you are a non-Crown organisation)
-* [Memorandum of Understanding](https://selfservice.payments.service.gov.uk/policy/download/memorandum-of-understanding-for-crown-bodies) (if you are a Crown organisation)
-* [Stripe Connected Account Agreement](https://selfservice.payments.service.gov.uk/policy/download/stripe-connected-account-agreement).
+* [GOV.UK Pay contract](https://selfservice.payments.service.gov.uk/policy/contract-for-non-crown-bodies) (if you are a non-Crown organisation)
+* [Memorandum of Understanding](https://selfservice.payments.service.gov.uk/policy/memorandum-of-understanding-for-crown-bodies) (if you are a Crown organisation)
+* [Stripe Connected Account Agreement](https://selfservice.payments.service.gov.uk/policy/stripe-connected-account-agreement).
 
 To get to the **Switch payment service provider** page:
 


### PR DESCRIPTION
Updated URL for 

GOV.UK Pay contract (if you are a non-Crown organisation)
Memorandum of Understanding (if you are a Crown organisation)
Stripe Connected Account Agreement.

### Context
A user pointed out some broken links on our PSP switching page. 

### Changes proposed in this pull request
Change the links of the Pay contracts from old to new 

### Guidance to review
You must be logged in to view the links 