### PR TITLE
PP-10817: Updates error description and example

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -184,8 +184,8 @@ For example:
 ```json
 {
   "field": "amount",
-  "code": "P0102",
-  "description": "Invalid attribute value: amount. Must be less than or equal to 10000000"
+  "code": "P0101",
+  "description": "Missing mandatory attribute: amount."
 }
 ```
 
@@ -196,7 +196,7 @@ These error descriptions are intended for developers, not your users.
 | Error code | Endpoint(s) | Meaning |
 |--------------|------------|---------|
 | P0101 | Create a payment<br><br>Send card details to authorise a MOTO payment | The request you sent is missing a required parameter.<br><br>Check the `field` attribute in the response to see which parameter is missing. |
-| P0102 | Create a payment<br><br>Send card details to authorise a MOTO payment | The value of a parameter you sent is invalid.<br><br>Check the `description` attribute in the response to find out which value is invalid. |
+| P0102 | Create a payment<br><br>Send card details to authorise a MOTO payment | A header or parameter value you sent in your request is invalid.<br><br>Check the `description` attribute in the response to find out which value is invalid. |
 | P0104 | Create a payment | You included `return_url` and `"authorisation_mode": "moto_api"` in your request. These parameters cannot be used together.<br><br>Remove the `return_url` parameter to create [a Mail Order / Telephone Order (MOTO) payment that accepts card details sent through the API](/moto_payments/moto_send_card_details_api).<br><br>Remove the `authorisation_mode` parameter to [create a standard payment](/making_payments). |
 | P0191 | Create a payment | The `Idempotency-Key` you sent in the request header has already been used to create a payment. |
 | P0195 | Create a payment | You tried to create a Mail Order / Telephone Order (MOTO) payment that accepts card details sent through the API but this feature is not enabled on your service.<br><br>You can [read more about setting up your service to accept card details sent through the API](/moto_payments/moto_send_card_details_api).<br><br>To create a standard payment, remove `"authorisation_mode": "moto_api"` from your request. |


### PR DESCRIPTION
### Context
Error `P0192` can trigger for header values, not just body parameter values.

### Changes proposed in this pull request
This PR:

* updates the `P0102` error to be more generic
* changes the error example on the API reference page to `P0101` because it doesn't change between `field` and `header`