### PR TITLE
Fixes mistyped review dates

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: API reference
-last_reviewed_on: 2022-06-22
+last_reviewed_on: 2023-06-22
 review_in: 6 months
 weight: 1400
 ---

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Security
-last_reviewed_on: 2022-06-22
+last_reviewed_on: 2023-06-22
 review_in: 6 months
 weight: 9200
 ---

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Stay up to date
-last_reviewed_on: 2022-06-22
+last_reviewed_on: 2023-06-22
 review_in: 6 months
 weight: 9100
 ---


### PR DESCRIPTION
Small PR that fixes a few review dates. Reviewer entered `2022` instead of `2023`, causing some issues with the review bot.
