### PR TITLE
Small tweaks on postgres maintenance

### DIFF
--- a/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
+++ b/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
@@ -39,10 +39,11 @@ During this time, you cannot:
 
 * sign in to the GOV.UK Pay admin tool
 * use the API to search for transactions
+* take recurring payments
 
 You'll still be able to:
 
-* create and take payments through the API
+* create and take one-off payments through the API
 * check an individual payment's status through the API
 * take payments using existing payment links
 * refund payments through the API


### PR DESCRIPTION
A couple of small tweaks to the postgres update page:

* explains that recurring payments will not be available during partial outages
* clarifies the types of payments services can take during outages