### PR TITLE
PP-11095/PP-11096: Adds information about updating cards

### DIFF
--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -176,6 +176,14 @@ If the user’s payment fails, their payment details are not saved and the agree
 
 Read more about creating payments in [our guidance for taking payments](/making_payments) or our [API reference page for creating payments](/api_reference/create_a_payment_reference).
 
+### Update a user’s recurring payment card details
+
+You can update the card used to take recurring payments. This overrides the existing card details. You may need to do this if a user’s existing card expires, or if a user tells you they want to pay with a different card.
+
+To update the user’s card details, repeat [the process to set up an agreement](#set-up-an-agreement-for-recurring-payments) by creating a payment and adding set_up_agreement: "{AGREEMENT_ID}" to your API request.
+
+Once the user has successfully made the payment, you can take recurring payments using their new card. 
+
 ## Taking recurring payments
 
 Once you’ve set up the agreement, you can use it to take recurring payments without the paying user interacting with your service.


### PR DESCRIPTION
### Context
During user research, we discovered that a lot of users were confused about what to do if a user's card expires or if a user wants to change the card they use to make recurring payments.

### Changes proposed in this pull request
This PR:

- adds a new heading to recurring payment guidance: 'Update a user's recurring payment card details'
