### PR TITLE
Clarifies recurring payments and adds a new heading for digital wallet payments

### DIFF
--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -132,6 +132,10 @@ See the [GOV.UK Pay page on Apple Pay and Google Pay](https://www.payments.servi
 
 GOV.UK Pay cannot apply [corporate card surcharges](/corporate_card_surcharges/#add-corporate-card-fees) to digital wallet payments made with a corporate card.
 
+Users cannot make recurring payments with digital wallets.
+
+### Stored cardholder information in digital wallet payments
+
 GOV.UK Pay stores different cardholder information for digital wallet payments than standard card payments. There are further differences between payments made through Apple Pay and Google Pay.
 
 If you rely on cardholder information as part of your service, you should not collect this information through GOV.UK Pay. Cardholder information in digital wallet payments is unreliable because of how Google Pay and Apple Pay handle payment cards.


### PR DESCRIPTION
### Context
Digital wallets cannot be used to set up and take recurring payments. We already mention this on the recurring payments docs page, but not on the page for digital wallet payments.

### Changes proposed in this pull request
This PR:

* adds a sentence to [Take a digital wallet payment](https://docs.payments.service.gov.uk/digital_wallets/) that explains recurring payments can't be taken with wallets
* adds a H3 to the Take a digital wallet payment page to better organise the cardholder information restrictions from other restrictions