### PR TITLE
BAU: change paas deployment to zero downtime

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -78,8 +78,8 @@ jobs:
                 bundle exec middleman build
       - put: paas
         params:
-          command: push
-          app_name: govuk-pay-tech-docs
+          command: zero-downtime-push
+          current_app_name: govuk-pay-tech-docs
           path: pay-tech-docs/build
           manifest: pay-tech-docs/manifest.yml
   - name: build-pr


### PR DESCRIPTION
### Context
Currently when the tech-docs are deployed there is a short window of downtime as the app is deleted and the replacement brought up in place.

### Changes proposed in this pull request
Change to a zero downtime deployment