### PR TITLE
PP-9088 - Documentation for failed transaction fees

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -77,7 +77,7 @@ If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://se
 - payments ('payouts') that Stripe has made to your bank account
 - which of your users' payments are in each payout
 
-From 1 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount) they will deduct the fees from your Stripe balance. The failed payments are bundled into your regular payouts.
+From 1 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount) they will deduct the fees from your Stripe balance. The failed payments are bundled into your regular payouts. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments.
 
 If your PSP is Worldpay, contact them to find out your minimum payout and payment times. You'll receive a separate payout for each merchant code you use.
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -77,7 +77,7 @@ If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://se
 - payments ('payouts') that Stripe has made to your bank account
 - which of your users' payments are in each payout
 
-From 1 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount), they will deduct the fees from your Stripe balance. Stripe bundles the failed payments into your regular payouts. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments.
+From 6 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount), they will deduct the fees from your Stripe balance. Stripe bundles the failed payments into your regular payouts. Until 6 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments.
 
 If your PSP is Worldpay, contact them to find out your minimum payout and payment times. You'll receive a separate payout for each merchant code you use.
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -77,6 +77,8 @@ If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://se
 - payments ('payouts') that Stripe has made to your bank account
 - which of your users' payments are in each payout
 
+From 1 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount) they will deduct the fees from your Stripe balance. The failed payments are bundled into your regular payouts.
+
 If your PSP is Worldpay, contact them to find out your minimum payout and payment times. You'll receive a separate payout for each merchant code you use.
 
 #### Checking when your PSP sent a payment
@@ -92,7 +94,7 @@ Example response:
 }
 ```
 
-where `settled_date` is either:
+Where `settled_date` is either:
 
 - the date Stripe sent the payment to your bank account as part of a group of payments (‘payout’)
 - missing if Stripe has not yet sent the payment to your bank account

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -77,7 +77,7 @@ If your PSP is Stripe, you can sign in to the [GOV.UK Pay admin tool](https://se
 - payments ('payouts') that Stripe has made to your bank account
 - which of your users' payments are in each payout
 
-From 1 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount) they will deduct the fees from your Stripe balance. The failed payments are bundled into your regular payouts. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments.
+From 1 April 2022, [if Stripe charges fees on a failed payment](/reporting/#net-amount), they will deduct the fees from your Stripe balance. Stripe bundles the failed payments into your regular payouts. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments.
 
 If your PSP is Worldpay, contact them to find out your minimum payout and payment times. You'll receive a separate payout for each merchant code you use.
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -197,7 +197,9 @@ The `metadata` object includes any metadata keys and values you added when creat
 
 #### net_amount
 
-If you use GOV.UK’s PSP, `net_amount` is the amount that will be paid into your account after we take the [PSP transaction fee](https://docs.payments.service.gov.uk/reporting/#psp-fees).
+If your PSP is Stripe, `net_amount` is the amount that will be paid into your account after we take the [PSP transaction fees](https://docs.payments.service.gov.uk/reporting/#psp-fees).
+
+`net_amount` can be a negative number if [Stripe charges fees on a failed payment](/reporting/#psp-fees).
 
 #### payment_id
 
@@ -267,14 +269,16 @@ Example response:
 
 Where:
 
-- `total_amount` is the amount your user paid in pence, including a [corporate card surcharge](/corporate_card_surcharges/#add-corporate-card-fees) if you added one
+- `total_amount` is the amount your user paid in pence and only appears if a [corporate card surcharge](/corporate_card_surcharges/#add-corporate-card-fees) was added to the payment
 - `fee` is the PSP transaction fee that we took from the amount your user paid, in pence
 - `net_amount` is the amount that will be paid into your account, in pence
 
-The response will not contain a `fee` or `net_amount` parameter if either:
+The response will not contain `fee` or `net_amount` if either:
 
 - your PSP is Worldpay - we do not deduct these PSPs' transaction fees
 - you're using an API key from your test ('sandbox') account - we do not deduct fees from payments in this account
+
+Stripe may charge transaction fees on failed payments. If this happens, `net_amount` will be a negative number. Starting 1 April 2022, this negative amount will be taken from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
 
 To test transaction fees, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -185,7 +185,7 @@ payment journey, the `card_details` section contains the information they entere
 
 #### fee
 
-If you use GOV.UK’s payment service provider (PSP), `fee` is the [PSP transaction fee](/reporting/#psp-fees) that we took from the amount your user paid.
+If you use GOV.UK’s payment service provider (PSP), `fee` is the [PSP transaction fee](/reporting/#psp-fees) we took from the amount your user paid.
 
 #### metadata
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -278,7 +278,9 @@ The response will not contain `fee` or `net_amount` if either:
 - your PSP is Worldpay - we do not deduct these PSPs' transaction fees
 - you're using an API key from your test ('sandbox') account - we do not deduct fees from payments in this account
 
-Stripe may charge transaction fees on failed payments. If this happens, `net_amount` will be a negative number. From 1 April 2022, this negative amount will be taken from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
+Stripe may charge transaction fees on failed payments. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments and these fees will not appear in a `GET /v1/payments/{PAYMENT_ID}` response.
+
+If Stripe charge transaction fees on a failed payment on or after 1 April 2022, `net_amount` will be a negative number. From 1 April 2022, this negative amount will be taken from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
 
 To test transaction fees, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -197,7 +197,7 @@ The `metadata` object includes any metadata keys and values you added when creat
 
 #### net_amount
 
-If your PSP is Stripe, `net_amount` is the amount that will be paid into your account after we take the [PSP transaction fees](https://docs.payments.service.gov.uk/reporting/#psp-fees).
+If your PSP is Stripe, `net_amount` is the amount that Stripe will pay into your account after GOV.UK Pay take the [PSP transaction fees](https://docs.payments.service.gov.uk/reporting/#psp-fees).
 
 `net_amount` can be a negative number if [Stripe charges fees on a failed payment](/reporting/#psp-fees).
 
@@ -269,7 +269,7 @@ Example response:
 
 Where:
 
-- `total_amount` is the amount your user paid in pence and only appears if a [corporate card surcharge](/corporate_card_surcharges/#add-corporate-card-fees) was added to the payment
+- `total_amount` is the amount your user paid in pence and only appears if you added a [corporate card surcharge](/corporate_card_surcharges/#add-corporate-card-fees) to the payment
 - `fee` is the PSP transaction fee that we took from the amount your user paid, in pence
 - `net_amount` is the amount that will be paid into your account, in pence
 
@@ -280,7 +280,7 @@ The response will not contain `fee` or `net_amount` if either:
 
 Stripe may charge transaction fees on failed payments. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments and these fees will not appear in a `GET /v1/payments/{PAYMENT_ID}` response.
 
-If Stripe charge transaction fees on a failed payment on or after 1 April 2022, `net_amount` will be a negative number. From 1 April 2022, this negative amount will be taken from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
+If Stripe charge transaction fees on a failed payment on or after 1 April 2022, `net_amount` will be a negative number. From 1 April 2022, Stripe will take negative amount from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
 
 To test transaction fees, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -185,7 +185,7 @@ payment journey, the `card_details` section contains the information they entere
 
 #### fee
 
-If you use GOV.UK’s payment service provider (PSP), `fee` is the [PSP transaction fee](https://docs.payments.service.gov.uk/reporting/#psp-fees) that we took from the amount your user paid.
+If you use GOV.UK’s payment service provider (PSP), `fee` is the [PSP transaction fee](/reporting/#psp-fees) that we took from the amount your user paid.
 
 #### metadata
 
@@ -278,7 +278,7 @@ The response will not contain `fee` or `net_amount` if either:
 - your PSP is Worldpay - we do not deduct these PSPs' transaction fees
 - you're using an API key from your test ('sandbox') account - we do not deduct fees from payments in this account
 
-Stripe may charge transaction fees on failed payments. If this happens, `net_amount` will be a negative number. Starting 1 April 2022, this negative amount will be taken from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
+Stripe may charge transaction fees on failed payments. If this happens, `net_amount` will be a negative number. From 1 April 2022, this negative amount will be taken from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
 
 To test transaction fees, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -278,9 +278,9 @@ The response will not contain `fee` or `net_amount` if either:
 - your PSP is Worldpay - we do not deduct these PSPs' transaction fees
 - you're using an API key from your test ('sandbox') account - we do not deduct fees from payments in this account
 
-Stripe may charge transaction fees on failed payments. Until 1 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments and these fees will not appear in a `GET /v1/payments/{PAYMENT_ID}` response.
+Stripe may charge transaction fees on failed payments. Until 6 April 2022, GOV.UK Pay will cover the cost of transaction fees on failed payments and these fees will not appear in a `GET /v1/payments/{PAYMENT_ID}` response.
 
-If Stripe charge transaction fees on a failed payment on or after 1 April 2022, `net_amount` will be a negative number. From 1 April 2022, Stripe will take negative amount from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
+If Stripe charge transaction fees on a failed payment on or after 6 April 2022, `net_amount` will be a negative number. From 6 April 2022, Stripe will take negative amount from your Stripe account balance. For example, a `net_amount` of `-200` will take £2.00 from your Stripe account.
 
 To test transaction fees, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
 


### PR DESCRIPTION
### Context
PP-8951 implements Stripe's new fee structure, including the possibility of fees on failed payments and changes to the behaviour of the `total_amount` and `net_amount` values.

### Changes proposed in this pull request
This PR changes the following page s:

- Report on a payment
  - `net_amount` - updated description to mention negative amounts
  - `total_amount` - updated description to make it clear that it only appears when there is a corporate card surcharge
  - Added links to 'Integrate with GOV.UK Pay API', which explains how negative `net_amount` can occur
- Integrate with GOV.UK Pay API
  - Updated 'Checking when your PSP sent a payment' to include the possibility of payments being taken from Stripe balance if they fail but have fees

### Guidance to review
