### PR TITLE
PP-11343: Extend review time for established pages

### DIFF
--- a/source/account_structure/index.html.md.erb
+++ b/source/account_structure/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Setting up multiple services
 last_reviewed_on: 2023-04-12
-review_in: 6 months
+review_in: 12 months
 weight: 6300
 ---
 

--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Set up which bank accounts your payments go to
 last_reviewed_on: 2023-04-12
-review_in: 6 months
+review_in: 12 months
 weight: 6310
 ---
 

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Set up how your services link to GOV.UK Pay services
 last_reviewed_on: 2023-04-12
-review_in: 6 months
+review_in: 12 months
 weight: 6320
 ---
 

--- a/source/api_reference/cancel_payment_reference/index.html.md.erb
+++ b/source/api_reference/cancel_payment_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Cancel a payment API reference
 last_reviewed_on: 2023-03-15
-review_in: 6 months
+review_in: 12 months
 weight: 14140
 ---
 

--- a/source/api_reference/capture_payment_reference/index.html.md.erb
+++ b/source/api_reference/capture_payment_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Take ('capture') a delayed payment API reference
 last_reviewed_on: 2023-03-15
-review_in: 6 months
+review_in: 12 months
 weight: 14150
 ---
 

--- a/source/api_reference/payment_event_reference/index.html.md.erb
+++ b/source/api_reference/payment_event_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get a payment's events API reference
 last_reviewed_on: 2023-04-01
-review_in: 6 months
+review_in: 12 months
 weight: 14130
 ---
 

--- a/source/api_reference/payment_refunds_reference/index.html.md.erb
+++ b/source/api_reference/payment_refunds_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get information about a payment's refunds API reference
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 14230
 ---
 

--- a/source/api_reference/refund_payment_reference/index.html.md.erb
+++ b/source/api_reference/refund_payment_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Refund a payment API reference
 last_reviewed_on: 2023-06-22
-review_in: 6 months
+review_in: 12 months
 weight: 14210
 ---
 

--- a/source/api_reference/refund_status_reference/index.html.md.erb
+++ b/source/api_reference/refund_status_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Check the status of a refund API reference
 last_reviewed_on: 2023-06-22
-review_in: 6 months
+review_in: 12 months
 weight: 14220
 ---
 

--- a/source/api_reference/search_disputes_reference/index.html.md.erb
+++ b/source/api_reference/search_disputes_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Search disputes API reference
 last_reviewed_on: 2023-08-07
-review_in: 6 months
+review_in: 12 months
 weight: 14410
 ---
 

--- a/source/api_reference/search_refunds_reference/index.html.md.erb
+++ b/source/api_reference/search_refunds_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Search refunds API reference
 last_reviewed_on: 2023-06-22
-review_in: 6 months
+review_in: 12 months
 weight: 14240
 ---
 

--- a/source/api_reference/send_card_details_moto_reference/index.html.md.erb
+++ b/source/api_reference/send_card_details_moto_reference/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Send card details to authorise a MOTO payment API reference
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 14510
 ---
 

--- a/source/block_prepaid_cards/index.html.md.erb
+++ b/source/block_prepaid_cards/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Block prepaid cards
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 5500
 ---
 

--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Add corporate card fees
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 5400
 ---
 

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Delay taking a payment
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 2500
 ---
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,7 +2,7 @@
 title: GOV.UK Pay technical documentation
 weight: 1100
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 ---
 
 # GOV.UK Pay technical documentation

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Prefill payment fields
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 5240
 ---
 

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Use your own payment failure pages
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 5230
 ---
 

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Use Welsh on your payment pages
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 5220
 ---
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How GOV.UK Pay works
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 1300
 ---
 

--- a/source/prefill_payment_links/index.html.md.erb
+++ b/source/prefill_payment_links/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Prefill payment reference and amount when using a payment link
 last_reviewed_on: 2023-07-18
-review_in: 6 months
+review_in: 12 months
 weight: 5300
 ---
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Refund a payment
 last_reviewed_on: 2023-06-22
-review_in: 6 months
+review_in: 12 months
 weight: 4100
 ---
 

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Support
 last_reviewed_on: 2023-07-18
-review_in: 3 months
+review_in: 6 months
 weight: 9400
 ---
 

--- a/source/switch_payment_service_provider/index.html.md.erb
+++ b/source/switch_payment_service_provider/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Switch payment service provider (PSP)
 last_reviewed_on: 2023-02-14
-review_in: 6 months
+review_in: 12 months
 weight: 7200
 ---
 

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Switch payment service provider to Stripe
 last_reviewed_on: 2023-02-14
-review_in: 6 months
+review_in: 12 months
 weight: 7210
 ---
 

--- a/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_worldpay/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Switch payment service provider to Worldpay
 last_reviewed_on: 2023-02-14
-review_in: 6 months
+review_in: 12 months
 weight: 7220
 ---
 

--- a/source/versioning/index.html.md.erb
+++ b/source/versioning/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Stay up to date
 last_reviewed_on: 2023-06-22
-review_in: 6 months
+review_in: 12 months
 weight: 9100
 ---
 


### PR DESCRIPTION
### Context
Documentation reviews are more frequent than is needed for a lot of pages in the GOV.UK Pay documentation. Many pages have been the same for a long time and, when they are reviewed, do not need any changes.

### Changes proposed in this pull request
This PR extends the `review_in` time from `6 months` to `12 months` or from `3 months` to `6 months` on pages that have not been updated in a while and will not be worked on in the near future.