### PR TITLE
Adds proving government entity status details + document upload steps

### DIFF
--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -31,17 +31,27 @@ To switch to Stripe, you’ll need:
 * the name, date of birth and email address of the director of your service (or someone at director level)
 * a debit or credit card to make a refundable payment to test your service
 
+You also need a document that verifies your organisation is a government entity. This must be a colour copy of (one of the following):
+
+* your VAT registration
+* your certificate of incorporation
+* a document from Companies House
+* a VAT certificate from HM Revenue and Customs
+* an account statement from HM Revenue and Customs
+* a document from the Charity Commission
+* a document from the Scottish Charity Regulator (OSCR)
+
 Before switching, read the:
 
 * [GOV.UK Pay contract](https://selfservice.payments.service.gov.uk/policy/contract-for-non-crown-bodies) (if you are a non-Crown organisation)
 * [Memorandum of Understanding](https://selfservice.payments.service.gov.uk/policy/memorandum-of-understanding-for-crown-bodies) (if you are a Crown organisation)
-* [Stripe Connected Account Agreement](https://selfservice.payments.service.gov.uk/policy/stripe-connected-account-agreement).
+* [Stripe Connected Account Agreement](https://selfservice.payments.service.gov.uk/policy/stripe-connected-account-agreement)
 
 To get to the **Switch payment service provider** page:
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
 
-2. Select the service you want to switch from the **Overview** page - services you can switch are labelled **LIVE - SWITCH PSP**
+2. Select the service you want to switch from the **Overview** page - services you can switch are labelled **LIVE - SWITCH PSP**.
 
 3. On your service dashboard, select the ‘**...how to switch to Stripe**' link in the banner at the top of the page, or select **Settings** in the navigation.
 
@@ -86,6 +96,12 @@ The live payment is £2.00 and is refundable. Your new Stripe account will be de
 1. If your organisation has a company registration number, select **Yes** and enter your company registration number.
 
 1. If your organisation does not have a company registration number, select **No**.
+
+1. Select **Save and continue**.
+
+1. Select **Upload proof of government entity document**.
+
+1. Select **Choose file** and upload a document that verifies your organisation is a government entity.
 
 1. Select **Save and continue**.
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -99,9 +99,9 @@ The live payment is £2.00 and is refundable. Your new Stripe account will be de
 
 1. Select **Save and continue**.
 
-1. Select **Upload proof of government entity document**.
+1. Select **Add a government entity document**.
 
-1. Select **Choose file** and upload a document that verifies your organisation is a government entity.
+1. Select **Choose file** and add a document that verifies your organisation is a government entity.
 
 1. Select **Save and continue**.
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -99,9 +99,9 @@ The live payment is £2.00 and is refundable. Your new Stripe account will be de
 
 1. Select **Save and continue**.
 
-1. Select **Add a government entity document**.
+1. Select **Upload a government entity document**.
 
-1. Select **Choose file** and add a document that verifies your organisation is a government entity.
+1. Select **Choose file** and upload a document that verifies your organisation is a government entity.
 
 1. Select **Save and continue**.
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -36,8 +36,8 @@ You also need a document that verifies your organisation is a government entity.
 * your VAT registration
 * your certificate of incorporation
 * a document from Companies House
-* a VAT certificate from HM Revenue and Customs
-* an account statement from HM Revenue and Customs
+* a VAT certificate from HM Revenue and Customs (HMRC)
+* an account statement from HMRC
 * a document from the Charity Commission
 * a document from the Scottish Charity Regulator (OSCR)
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -23,7 +23,17 @@ You must add:
 * the name, date of birth and work email address of the director of your service (or someone at director level)
 * your company registration number (if applicable)
 
-To add these details, sign in the the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login), select your service from the **Overview** screen, and follow the on-screen instructions.
+You must also add a document that verifies your organisation is a government entity. This must be a colour copy of (one of the following):
+
+* your VAT registration
+* your certificate of incorporation
+* a document from Companies House
+* a VAT certificate from HM Revenue and Customs
+* an account statement from HM Revenue and Customs
+* a document from the Charity Commission
+* a document from the Scottish Charity Regulator (OSCR)
+
+To add these details and the document, sign in the the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login), select your service from the **Overview** screen, and follow the on-screen instructions.
 
 GOV.UK Pay only stores your organisation's address and telephone number. We pass all other information to Stripe. Stripe then processes and stores that information.
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -33,7 +33,7 @@ You must also add a document that verifies your organisation is a government ent
 * a document from the Charity Commission
 * a document from the Scottish Charity Regulator (OSCR)
 
-To add these details and the document, sign in the the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login), select your service from the **Overview** screen, and follow the on-screen instructions.
+To add these details and the document, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login). Select your service from the **Overview** screen, and follow the on-screen instructions.
 
 GOV.UK Pay only stores your organisation's address and telephone number. We pass all other information to Stripe. Stripe then processes and stores that information.
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -28,8 +28,8 @@ You must also add a document that verifies your organisation is a government ent
 * your VAT registration
 * your certificate of incorporation
 * a document from Companies House
-* a VAT certificate from HM Revenue and Customs
-* an account statement from HM Revenue and Customs
+* a VAT certificate from HM Revenue and Customs (HMRC)
+* an account statement from HMRC
 * a document from the Charity Commission
 * a document from the Scottish Charity Regulator (OSCR)
 


### PR DESCRIPTION
### Context
[PP-8962](https://payments-platform.atlassian.net/browse/PP-8962#icft=PP-8962) adds a document uploader to allow services to prove that they are government entities. Services that use GOV.UK Pay and choose Stripe as their service provider must upload a document that proves they are a government entity. Only certain documents are allowed.

### Changes proposed in this pull request
This PR makes changes to the following pages:

- Connect your live account to Stripe
  - Specifies the valid documents for proving government entity status
- Switch payment service provider to Stripe
  - Specifies the valid documents for proving government entity status
  - Adds a document upload step to the process for switching to Stripe

### Guidance to review

Notes:

* the UI text in line 102 of switch_psp_to_stripe is TBC - content designer needs to review it. Will update that text when it's confirmed/changed.

Questions for pre-i / 2i reviewer:

* does it matter that there are now two big lists next to each other? _(lines 24 - 42 in switch_psp_to_stripe / lines 18 - 34 in set_up_a_live_stripe_account)_
* should I specify 'one document', rather than 'a document' before the lists of valid documents? _(line 34 in switch_psp_to_stripe / line 26 in set_up_a_live_stripe_account)_
* 