### PR TITLE
Adds a request for payment descriptors to initial switch PSP email

### DIFF
--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -20,7 +20,8 @@ You must be a GOV.UK Pay admin user to switch PSP. To check if you are an admin 
 Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:mailto:govuk-pay-support@digital.cabinet-office.gov.uk) asking to switch your PSP to Stripe. Your email must include:
 
 * a list of services you want to switch to Stripe
-* a clear payment descriptor of maximum 22 characters for each service - the payment descriptor is what will appear on your users' bank statements, not the service itself
+* a clear payment descriptor of maximum 22 characters for each service - the payment descriptor will appear on your users' bank statements, not the service itself
+* a clear statement descriptor of maximum 22 characters for each service - the statement descriptor will appear on your bank statements when you receive payouts
 
 You can [read Stripe's payment or 'statement' descriptor guidance](https://stripe.com/docs/statement-descriptors) for more information.
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -17,9 +17,14 @@ You must be a GOV.UK Pay admin user to switch PSP. To check if you are an admin 
 
 ## Prepare to switch to Stripe
 
-Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:mailto:govuk-pay-support@digital.cabinet-office.gov.uk) asking to switch your PSP to Stripe on all services for your organisation, or list out specific services.
+Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:mailto:govuk-pay-support@digital.cabinet-office.gov.uk) asking to switch your PSP to Stripe. Your email must include:
 
-The GOV.UK Pay support team will confirm when we’ve enabled the switch PSP feature for your service.
+* a list of services you want to switch to Stripe
+* a clear payment descriptor of maximum 22 characters for each service - the payment descriptor is what will appear on your users' bank statements, not the service itself
+
+You can [read Stripe's payment or 'statement' descriptor guidance](https://stripe.com/docs/statement-descriptors) for more information.
+
+The GOV.UK Pay support team will email you to confirm when you can start switching PSP.
 
 To switch to Stripe, you’ll need:
 


### PR DESCRIPTION
### Context
When services request to switch PSP to Stripe, we currently ask for their payment descriptor through Zendesk. This is wasteful when they could include it in their initial switch request.

### Changes proposed in this pull request
This PR adds a few lines to the start of the 'Switching PSP to Stripe' guidance. The new content asks services to send us payment descriptors for each service they're switching over to try and avoid having to ask this via Zendesk email later in the process.

It links out to Stripe's guidance on good descriptors to avoid copying the information ourselves.