### PR TITLE
pay-tech-docs.cloudapps.digital has been deleted

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -60,9 +60,6 @@ http {
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
         add_header Strict-Transport-Security "max-age=31536000";
       <% end %>
-      if ($host != "pay-tech-docs.cloudapps.digital") {
-        return 301 https://pay-tech-docs.cloudapps.digital$request_uri;
-      }
     }
 
   <% unless File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_dotfiles")) %>


### PR DESCRIPTION
`pay-tech-docs.cloudapps.digital` was found running in the `govuk-service-manual` organisation and is being deleted.

Just removing this reference in case anyone gets confused by it in the future
