### PR TITLE
BAU — MOTO: Replace curly quotation marks with straight ones

### DIFF
--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -188,7 +188,7 @@ Follow these steps to create and complete the MOTO payment using the GOV.UK Pay 
 
 1. If your PSP is Worldpay, go to **Services** in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) to make sure you're using an API key from your MOTO service.
 
-2. [Create a payment](/making_payments/#creating-a-payment) with the GOV.UK Pay API, and include `“moto”: true` in the request body.
+2. [Create a payment](/making_payments/#creating-a-payment) with the GOV.UK Pay API, and include `"moto": true` in the request body.
 
 3. Go to the [`next_url`](/making_payments/#receiving-the-api-response) included in the body of the response to your API call.
 


### PR DESCRIPTION
Make it `"moto": true` rather than `“moto”: true`.