### PR TITLE
Improved the description of what a service should do with return URL users

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -259,6 +259,8 @@ If your user is directed to the `return_url`, they could have:
 Your service should use a `GET /v1/payments/{PAYMENT_ID}` call to [check the payment's status](https://docs.payments.service.gov.uk/reporting/#get-information-about-a-single-payment) when your user
 reaches the `return_url`. You should provide an appropriate response based on the `state` the payment attempt.
 
+Do not use other API calls to check the payment’s status. Other calls, such as [search payments](/reporting/#search-payments), do not update immediately and so may not be up to date.
+
 ## When your user does not complete their payment journey
 
 Your user may close their browser or lose internet connectivity in the middle of

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -256,9 +256,8 @@ If your user is directed to the `return_url`, they could have:
 
  * not paid because of a technical error
 
-Your service should use the API to check the payment status when your user
-reaches the `return_url`, and provide an appropriate response based on the final
-status of the payment attempt.
+Your service should use a `GET /v1/payments/{PAYMENT_ID}` call to [check the payment's status](https://docs.payments.service.gov.uk/reporting/#get-information-about-a-single-payment) when your user
+reaches the `return_url`. You should provide an appropriate response based on the `state` the payment attempt.
 
 ## When your user does not complete their payment journey
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Go live
-last_reviewed_on: 2021-09-09
+last_reviewed_on: 2022-01-24
 review_in: 6 months
 weight: 160
 ---
@@ -107,7 +107,7 @@ You make a real payment using either:
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
-    If you want to see the payment in your bank account, make sure the payment amount is [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments).
+    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after your PSP has taken their fees. If your PSP is Stripe, we recommend a test payment of at least £2.
 
 ### Make a payment using a payment link
 
@@ -119,7 +119,7 @@ You make a real payment using either:
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
-    If you want to see the payment in your bank account, make sure the payment amount is [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments).
+    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after your PSP has taken their fees. If your PSP is Stripe, we recommend a test payment of at least £2.
 
 ### Check that the payment was successful
 


### PR DESCRIPTION
### Context
Some services have been trying to use the search payments API call to check the `status` of payments after users reach the `return_url`. This was providing inaccurate `status` information.

### Changes proposed in this pull request
Improve the description of what services should do when their users are directed to their `return_url`.