### PR TITLE
PP9297 - Improves linking to the API reference

### DIFF
--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -30,7 +30,7 @@ Your service must send the delayed capture request within 120 hours (5 days) of 
 If you've enabled sending payment confirmation emails, GOV.UK Pay will send a
 payment confirmation email to your user once we've received and processed your service’s capture request.
 
-You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/capture_payment_reference). You can also view [possible responses to your capture request](http://localhost:4567/api_reference/#responses).
+You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/capture_payment_reference). You can also view [possible responses to your capture request](/api_reference/#responses).
 
 ## See the capture URL for a payment
 

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -25,22 +25,12 @@ __Confirm__ on the __Confirm your details__ page:
 `POST /v1/payments/{PAYMENT_ID}/capture` endpoint to send a delayed capture
 request
 
-There are 7 possible responses:
-
-|Status code | Meaning |
-|:---|:---|
-|204| Your capture request succeeded. |
-|400| The server cannot process the request due to a client error, for example missing details in the request or a failed payment cancellation. |
-|401|	Required authentication has failed or has not been provided. |
-|404| No payment matched the `paymentId` you provided. |
-|409| You cannot capture the payment because its `status` is not `capturable`. |
-|429|	Too many requests. Request rate is above the rate limit. |
-|500| Something is wrong with GOV.UK Pay. Please [contact us](/support_contact_and_more_information/). |
-
 Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
 
 If you've enabled sending payment confirmation emails, GOV.UK Pay will send a
 payment confirmation email to your user once we've received and processed your service’s capture request.
+
+You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/capture_payment_reference). You can also view [possible responses to your capture request](http://localhost:4567/api_reference/#responses).
 
 ## See the capture URL for a payment
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -56,6 +56,8 @@ For example:
 
 ### API call parameters
 
+You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/create_a_payment_reference).
+
 #### amount
 
 `amount` is the amount in pence. In the example, the payment is for £145.

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -36,7 +36,7 @@ You can refer to the [GOV.UK Service Manual](https://www.gov.uk/service-manual/t
 
 You can generate a client library from [our OpenAPI file](https://github.com/alphagov/pay-publicapi/blob/master/openapi/publicapi_spec.json) using [Swagger Editor](http://editor.swagger.io/). This may be an easier way for you to integrate your service with GOV.UK Pay than writing a client library from scratch.
 
-See the [documentation on integrating with the API](/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api) for more information.
+Read our [documentation on integrating with the API](/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api) for more information. Read our [API reference](/api_reference) for an index of everything the GOV.UK API can do.
 
 ### Set up a payment link
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -71,6 +71,8 @@ Example refund request:
 }
 ```
 
+You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/refund_payment_reference).
+
 ### amount
 
 `amount` is how much to refund your user in pence. You can refund all or part of the payment.
@@ -132,6 +134,8 @@ Example response:
   }
 }
 ```
+
+You can see definitions and possible values of every attribute for this endpoint in our [API reference](/api_reference/refund_status_reference).
 
 ### settlement_summary
 
@@ -225,6 +229,8 @@ Example response:
 }
 ```
 
+You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/payment_refunds_reference).
+
 ## Searching refunds
 
 `GET /v1/refunds?{QUERY_PARAMETERS}`
@@ -279,6 +285,8 @@ Example search response:
 ```
 
 The `_links` object includes a `payment` URL and method that you can use to get information about the payment the refund is for.
+
+You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/search_refunds_reference).
 
 ### Filtering by date
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -128,6 +128,8 @@ Your user can continue their journey through your service if, in the `state` obj
 
 ### API response parameters
 
+You can see definitions and possible values of every attribute for this endpoint in our [API reference](/api_reference/single_payment_reference).
+
 #### \_links
 
 The `_links` object includes `href` and `method` fields that you can use to make API requests related to the payment. Use:
@@ -331,6 +333,8 @@ For example:
   ],
 }
 ```
+
+You can see definitions and possible values of every attribute for this endpoint in our [API reference](/api_reference/payment_event_reference).
 
 ### Get notified of payment state changes
 


### PR DESCRIPTION
### Context
The API reference lives in a bit of a bubble at the moment. Users can find it from the side navigation but it isn't linked to from many places.

### Changes proposed in this pull request
Where it makes sense, this PR adds links to the API reference.