### PR TITLE
PP-10116: Update detect-secrets to 1.4.0, add GHA workflow

### DIFF
--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,0 +1,13 @@
+name: Detect secrets
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  rev: v1.4.0
   hooks:
     - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+      args: [ '--baseline', '.secrets.baseline' ]
+      exclude: ^package-lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.1.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +47,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -56,10 +74,6 @@
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -91,34 +105,18 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "package-lock.json"
-      ]
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
-        "is_verified": false,
-        "line_number": 3
-      }
-    ],
     "config/tech-docs.yml": [
       {
         "type": "Base64 High Entropy String",
         "filename": "config/tech-docs.yml",
         "hashed_secret": "f9ba52490176c0bc5626c80f332a8c2157b22867",
         "is_verified": false,
-        "line_number": 32,
-        "is_secret": false
+        "line_number": 32
       }
     ]
   },
-  "generated_at": "2021-08-13T15:23:37Z"
+  "generated_at": "2022-11-08T18:01:50Z"
 }


### PR DESCRIPTION
See https://github.com/alphagov/pay-webhooks/pull/510 for details.

This repository didn't have any Github Actions workflows set up - given this is a public repository I think it's worth adding a detect-secrets workflow here. I've enabled this and added the `actions/checkout` to the approved actions list in the repo settings.