### PR TITLE
PP-10033: Creates a new page weighting system

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Setting up multiple services
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 145
+weight: 6300
 ---
 
 # Setting up multiple services

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Set up which bank accounts your payments go to
 last_reviewed_on: 2022-08-18
 review_in: 6 months
-weight: 141
+weight: 6310
 ---
 
 # Set up which bank accounts your payments go to

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Set up how your services link to GOV.UK Pay services
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 142
+weight: 6320
 ---
 
 # Set up how your services link to GOV.UK Pay services

--- a/source/api_reference/cancel_agreement_reference/index.html.md.erb
+++ b/source/api_reference/cancel_agreement_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Cancel an agreement for recurring payments API reference
 last_reviewed_on: 2022-08-20
 review_in: 6 months
-weight: 45
+weight: 14330
 ---
 
 # Cancel an agreement for recurring payments API reference

--- a/source/api_reference/cancel_payment_reference/index.html.md.erb
+++ b/source/api_reference/cancel_payment_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Cancel a payment API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 34
+weight: 14140
 ---
 
 # Cancel a payment API reference

--- a/source/api_reference/capture_payment_reference/index.html.md.erb
+++ b/source/api_reference/capture_payment_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Take ('capture') a delayed payment API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 37
+weight: 14150
 ---
 
 # Take (‘capture’) a delayed payment API reference

--- a/source/api_reference/create_a_payment_reference/index.html.md.erb
+++ b/source/api_reference/create_a_payment_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Create a payment API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 10
+weight: 14110
 ---
 
 # Create a payment API reference

--- a/source/api_reference/create_an_agreement_reference/index.html.md.erb
+++ b/source/api_reference/create_an_agreement_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Create an agreement for recurring payments API reference
 last_reviewed_on: 2022-08-20
 review_in: 6 months
-weight: 42
+weight: 14310
 ---
 
 # Create an agreement for recurring payments API reference

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 180
+weight: 1400
 ---
 
 # API reference

--- a/source/api_reference/payment_event_reference/index.html.md.erb
+++ b/source/api_reference/payment_event_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Get a payment's events API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 30
+weight: 14130
 ---
 
 # Get a payment’s events API reference

--- a/source/api_reference/payment_refunds_reference/index.html.md.erb
+++ b/source/api_reference/payment_refunds_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Get information about a payment's refunds API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 70
+weight: 14230
 ---
 
 # Get information about a payment’s refunds API reference

--- a/source/api_reference/refund_payment_reference/index.html.md.erb
+++ b/source/api_reference/refund_payment_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Refund a payment API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 50
+weight: 14210
 ---
 
 # Refund a payment API reference

--- a/source/api_reference/refund_status_reference/index.html.md.erb
+++ b/source/api_reference/refund_status_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Check the status of a refund API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 60
+weight: 14220
 ---
 
 # Check the status of a refund API reference

--- a/source/api_reference/search_agreements_reference/index.html.md.erb
+++ b/source/api_reference/search_agreements_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Search agreements for recurring payments
 last_reviewed_on: 2022-08-20
 review_in: 6 months
-weight: 44
+weight: 14340
 ---
 
 # Search agreements for recurring payments

--- a/source/api_reference/search_disputes_reference/index.html.md.erb
+++ b/source/api_reference/search_disputes_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Search disputes API reference
 last_reviewed_on: 2022-07-22
 review_in: 6 months
-weight: 100
+weight: 14410
 ---
 
 # Search disputes API reference

--- a/source/api_reference/search_payments_reference/index.html.md.erb
+++ b/source/api_reference/search_payments_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Search payments API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 40
+weight: 14160
 ---
 
 # Search payments API reference

--- a/source/api_reference/search_refunds_reference/index.html.md.erb
+++ b/source/api_reference/search_refunds_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Search refunds API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 80
+weight: 14240
 ---
 
 # Search refunds API reference

--- a/source/api_reference/send_card_details_moto_reference/index.html.md.erb
+++ b/source/api_reference/send_card_details_moto_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Send card details to authorise a MOTO payment API reference
 last_reviewed_on: 2022-06-01
 review_in: 6 months
-weight: 38
+weight: 14510
 ---
 
 # Send card details to authorise a MOTO payment API reference

--- a/source/api_reference/single_agreement_reference/index.html.md.erb
+++ b/source/api_reference/single_agreement_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Get information about a single agreement for recurring payments API reference
 last_reviewed_on: 2022-08-20
 review_in: 6 months
-weight: 43
+weight: 14320
 ---
 
 # Get information about a single agreement for recurring payments API reference

--- a/source/api_reference/single_payment_reference/index.html.md.erb
+++ b/source/api_reference/single_payment_reference/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Get information about a single payment API reference
 last_reviewed_on: 2022-05-10
 review_in: 6 months
-weight: 20
+weight: 14120
 ---
 
 # Get information about a single payment API reference

--- a/source/block_prepaid_cards/index.html.md.erb
+++ b/source/block_prepaid_cards/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Block prepaid cards
 last_reviewed_on: 2022-08-16
 review_in: 6 months
-weight: 130
+weight: 5500
 ---
 
 # Block prepaid cards

--- a/source/contribute/index.html.md.erb
+++ b/source/contribute/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Contribute
 last_reviewed_on: 2022-06-10
 review_in: 6 months
-weight: 210
+weight: 9300
 ---
 
 # Contribute

--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Add corporate card fees
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 120
+weight: 5400
 ---
 
 # Add corporate card fees

--- a/source/custom_metadata/index.html.md.erb
+++ b/source/custom_metadata/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Add custom metadata
-weight: 90
+weight: 5100
 last_reviewed_on: 2022-06-10
 review_in: 6 months
 ---

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Delay taking a payment
 last_reviewed_on: 2022-05-06
 review_in: 6 months
-weight: 80
+weight: 2500
 ---
 
 # Delay taking a payment

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Take a digital wallet payment
 last_reviewed_on: 2022-06-10
 review_in: 6 months
-weight: 51
+weight: 2300
 ---
 
 # Take a digital wallet payment

--- a/source/disputes/index.html.md.erb
+++ b/source/disputes/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Report on a dispute
 last_reviewed_on: 2022-07-22
 review_in: 6 months
-weight: 62
+weight: 3200
 ---
 
 # Report on a dispute

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GOV.UK Pay technical documentation
-weight: 10
+weight: 1100
 last_reviewed_on: 2022-06-10
 review_in: 6 months
 ---

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Integrate with the GOV.UK Pay API
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 140
+weight: 6100
 ---
 
 # Integrate with the GOV.UK Pay API

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Take a payment
 last_reviewed_on: 2022-08-18
 review_in: 3 months
-weight: 50
+weight: 2100
 ---
 
 # Take a payment

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Take a payment over the phone ('MOTO' payments)
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 52
+weight: 2400
 ---
 
 # Take a payment over the phone (‘MOTO’ payments)

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Add custom branding
 last_reviewed_on: 2022-06-10
 review_in: 4 months
-weight: 101
+weight: 5210
 ---
 
 # Add custom branding

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Customise your payment pages
-weight: 100
+weight: 5200
 ---
 
 # Customise your payment pages

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Prefill payment fields
 last_reviewed_on: 2022-05-06
 review_in: 6 months
-weight: 104
+weight: 5240
 ---
 
 # Prefill payment fields

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Use your own payment failure pages
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 103
+weight: 5230
 ---
 
 # Use your own payment failure pages

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Use Welsh on your payment pages
 last_reviewed_on: 2022-08-16
 review_in: 6 months
-weight: 102
+weight: 5220
 ---
 
 # Use Welsh on your payment pages

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -2,7 +2,7 @@
 title: How GOV.UK Pay works
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 30
+weight: 1300
 ---
 
 # How GOV.UK Pay works

--- a/source/prefill_payment_links/index.html.md.erb
+++ b/source/prefill_payment_links/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Prefill payment reference and amount when using a payment link
 last_reviewed_on: 2022-07-21
 review_in: 6 months
-weight: 104
+weight: 5300
 ---
 
 # Prefill payment reference and amount when using a payment link

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Quick start
 last_reviewed_on: 2022-06-10
 review_in: 6 months
-weight: 20
+weight: 1200
 ---
 
 # Quick start

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Take recurring payments
 last_reviewed_on: 2022-08-20
 review_in: 1 months
-weight: 51
+weight: 2200
 ---
 
 # Take recurring payments

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Refund a payment
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 70
+weight: 4100
 ---
 
 # Refund a payment

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Report on a payment
 last_reviewed_on: 2022-09-07
 review_in: 6 months
-weight: 59
+weight: 3100
 ---
 
 # Report on a payment

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Security
 last_reviewed_on: 2022-06-10
 review_in: 6 months
-weight: 200
+weight: 9200
 ---
 
 # Security

--- a/source/send_card_details_api/index.html.md.erb
+++ b/source/send_card_details_api/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Take MOTO payments by sending card details through the API
 last_reviewed_on: 2022-06-01
 review_in: 6 months
-weight: 52
+weight: 2430
 ---
 
 # Take MOTO payments by sending card details through the API

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Support
 last_reviewed_on: 2022-08-18
 review_in: 3 months
-weight: 220
+weight: 9400
 ---
 
 # Support

--- a/source/switch_payment_service_provider/index.html.md.erb
+++ b/source/switch_payment_service_provider/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Switch payment service provider (PSP)
 last_reviewed_on: 2022-08-18
 review_in: 6 months
-weight: 165
+weight: 7200
 ---
 
 #Switch payment service provider (PSP)

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Switch payment service provider to Stripe
 last_reviewed_on: 2022-08-16
 review_in: 6 months
-weight: 167
+weight: 7210
 ---
 
 # Switch payment service provider to Stripe

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Switch payment service provider to Worldpay
 last_reviewed_on: 2022-08-16
 review_in: 6 months
-weight: 166
+weight: 7220
 ---
 
 # Switch payment service provider to Worldpay

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Go live
 last_reviewed_on: 2022-08-18
 review_in: 6 months
-weight: 160
+weight: 7100
 ---
 
 # Go live

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Connect your live account to Stripe
 last_reviewed_on: 2022-05-06
 review_in: 6 months
-weight: 161
+weight: 7110
 ---
 
 # Connect your live account to Stripe

--- a/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_worldpay_account/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Connect your live account to Worldpay
 last_reviewed_on: 2022-05-06
 review_in: 6 months
-weight: 162
+weight: 7120
 ---
 
 # Connect your live account to Worldpay

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Test your integration
 last_reviewed_on: 2022-06-10
 review_in: 6 months
-weight: 150
+weight: 6200
 ---
 
 # Test your integration

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Stay up to date
 last_reviewed_on: 2022-06-10
 review_in: 6 months
-weight: 190
+weight: 9100
 ---
 
 # Stay up to date

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Receive automatic payment event updates using webhooks
 last_reviewed_on: 2022-08-20
 review_in: 1 months
-weight: 65
+weight: 3300
 ---
 
 # Receive automatic payment event updates using webhooks


### PR DESCRIPTION
### Context
The documentation has grown and the page weighting system is now a bit of a mess. When we need to add a new page, we end up having to shuffle the `weight` of a load of other pages as well.

### Changes proposed in this pull request
This PR changes the `weight` of every page in the documentation to be more logical and add more space between pages in case new pages are introduced. In the new system:

**Page type** - **`weight`**

- CATEGORY: Introductions - `1XXX`
  - [GOV.UK](http://gov.uk/) Pay technical documentation - `1100`
  - Quick start - `1200`
  - How[ GOV.UK](http://gov.uk/) Pay works - 1300
  - API reference - `1400`
    - CATEGORY: Payment endpoints - `141XX`
      - Create a payment - `14110`
      - Get info on 1 payment - `14120`
      - Get payment events - `14130`
      - Cancel payment - `14140`
      - Capture payment - `14150`
      - Search payments - `14160`
    - CATEGORY: Refund endpoints - `142XX`
      - Refund a payment - `14210`
      - Get status of refund - `14220`
      - Get info on refund - `14230`
      - Search refunds - `14240`
    - CATEGORY: Agreement endpoints - `143XX`
      - Create agreement - `14310`
      - Get information about 1 agreement - `14320`
      - Cancel an agreement - `14330`
      - Search agreements - `14340`
  - CATEGORY: Dispute endpoints - `144XX`
      - Search disputes - `14410`
  - CATEGORY: Authorising payments - `145XX`
      - Authorise payments - `14510`
- CATEGORY: Taking payments - `2XXX`
  - Take a payment - `2100`
  - Take recurring payments - `2200`
  - Take a digital wallet payment - `2300`
  - MOTO payments - `2400`
  - Through the admin tool - `2410`
  - Through the API - `2420`
  - Send card details through API - `2430`
  - Delay taking a payment - `2500`
- CATEGORY: Reporting - `3XXX`
  - Report on a payment - `3100`
  - Report on a dispute - `3200`
  - Receive auto updates with webhooks - `3300`
- CATEGORY: Refunding - `4XXX`
  - Refund a payment - `4100`
- CATEGORY: Misc payment features - `5XXX`
  - Add custom metadata - `5100`
  - Customise your payment pages - `5200`
    - Add custom branding - `5210`
    - Use Welsh - `5220`
    - Use your own payment failure pages - `5230`
    - Prefill fields  - `5240`
  - Prefill payment ref + amount - `5300`
  - Add corporate card fees - `5400`
  - Block prepaid cards - `5500`
- CATEGORY: Configuring [GOV.UK](http://gov.uk/) Pay pages - `6XXX`
  - Integrate with the[ GOV.UK](http://gov.uk/) Pay API - `6100`
  - Test your integration - `6200`
  - Setting up multiple services - `6300`
  - Which bank accounts your payments go to - `6310`
  - How services link to [GOV.UK](http://gov.uk/) Pay service - `6320`
- CATEGORY: PSP stuff - `7XXX`
  - Go live - `7100`
    - Connect your live account to Stripe - `7110`
    - Connect to Worldpay - `7120`
  - Switch PSP - `7200`
    - Switch to Stripe - `7210`
    - Switch to Worldpay - `7220`
- CATEGORY: Meta topics - `9XXX`
  - Stay up to date - `9100`
  - Security - `9200`
  - Contribute - `9300`
  - Support - `9400`

This PR will not change the current order of the pages (other than one or two pages). It is just a new system of determining page `weight`.

Note: The API reference `weight` values are a bit wonky but this isn't a problem when the site builds.