### PR TITLE
BAU: Use npm ci instead of install, and make pr-build the same as build-and-deploy

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,9 +81,10 @@ jobs:
                 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
                 source "$NVM_DIR/nvm.sh"
 
+                set -x
                 gem install bundler
                 bundle install --deployment
-                npm install --only=production
+                npm ci --omit=dev
                 bundle exec middleman build
       - put: paas
         params:
@@ -129,8 +130,10 @@ jobs:
                 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
                 source "$NVM_DIR/nvm.sh"
 
+                set -x
                 gem install bundler
                 bundle install --deployment
+                npm ci --omit=dev
                 bundle exec middleman build
         on_failure:
           put: pull-request


### PR DESCRIPTION
### Context
build-and-deploy fails, build-pr does not fail.

Lets make them identical, and make it easier to diagnose the failed step by enabling -x in bash (to echo the command before running it)

### Changes proposed in this pull request
1. Use npm ci instead of install
2. Use npm --omit=dev instead of --only=production (a warning tells you do to this when it runs --only=production)
3. Make build-pr perform the same steps as build-and-deploy for their build step.