### PR TITLE
PP-9155 update verify your PSP docs - take a test payment

### DIFF
--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -117,7 +117,7 @@ The live payment is £2.00 and is refundable. Your new Stripe account will be de
 
 1. Select **Make a live payment to test your Stripe PSP** - you will need a debit or credit card for this step.
 
-1. Select **Continue to live payment**.
+1. Select **Continue to live payment**. If **Continue to live payment** is not visible, Stripe is still verifying your details. Try this step again later.
 
 1. Enter your card details.
 


### PR DESCRIPTION
### Context
- Service cannot take a test payment until Stripe has confirmed their details. Next step button is not visible if the process is still ongoing.
