### PR TITLE
PP-11369: Adds information about webhook callback URL restrictions

### DIFF
--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -34,7 +34,7 @@ Your callback URL must use HTTPS and present a valid certificate. GOV.UK webhook
 
 Your callback URL must have a domain that ends with `.gov.uk`. This restriction does not apply if you're using webhooks on a test service.
 
-We can allow other domains if you cannot host your callback URL on a domain that ends with `gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. If we allow your domain, there'll be a delay before you can use it.
+We can allow other domains if you cannot host your callback URL on a domain that ends with `.gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. If we allow your domain, there'll be a delay before you can use it.
 
 ## Create a webhook
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -32,6 +32,10 @@ You must set up your endpoint to receive the `POST` body from your webhook and r
 
 Your callback URL must use HTTPS and present a valid certificate. GOV.UK webhooks support TLS version 1.2.
 
+Your callback URL must have a domain that ends with `.gov.uk`. This restriction does not apply if you're using webhooks on a test service.
+
+We can allow domains that do not end with `gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. If we allow your domain, there'll be a delay before you can use it.
+
 ## Create a webhook
 
 You can create a webhook for your service from the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -34,7 +34,7 @@ Your callback URL must use HTTPS and present a valid certificate. GOV.UK webhook
 
 Your callback URL must have a domain that ends with `.gov.uk`. This restriction does not apply if you're using webhooks on a test service.
 
-We can allow other domains if you cannot host your callback URL on a domain that ends with `.gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. If we allow your domain, there'll be a delay before you can use it.
+We can allow other domains if you cannot host your callback URL on a domain that ends with `.gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. There may be a delay before we allow your domain to give us time to discuss your request.
 
 ## Create a webhook
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -34,7 +34,7 @@ Your callback URL must use HTTPS and present a valid certificate. GOV.UK webhook
 
 Your callback URL must have a domain that ends with `.gov.uk`. This restriction does not apply if you're using webhooks on a test service.
 
-We can allow domains that do not end with `gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. If we allow your domain, there'll be a delay before you can use it.
+We can allow other domains if you cannot host your callback URL on a domain that ends with `gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. If we allow your domain, there'll be a delay before you can use it.
 
 ## Create a webhook
 


### PR DESCRIPTION
### Context
Our documentation doesn't mention some of the restrictions we have on callback URLs for webhooks.

### Changes proposed in this pull request
This PR clarifies that (from the JIRA ticket):

- test webhook callback URLs have no domain restrictions
- live webhook callback URLs must have a domain that ends in .gov.uk
- a service can request a domain be allowed for live webhook callback URLs by emailing support
- we will only allow domains that exclusively belong to the service or its parent organisation
- even we decide to allow a domain, it will not be added immediately