### PR TITLE
BAU: Remove explicit dependency on middleman-search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,5 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 gem 'govuk_tech_docs', '~> 3.0.1'
-gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'
 
 gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/middleman-search.git
-  revision: 50d072378c6f92a78ea02fed366ec6453aea8552
-  specs:
-    middleman-search (0.10.0)
-      execjs (~> 2.6)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -201,7 +192,6 @@ PLATFORMS
 DEPENDENCIES
   govuk_tech_docs (~> 3.0.1)
   html-proofer
-  middleman-search!
   tzinfo-data
   wdm (~> 0.1.0)
 


### PR DESCRIPTION
This gem is now brought in by the govuk_tech_docs gem (see Gemfile). The previous dependency was fetching from git in a deprecated manner and [causing a failure in the PR build process](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pay-tech-docs/jobs/build-pr/builds/21.1).

Tested the search functionality locally without the dependency as a separate gem.