### PR TITLE
PP-11669 - Clarifies where wallets are available and fees

### DIFF
--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -7,14 +7,20 @@ weight: 2300
 
 # Take a digital wallet payment
 
-Your users can make payments with [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/).
+Your users can make payments with [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/). This page tells you how to enable digital wallet payments, test digital wallet payments, and the restrictions around diigtal wallets.
 
 Users can use digital wallets with:
 
 * payment links
 * payments created through the GOV.UK Pay API
 
+Users can only use Google Pay if they're making payments in Google Chrome.
+
+Users can only use Apple Pay if they're making payments in Safari on a recent Apple device.
+
 If your payment service provider (PSP) is Stripe, digital wallets are enabled by default. You can still disable Apple Pay and Google Pay in the GOV.UK Pay admin tool.
+
+There are no additional PSP fees if your service takes digital wallet payments.
 
 ## Enable Apple Pay
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -14,7 +14,7 @@ Users can use digital wallets with:
 * payment links
 * payments created through the GOV.UK Pay API
 
-Users can only use Google Pay if they're making payments in Google Chrome.
+Users can currently only use Google Pay if they're making payments in Google Chrome.
 
 Users can only use Apple Pay if they're making payments in Safari on a recent Apple device.
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -14,9 +14,9 @@ Users can use digital wallets with:
 * payment links
 * payments created through the GOV.UK Pay API
 
-Users can currently only use Google Pay if they're making payments in Google Chrome.
+Users can only use Google Pay if they're making payments in a supported browser, such as Google Chrome.
 
-Users can only use Apple Pay if they're making payments in Safari on a recent Apple device.
+Users can only use Apple Pay if they're making payments on a compatible Mac, iPhone, or iPad in a supported browser, such as Safari.
 
 If your payment service provider (PSP) is Stripe, digital wallets are enabled by default. You can still disable Apple Pay and Google Pay in the GOV.UK Pay admin tool.
 


### PR DESCRIPTION
### Context
Since enabling digital wallets for Stripe, we've had multiple support requests because users haven't been able to see the wallet buttons. We've also had multiple enquiries about potential additional fees for using Google Pay and/or Apple Pay.

### Changes proposed in this pull request
This PR:

* clarifies the situations users can pay with Google Pay and Apple Pay
* clarifies that there are no additional fees for wallet payments