### PR TITLE
PP-11391 - Adds testing information for wallets

### DIFF
--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -74,7 +74,7 @@ To enable Google Pay on a Worldpay service, you need to get a Google Pay merchan
 
 ## Test digital wallet payments
 
-You can test digital wallet payments using a GOV.UK Pay test account.
+You can test digital wallet payments using a Stripe test account.
 
 ### Test Google Pay
 
@@ -86,11 +86,11 @@ To test Google Pay:
 
 1. In your test service, [create a payment through the API](https://docs.payments.service.gov.uk/making_payments/#creating-a-payment) or create a payment link through the GOV.UK Pay admin tool.
 
-1. Open Chrome.
+1. Open Chrome on a desktop or Android device.
 
 1. Sign in to a Google account.
 
-1. In your chosen browser, visit the `next_url` you received when you created the test payment or visit the payment link.
+1. Visit the `next_url` you received when you created the test payment or visit the payment link.
 
 1. Complete the test payment using a real card or a test card. We will not take any money if you use a real debit or credit card.
 
@@ -113,22 +113,6 @@ To test Apple Pay:
 1. In your chosen browser, visit the `next_url` you received when you created the test payment or visit the payment link.
 
 1. Complete the test payment using the credit or debit card you added to your Apple Wallet. We will not take any money.
-
-### Test failed digital wallet payments
-
-You can test failed digital wallet payments through the GOV.UK Pay API if your PSP is Stripe.
-
-Change your `description` value to `DECLINED` when you send your payment creation request to your test service. 
-
-When you try to complete the payment, we’ll decline the payment and redirect you to your [service’s failure page](https://docs.payments.service.gov.uk/payment_flow/#show-a-failure-page).
-
-### Test 3D secure (3DS) with digital wallet payments
-
-You can force a 3DS check on a digital wallet payment through the GOV.UK Pay API if your PSP is Stripe.
-
-Change your `description` value to `3DS` when you send your payment creation request to your test service. 
-
-When you complete the payment, there’ll be a 3DS check. 
 
 ## Strong Customer Authentication (3D Secure)
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -41,7 +41,7 @@ You do not need to ask Worldpay to enable Apple Pay in your Worldpay account.
 
 ## Enable Google Pay
 
-If your payment service provider (PSP) is Stripe, Google Pay is enabled by default.
+If your PSP is Stripe, Google Pay is enabled by default.
 
 If your PSP is Worldpay, you'll need to enable Google Pay.
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -7,13 +7,20 @@ weight: 2300
 
 # Take a digital wallet payment
 
-You can enable [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/) to take payments from your users.
+Your users can make payments with [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/).
 
-This is only available to services with a [live Worldpay account](/switching_to_live/set_up_a_live_worldpay_account/#connect-your-live-account-to-worldpay).
+Users can use digital wallets with:
 
-Digital wallet payments work with both [integrating with the GOV.UK Pay API](/integrate_with_govuk_pay/#integrate-with-the-gov-uk-pay-api) or using [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+* payment links
+* payments created through the GOV.UK Pay API
+
+If your payment service provider (PSP) is Stripe, digital wallets are enabled by default. You can still disable Apple Pay and Google Pay in the GOV.UK Pay admin tool.
 
 ## Enable Apple Pay
+
+If your PSP is Stripe, Apple Pay is enabled by default.
+
+If your PSP is Worldpay, you'll need to enable Apple Pay.
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/).
 
@@ -25,11 +32,20 @@ Digital wallet payments work with both [integrating with the GOV.UK Pay API](/in
 
 You do not need to ask Worldpay to enable Apple Pay in your Worldpay account.
 
+### Disable Apple Pay
+
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk).
+1. Under **Services**, select the service where you want to disable Apple Pay.
+1. Select **Settings**.
+1. Change **Apple Pay** to **Off**.
+
 ## Enable Google Pay
 
-To enable Google Pay, you must enter a unique Google Pay merchant ID into your GOV.UK Pay account.
+If your payment service provider (PSP) is Stripe, Google Pay is enabled by default.
 
-You get a Google Pay merchant ID from your Worldpay merchant admin interface.
+If your PSP is Worldpay, you'll need to enable Google Pay.
+
+To enable Google Pay on a Worldpay service, you need to get a Google Pay merchant ID from your Worldpay merchant admin interface
 
 1. If required, speak to your Worldpay account manager to upgrade your Worldpay merchant admin interface to include Google Pay functionality.
 
@@ -49,6 +65,71 @@ You get a Google Pay merchant ID from your Worldpay merchant admin interface.
 
 1. Go to the **Google Pay** setting, select **On** and enter the merchant ID.
 
+### Disable Google Pay
+
+1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk).
+1. Under **Services**, select the service where you want to disable Google Pay.
+1. Select **Settings**.
+1. Change **Google Pay** to **Off**.
+
+## Test digital wallet payments
+
+You can test digital wallet payments using a GOV.UK Pay test account.
+
+### Test Google Pay
+
+To test Google Pay, you need a Google account and you must add a credit or debit card to that account. You can add a real credit or debit card, or [use Google Pay’s test cards](https://developers.google.com/pay/api/android/guides/resources/test-card-suite).
+
+We will not take any money if you use a real credit or debit card.
+
+To test Google Pay:
+
+1. In your test service, [create a payment through the API](https://docs.payments.service.gov.uk/making_payments/#creating-a-payment) or create a payment link through the GOV.UK Pay admin tool.
+
+1. Open Chrome.
+
+1. Sign in to a Google account.
+
+1. In your chosen browser, visit the `next_url` you received when you created the test payment or visit the payment link.
+
+1. Complete the test payment using a real card or a test card. We will not take any money if you use a real debit or credit card.
+
+You can see the payment in the GOV.UK Pay admin tool and through the API.
+
+### Test Apple Pay
+
+To test Apple Pay, you must set up Apple Pay on an iOS or macOS device. You can use a real credit or debit card. 
+
+We will not take any money if you add a real credit debit card to test Apple Pay. 
+
+If your organisation has an Apple developer account, you may be able to use [Apple’s test cards](https://developer.apple.com/apple-pay/sandbox-testing/).
+
+To test Apple Pay:
+
+1. In your test service, [create a payment through the API](https://docs.payments.service.gov.uk/making_payments/#creating-a-payment) or create a payment link through the GOV.UK Pay admin tool.
+
+1. On an iOS device, open a browser that supports Apple Pay, such as Safari, Chrome, or Microsoft Edge. If you’re using a Mac, open Safari.
+
+1. In your chosen browser, visit the `next_url` you received when you created the test payment or visit the payment link.
+
+1. Complete the test payment using the credit or debit card you added to your Apple Wallet. We will not take any money.
+
+### Test failed digital wallet payments
+
+You can test failed digital wallet payments through the GOV.UK Pay API if your PSP is Stripe.
+
+Change your `description` value to `DECLINED` when you send your payment creation request to your test service. 
+
+When you try to complete the payment, we’ll decline the payment and redirect you to your [service’s failure page](https://docs.payments.service.gov.uk/payment_flow/#show-a-failure-page).
+
+### Test 3D secure (3DS) with digital wallet payments
+
+You can force a 3DS check on a digital wallet payment through the GOV.UK Pay API if your PSP is Stripe.
+
+Change your `description` value to `3DS` when you send your payment creation request to your test service. 
+
+When you complete the payment, there’ll be a 3DS check. 
+
 ## Strong Customer Authentication (3D Secure)
 
 Apple Pay requires your users to authenticate digital wallet transactions using a secure method such as a fingerprint scan. Your Apple Pay users do not need to complete a Strong Customer Authentication (SCA) method such as 3D Secure separately.
@@ -59,7 +140,7 @@ See the [GOV.UK Pay page on Apple Pay and Google Pay](https://www.payments.servi
 
 ## Restrictions of digital wallet payments
 
-GOV.UK Pay cannot apply [corporate card surcharges](/corporate_card_surcharges/#add-corporate-card-fees) to digital wallet transactions made with a corporate card.
+GOV.UK Pay cannot apply [corporate card surcharges](/corporate_card_surcharges/#add-corporate-card-fees) to digital wallet payments made with a corporate card.
 
 GOV.UK Pay stores different cardholder information for digital wallet payments than standard card payments. There are further differences between payments made through Apple Pay and Google Pay.
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -169,6 +169,7 @@ For example:
     "expiry_date": "10/25",
     "billing_address": null,
     "card_brand": "Mastercard",
-    "card_type": "debit"
+    "card_type": "debit",
+    "wallet_type": "Apple Pay"
 }
 ```

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -176,6 +176,8 @@ Once the user has made the payment, the agreement’s `status` will be `active`.
 
 If the user’s payment fails, their payment details are not saved and the agreement’s `status` remains `created`.
 
+Users cannot use Apple Pay or Google Pay to make their first payment or any recurring payments.
+
 Read more about creating payments in [our guidance for taking payments](/making_payments) or our [API reference page for creating payments](/api_reference/create_a_payment_reference).
 
 ### Update a user’s recurring payment card details


### PR DESCRIPTION
# Context
We’re adding digital wallet support for Stripe services.

# Changes

* Take a digital wallet payment
  * explain that digital wallets are enabled by default for Stripe
  * clarify that the ‘Enable Apple Pay’ and ‘Enable Google Pay’ headings are for Worldpay services only
  * add ‘Disable Apple Pay’ heading
  * add ‘Disable Google Pay’ heading
  * add information about testing digital wallet payments
* Take a recurring payment
  * mention that users cannot use a digital wallet payments to set up an agreement for recurring payments