### PR TITLE
PP-11138: Configure Dependabot for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,38 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
+  - ruby
 - package-ecosystem: pip
   directory: "/"
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
+  - python
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
+  - javascript
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 0
+  labels:
+    - dependencies
+    - govuk-pay
+    - github_actions


### PR DESCRIPTION
### Context
See RFC https://github.com/alphagov/pay-architecture/discussions/97

### Changes proposed in this pull request

- Also adds config for Github Actions dependencies to make sure we pick up security updates for these.
- Also adds labels for npm, pip and bundler.