### PR TITLE
PP-11787: Minor docs changes based on feedback

### DIFF
--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -40,8 +40,8 @@ response fields:
 
 | Response field                   | Meaning
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `"amount"`                       | Contains the amount in pence, without any surcharge. </br> This field always appears, even if a surcharge is not applicable.|
-| `"total_amount"`                 | Contains the total amount in pence, including any surcharge. </br> Only appears if a surcharge is applicable.               |
-| `"corporate_card_surcharge"`     | Contains only the surcharge amount, in pence. </br> Only appears if a surcharge is applicable.                              |
+| `amount`                       | Contains the amount in pence, without any surcharge. </br> This field always appears, even if a surcharge is not applicable.|
+| `total_amount`                 | Contains the total amount in pence, including any surcharge. </br> Only appears if a surcharge is applicable.               |
+| `corporate_card_surcharge`     | Contains only the surcharge amount, in pence. </br> Only appears if a surcharge is applicable.                              |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -13,7 +13,10 @@ You may want to use delayed capture if you need time to do your own anti-fraud c
 
 During the delay, your user's available bank balance is reduced by the payment amount.
 
-You cannot use delayed capture if you only use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+You cannot use delayed capture for:
+
+* payments made with [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
+* [recurring payments](/recurring_payments)
 
 To use this feature, include `"delayed_capture": true` in the body of a [Create new payment](/making_payments/#creating-a-payment) request.
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -22,6 +22,8 @@ If your payment service provider (PSP) is Stripe, digital wallets are enabled by
 
 There are no additional PSP fees if your service takes digital wallet payments.
 
+If you have disabled any card brands through the GOV.UK Pay admin tool, these card brands will also be disabled for digital wallet payments.
+
 ## Enable Apple Pay
 
 If your PSP is Stripe, Apple Pay is enabled by default.

--- a/source/optional_features/use_your_own_error_pages/index.html.md.erb
+++ b/source/optional_features/use_your_own_error_pages/index.html.md.erb
@@ -26,7 +26,7 @@ state. You can set the `return_url` manually when you [create a payment](/making
 
 You should configure your service to query payments to determine what
 payment failure states are from API responses. Once your service
-knows the [state of a payment](/payment_flow/#7-show-a-final-page), it should direct your user appropriately. For
+knows the [state of a payment](/api_reference/#payment-status-lifecycle), it should [direct your user appropriately](/payment_flow/#7-show-a-final-page). For
 example if your user's payment expires, you may want your service to return your user to the start of their payment journey.
 
 In very rare cases, GOV.UK Pay is unable to redirect payments. You should

--- a/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
+++ b/source/support_contact_and_more_information/scheduled_maintenance/index.html.md.erb
@@ -15,8 +15,8 @@ We’ve also scheduled two backup windows that we’ll only use if we cannot com
 
 GOV.UK Pay will be completely unavailable on the following dates:
 
-* Tuesday 14 November, 4am to 8am
-* Tuesday 21 November, 4am to 8am
+* Tuesday 14 November, 4:00am to 8:00am
+* Tuesday 21 November, 4:00m to 8:00am
 
 During these times, you cannot:
 
@@ -27,13 +27,13 @@ During these times, you cannot:
 
 If there are any issues with the maintenance during either of these windows, we have scheduled a backup date:
 
-* Tuesday 28 November, 4am to 8am
+* Tuesday 28 November, 4:00am to 8:00am
 
 ## Partial GOV.UK Pay outage
 
 Parts of GOV.UK Pay will be unavailable on the following date:
 
-* Wednesday 15 November, 10am to 2pm
+* Wednesday 15 November, 10:00am to 2:00pm
 
 During this time, you cannot:
 
@@ -50,7 +50,7 @@ You'll still be able to:
 
 If there are any issues with the maintenance during this window, we have scheduled a backup date:
 
-* Thursday 16 November, 10am to 2pm
+* Thursday 16 November, 10:00am to 2:00pm
 
 ## Communicate the maintenance with stakeholders
 

--- a/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
+++ b/source/switching_to_live/set_up_a_live_stripe_account/index.html.md.erb
@@ -31,6 +31,8 @@ You must also add a document that verifies your organisation is a government ent
 * a document from the Charity Commission
 * a document from the Scottish Charity Regulator (OSCR)
 
+The address on your government entity document must not be a PO box.
+
 To add these details and the document, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login). Select your service from the **Overview** screen, and follow the on-screen instructions.
 
 GOV.UK Pay only stores your organisation's address and telephone number. We pass all other information to Stripe. Stripe then processes and stores that information.

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -87,16 +87,17 @@ There are separate sets of mock card numbers for:
 
 ##### Testing recurring payments on a test account
 
-You can test successful [recurring payments](/recurring_payments) using the same mock card numbers you use to test normal GOV.UK Pay payments.
+Recurring payments are made up of two stages:
 
-To test unsuccessful recurring payments, use this mock card number:
+1. An initial payment to set up the agreement for recurring payments.
+2. Further recurring payments that are taken automatically without a user's input.
+
+To test both stages, we offer mock cards that have two testing actions - one for the initial payment and one for the further recurring payments.
 
 |Testing actions |Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |
-|Successful set up payment<br><br>Unsuccessful recurring payment | 5105105105105100 | Mastercard | Debit |
-|Successul set up payment<br><br>Successful recurring payment | 4000056655665556 | Visa | Debit |
-
-This card takes one initial payment to set up the recurring payment agreement, but fails further recurring payment attempts.
+|1. Successul set up payment<br><br>2. Successful recurring payment | 4000056655665556 | Visa | Debit |
+|1. Successful set up payment<br><br>2. Unsuccessful recurring payment | 5105105105105100 | Mastercard | Debit |
 
 #### If you're using a test Stripe account
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -94,6 +94,7 @@ To test unsuccessful recurring payments, use this mock card number:
 |Testing actions |Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |
 |Successful set up payment<br><br>Unsuccessful recurring payment | 5105105105105100 | Mastercard | Debit |
+|Successul set up payment<br><br>Successful recurring payment | 4000056655665556 | Visa | Debit |
 
 This card takes one initial payment to set up the recurring payment agreement, but fails further recurring payment attempts.
 


### PR DESCRIPTION
### Context
We’ve identified a need for a few small documentation changes through reviews and support tickets. These changes are not large enough to need a whole ticket to themselves, so they’re aggregated into this one.

### The changes

- Corporate card fee page - remove inverted commas from response attribute names
- Use your own payment failure pages - link for payment status goes to the wrong page at the moment
- Use Welsh - link text currently implies that we have specific instructions for Welsh pages when the link should only go to the generic create payment docs page
- Testing integration - clarify the testing actions for recurring card payment cards
- Scheduled downtime - fix time formatting from 4am to 4:00am
- Go live with Stripe - make it clear that services need a real, physical address, and not a PO box
- Delayed capture - mention that it cannot be used with recurring payments
- Digital wallets - clarify that wallets respect any disabled card brands
