### PR TITLE
PP-10200: Redirects the old auth API page to new MOTO section

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -42,6 +42,7 @@ after_build do |builder|
 end
 
 redirect "payment_flow_overview/index.html", to: "payment_flow/index.html"
+redirect "send_card_details_api/index.html", to: "moto_payments/moto_send_card_details_api/index.html"
 
 # Expose external assets (common analytics files) to to sprockets loader
 sprockets.append_path File.join root, "node_modules"


### PR DESCRIPTION
### Context
When we restructured the MOTO payment documentation ([PP-9135](https://payments-platform.atlassian.net/browse/PP-9136)), we changed the location of the primary authorisation API docs. Some users still accessed those docs through a direct link, so this link is now 404ing.

### Changes proposed in this pull request
This PR redirects users that use the old URL (/send_card_details_api) to the new URL (/moto_payments/moto_send_card_details_api).
