### PR TITLE
ZD-4941485 Remove Diners Club card number from mock card numbers

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -74,7 +74,6 @@ Mock card numbers do not work with your live account.
 |Successful payment |371449635398431| American Express | Credit |
 |Successful payment |3566002020360505| JCB | Credit |
 |Successful payment |6011000990139424| Discover | Credit |
-|Successful payment |36148900647913| Diners Club | Credit |
 |Card type not accepted |6759649826438453|Maestro| Debit |
 |Card declined|4000000000000002|Visa| Credit or debit |
 |Card expired|4000000000000069|Visa| Credit or debit |


### PR DESCRIPTION
The latest BIN ranges we have from Worldpay map Diners Club card numbers to `DINERS DISCOVER` (Discover acquired Diners Club in 2008), which we treat as being Discover.

Therefore, if a service is configured to accept Diners Club cards but not Discover cards, the mock Diners Club card number of 36148900647913 will not actually work, which causes confusion.

Remove 36148900647913 from the mock card numbers. (There is already another Discover card number.)