### PR TITLE
Updated Go Live test payment amount advice.

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Go live
-last_reviewed_on: 2021-09-09
+last_reviewed_on: 2022-01-24
 review_in: 6 months
 weight: 160
 ---
@@ -107,7 +107,7 @@ You make a real payment using either:
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
-    If you want to see the payment in your bank account, make sure the payment amount is [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments).
+    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after PSP fees are taken. If your PSP is Stripe, we recommend a test payment of at least £2.
 
 ### Make a payment using a payment link
 
@@ -119,7 +119,7 @@ You make a real payment using either:
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
-    If you want to see the payment in your bank account, make sure the payment amount is [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments).
+    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after PSP fees are taken. If your PSP is Stripe, we recommend a test payment of at least £2.
 
 ### Check that the payment was successful
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -107,7 +107,7 @@ You make a real payment using either:
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
-    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after PSP fees are taken. If your PSP is Stripe, we recommend a test payment of at least £2.
+    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after your PSP has taken their fees. If your PSP is Stripe, we recommend a test payment of at least £2.
 
 ### Make a payment using a payment link
 
@@ -119,7 +119,7 @@ You make a real payment using either:
 
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
-    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after PSP fees are taken. If your PSP is Stripe, we recommend a test payment of at least £2.
+    If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/integrate_with_govuk_pay/#receiving-payments) after your PSP has taken their fees. If your PSP is Stripe, we recommend a test payment of at least £2.
 
 ### Check that the payment was successful
 


### PR DESCRIPTION
### Context
We occasionally get service desk enquiries where a service admin has made a £1 test payment and, after transaction fees are taken, they are unable to get this test payment back as they are short of the £1 minimum payout threshold.

### Changes proposed in this pull request
This PR updates the Go Live documentation to recommend that test payments are at least £2 to ensure that they can make a payout to test their integration. This is in line with our advice during the PSP switching process.
