### PR TITLE
PP9897 - Minor docs changes for July 2022

### DIFF
--- a/source/api_reference/cancel_payment_reference/index.html.md.erb
+++ b/source/api_reference/cancel_payment_reference/index.html.md.erb
@@ -41,6 +41,6 @@ curl -X POST "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact52
 
 ## Example response for ‘Cancel a payment’
 
-A successful payment cancellation returns a 204 HTTP status code without a response body.
+A successful payment cancellation returns a `204` HTTP status code without a response body.
 
 You can [read more about HTTP status codes and their meaning in the GOV.UK Pay API](/api_reference/#responses).

--- a/source/api_reference/create_a_payment_reference/index.html.md.erb
+++ b/source/api_reference/create_a_payment_reference/index.html.md.erb
@@ -47,6 +47,8 @@ The data from this endpoint is ‘strongly consistent’, meaning it is updated 
 
 ## Example request for 'Create a payment'
 
+This example request creates a £145 council tax payment with a reference of `12345`. It also prefills some payment fields and uses metadata to add an internal ledger code and reference number:
+
 ```json
 curl "https://publicapi.payments.service.gov.uk/v1/payments" \
 -H 'Authorization: Bearer api_test_123abc456def' \
@@ -59,7 +61,7 @@ curl "https://publicapi.payments.service.gov.uk/v1/payments" \
           "delayed_capture": false,
           "metadata": {
                 "ledger_code": "AB100",
-                "an_internal_reference_number": 200
+                "internal_reference_number": 200
           },
           "email": "sherlock.holmes@example.com",
           "prefilled_cardholder_details": {

--- a/source/api_reference/single_payment_reference/index.html.md.erb
+++ b/source/api_reference/single_payment_reference/index.html.md.erb
@@ -57,7 +57,7 @@ After you send your request to get information about a payment, you’ll receive
   "language": "en",
   "metadata": {
     "ledger_code": "AB100",
-    "an_internal_reference_number": 200
+    "internal_reference_number": 200
   },
   "email": "sherlock.holmes@example.com",
   "card_details": {

--- a/source/api_reference/single_payment_reference/index.html.md.erb
+++ b/source/api_reference/single_payment_reference/index.html.md.erb
@@ -37,7 +37,7 @@ The data from this endpoint is strongly consistent, meaning it is updated immedi
 This example request gets information about the payment with payment ID `hu20sqlact5260q2nanm0q8u93`:
 
 ```
-curl "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93/" -H "Authorization: Bearer api_test_123abc456def"
+curl GET "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93/" -H "Authorization: Bearer api_test_123abc456def"
 ```
 
 ## Example response for ‘Get information about a single payment’

--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -18,7 +18,7 @@ You can set a different surcharge for each of the following 3 corporate card typ
 
 * non-prepaid credit cards
 * non-prepaid debit cards
-* prepaid debit and credit cards
+* prepaid debit cards
 
 In a payment journey, when your user enters a card number the GOV.UK Pay platform checks to determine if it’s one of the 3 corporate card types. If a surcharge is applicable, the platform will inform them that a surcharge of a certain amount will be added to the total.
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -43,9 +43,8 @@ To set up custom branding, do the following.
 To customise your banner logo, email us an image of your banner logo. Your image should be:
 
 * in PNG or SVG format
-* 300 pixels or less in height
-* 120 pixels or less in width
-* at least double the size of the image as displayed on-screen
+* at least 600 pixels in width
+* at least 240 pixels in height
 * cropped to leave minimal whitespace around the logo
 * compressed (optimised for web)
 

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -175,7 +175,7 @@ You have now switched PSP to Worldpay but you must enable 3DS Flex to begin taki
 
 Users making payments as you switch are unaffected. Your old PSP will process their payments.
 
-## Enable 3DS2 (3DS Flex)
+## Enable 3DS2 (3DS Flex) before taking payments
 
 3DS Flex is a Worldpay product that enables 3DS2 payment authentication. You must turn on 3DS Flex to take payments using GOV.UK Pay.
 

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -171,9 +171,27 @@ Once you’ve successfully linked your Worldpay account with GOV.UK Pay and made
 
 To switch, select **Switch to Worldpay** on the **Switch payment service provider (PSP)** page. A **Success** banner confirms the switch.
 
-You have now switched PSP to Worldpay. Worldpay will process any new payments.
+You have now switched PSP to Worldpay but you must enable 3DS Flex to begin taking payments.
 
 Users making payments as you switch are unaffected. Your old PSP will process their payments.
+
+## Enable 3DS2 (3DS Flex)
+
+3DS Flex is a Worldpay product that enables 3DS2 payment authentication. You must turn on 3DS Flex to take payments using GOV.UK Pay.
+
+Once you've connected your Worldpay account to GOV.UK Pay, Worldpay will send you your 3DS Flex credentials. You can also find your 3DS credentials in [Worldpay’s Merchant Admin Interface](https://secure.worldpay.com/sso/public/auth/login.html?serviceIdentifier=merchantadmin) by selecting **INTEGRATION** and then **3DS Flex**.
+
+1. In [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/), select the account you want to set up on the **Overview** page.
+
+1. In **Settings**, make sure **3D Secure** is set to **On**.
+
+1. In **Your PSP**, enter your 3DS Flex credentials.
+
+1. Select **Save credentials**.
+
+1. Select **Turn on 3DS Flex**.
+
+Worldpay will now process any new payments.
 
 ## Refund payments after switching to Worldpay
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -42,18 +42,12 @@ You can still use your test account.
 
 ## 2. Connect your live account to your PSP
 
-Once you have a GOV.UK Pay live account, you can connect that account to your payment service provider (PSP).
+Once you have a GOV.UK Pay live account, you must connect that account to your payment service provider (PSP).
 
-You can connect your live account to:
+Use our guidance to:
 
-* Stripe, GOV.UK Pay's current PSP
-* Worldpay using a contract through Government Banking
-
-GOV.UK Pay has created guidance to:
-
-* [connect your live account to Stripe](/switching_to_live/set_up_a_live_stripe_account/)
-* [connect your live account to Worldpay](/switching_to_live/set_up_a_live_worldpay_account/)
-
+* [connect your live account to Stripe](/switching_to_live/set_up_a_live_stripe_account/), GOV.UK Pay's current PSP
+* [connect your live account to Worldpay](/switching_to_live/set_up_a_live_worldpay_account/) using a contract through Government Banking]
 
 If either GOV.UK Pay's or Government Banking's PSP changes, we'll work with you to move you to the new PSP.
 


### PR DESCRIPTION
### Context
Minor documentation fixes are bundled together into a single PR.

### Changes proposed in this pull request
This PR:

- Makes it clearer how users need to get to PSP-specific guidance in the Go live docs
- Improves the custom branding banner logo instructions
- Changes ‘prepaid credit and debit cards’ to ‘prepaid debit cards’
- Adds a step to Switch to Worldpay guidance to enable 3DS Flex after switching
- Adds `GET` to the example request in the Get single payment API reference page
- Add an introductory sentence before the example request in the Create a payment API reference page
- Add backticks to `204` HTTP code in the response section of the Cancel a payment API reference page