### PR TITLE
PP-10595: Adds mock card number for recurring payments

### DIFF
--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -235,7 +235,7 @@ You can [read more about using webhooks to automatically receive updates](/webho
 
 ### Test your recurring payments integration
 
-GOV.UK Pay have [mock card numbers for you to test your integration](/testing_govuk_pay/#mock-card-numbers). This includes a [mock card for testing recurring payments](/testing_govuk_pay/#testing-recurring-payments) that you can use to set up an agreement but will fail further recurring payment attempts.
+GOV.UK Pay have [mock card numbers for you to test your integration](/testing_govuk_pay/#mock-card-numbers), including a [mock card number for testing recurring payments](/testing_govuk_pay/#testing-recurring-payments). You can use this mock card number to set up an agreement with an initial payment, but further recurring payments will be declined.
 
 ## Reporting on recurring payments
 

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -233,6 +233,10 @@ You may want to use these webhooks to trigger a notification in your case manage
 
 You can [read more about using webhooks to automatically receive updates](/webhooks).
 
+### Test your recurring payments integration
+
+GOV.UK Pay have [mock card numbers for you to test your integration](/testing_govuk_pay/#mock-card-numbers). This includes a [mock card for testing recurring payments](/testing_govuk_pay/#testing-recurring-payments) that you can use to set up an agreement but will fail further recurring payment attempts.
+
 ## Reporting on recurring payments
 
 You can find information about agreements you’ve created in the GOV.UK Pay admin tool or through our API.

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -80,6 +80,16 @@ Mock card numbers do not work with your live account.
 |Invalid CVC code|4000000000000127|Visa| Credit or debit |
 |General error|4000000000000119|Visa| Credit or debit |
 
+##### Testing recurring payments
+
+You can use mock card numbers to test [recurring payments](/recurring_payments).
+
+To test unsuccessful recurring payments, you need to use this mock card number. This card can take one payment to set up the recurring payment agreement. Further attempts to make recurring payments with this card will fail.
+
+|Testing action |Card number | Card brand | Card type |
+| -------- | ------- | ------- | ------- |
+|Declined recurring payment | 5105105105105100 | Mastercard | Debit |
+
 #### If you're using a test Stripe account
 
 The [PSP transaction fee](/reporting/#psp-fees) depends on which country the test card is from.

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -84,7 +84,7 @@ Mock card numbers do not work with your live account.
 
 You can use mock card numbers to test [recurring payments](/recurring_payments).
 
-To test unsuccessful recurring payments, you need to use this mock card number. This card can take one payment to set up the recurring payment agreement. Further attempts to make recurring payments with this card will fail.
+To test unsuccessful recurring payments, you need to use this mock card number. This mock card can take one initial payment to set up the recurring payment agreement. Further attempts to make recurring payments with this mock card number will fail.
 
 |Testing action |Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |


### PR DESCRIPTION
### Context
To test recurring payments, users can use existing mock card numbers. These existing card numbers can only provide successful OR declined payments. To test every situation for recurring payments, services need a mock card number that can be successful once (to set up the agreement), then fail subsequent attempts.

### Changes proposed in this pull request
This PR:

- adds recurring payments mock card under a new heading
- adds a link to the new mock card from the main recurring payments docs page
