### PR TITLE
Small changes to the maintenance page

### DIFF
--- a/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
+++ b/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
@@ -1,0 +1,74 @@
+---
+title: Scheduled GOV.UK Pay maintenance
+last_reviewed_on: 2023-10-10
+review_in: 6 months
+weight: 9450
+---
+
+# Scheduled GOV.UK Pay maintenance
+
+GOV.UK Pay will be unavailable for three 4-hour windows during November 2023. 
+
+We’ve also scheduled two backup windows that we’ll only use if we cannot complete the maintenance work in time.
+
+## Full GOV.UK Pay outages
+
+GOV.UK Pay will be completely unavailable on the following dates:
+
+* Tuesday 14 November, 4am to 8am
+* Tuesday 21 November, 4am to 8am
+
+During these times, you cannot:
+
+* create or take any payments
+* use the GOV.UK Pay API
+* sign in to the GOV.UK Pay admin tool
+* query, report on or refund any payments
+
+If there are any issues with the maintenance during either of these windows, we have scheduled a backup date:
+
+* Tuesday 28 November, 4am to 8am
+
+## Partial GOV.UK Pay outage
+
+Parts of GOV.UK Pay will be unavailable on the following date:
+
+* Wednesday 15 November, 10am to 2pm
+
+During this time, you cannot:
+
+* sign in to the GOV.UK Pay admin tool
+* use the API to search for transactions
+
+You'll still be able to:
+
+* create and take payments through the API
+* check an individual payment's status through the API
+* take payments using existing payment links
+* refund payments through the API
+
+If there are any issues with the maintenance during this window, we have scheduled a backup date:
+
+* Thursday 16 November, 10am to 2pm
+
+## Communicate the maintenance with stakeholders
+
+You should communicate this scheduled downtime to relevant stakeholders. This could include call centre staff, case workers, and technical teams.
+
+If your service has a technical team, you should:
+
+* check if there are any automated jobs scheduled to run during the maintenance windows and check they can handle errors appropriately
+
+* check if you can show your users a maintenance page earlier in their online journey to prevent them from reaching the payment stage of your service
+
+* make them aware that we will still deliver webhooks messages but they may be delayed by the maintenance
+
+## Check the GOV.UK Pay status page
+
+We’ll keep the [GOV.UK Pay status page](https://payments.statuspage.io/) updated as we complete the scheduled maintenance.
+
+Select **subscribe to updates** to receive alerts about disruption to GOV.UK Pay service.
+
+## Contact GOV.UK Pay about scheduled maintenance
+
+If you have any further questions or concerns about the scheduled maintenance, contact govuk-pay-support@digital.cabinet-office.gov.uk.

--- a/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
+++ b/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
@@ -39,10 +39,11 @@ During this time, you cannot:
 
 * sign in to the GOV.UK Pay admin tool
 * use the API to search for transactions
+* take recurring payments
 
 You'll still be able to:
 
-* create and take payments through the API
+* create and take one-off payments through the API
 * check an individual payment's status through the API
 * take payments using existing payment links
 * refund payments through the API


### PR DESCRIPTION
A couple of small tweaks to the postgres update page:

* explains that recurring payments will not be available during partial outages
* clarifies the types of payments services can take during outages