### PR TITLE
PP-11086 - Removes beta warning text

### DIFF
--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -7,9 +7,7 @@ weight: 2200
 
 # Take recurring payments
 
-GOV.UK Pay is still developing recurring payments so this feature is only available to a limited number of services at the moment. [Contact us](/support_contact_and_more_information/#during-office-hours) if you’re interested in taking recurring payments.
-
-If you are a beta service, you can take recurring payments from a user using GOV.UK Pay. The user consents to making recurring payments, enters into an ‘agreement’ with your service, and provides their payment details. The agreement allows you to take further payments through our API without the user interacting with your service again.
+You can take recurring payments from a user using GOV.UK Pay. The user consents to making recurring payments, enters into an ‘agreement’ with your service, and provides their payment details. The agreement allows you to take further payments through our API without the user interacting with your service again.
 
 Your service has [additional responsibilities when taking recurring payments](/recurring_payments/#1-understand-what-your-service-is-responsible-for). You’re responsible for:
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -9,8 +9,6 @@ weight: 3300
 
 This section tells you how to use webhooks to automatically receive updates after payment events.
 
-GOV.UK Pay is still developing webhooks so this feature is only available to a limited number of services at the moment. [Contact us](/support_contact_and_more_information/#during-office-hours) if you’re interested in using webhooks to receive payment event updates.
-
 A webhook is when GOV.UK Pay sends automatic `POST` requests to your service after payment events. A payment event is when a payment reaches a milestone in its journey and its `state` updates, such as when it’s created, paid, or refunded.
 
 You can receive updates when:


### PR DESCRIPTION
### Context
We are releasing webhooks and recurring payments to all Pay services. The docs for these features currently have warning text about them being in development

### Changes proposed in this pull request
- Removes the beta warning text from the webhooks documentation
- Removes the beta warning text from the recurring payments documentation
