### PR TITLE
PP-11779: Removes mention of Stripe test accounts

### DIFF
--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -82,8 +82,6 @@ To enable Google Pay on a Worldpay service, you need to get a Google Pay merchan
 
 ## Test digital wallet payments
 
-You can test digital wallet payments using a Stripe test account.
-
 ### Test Google Pay
 
 To test Google Pay, you need a Google account and you must add a credit or debit card to that account. You can add a real credit or debit card, or [use Google Pay’s test cards](https://developers.google.com/pay/api/android/guides/resources/test-card-suite).


### PR DESCRIPTION
### Context
Services can now test digital wallet payments in sandbox, so we no longer need to specify that services need a Stripe test account.

### Changes proposed in this pull request
This PR:
- removes the mention of Stripe test accounts from the 'Take a digital wallet payment' docs page.