### PR TITLE
PP-12141: Improve API request examples

### DIFF
--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -18,7 +18,7 @@ You cannot use delayed capture for:
 * payments made with [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
 * [recurring payments](/recurring_payments)
 
-To use this feature, include `"delayed_capture": true` in the body of your [request to create a new payment](/making_payments/#creating-a-payment) request:
+To use this feature, include `"delayed_capture": true` in the body of your [request to create a new payment](/making_payments/#creating-a-payment):
 
 `POST /v1/payments`
 
@@ -32,25 +32,20 @@ To use this feature, include `"delayed_capture": true` in the body of your [requ
 }
 ```
 
-Your user will follow the standard payment flow. After your user selects
-__Confirm__ on the __Confirm your details__ page:
+Your user will follow the standard payment flow. After your user selects __Confirm__ on the __Confirm your details__ page:
 
 - the [payment's status](/api_reference/#payment-status-lifecycle) will change to `capturable`
-- your service can make a request to the
-`POST /v1/payments/{PAYMENT_ID}/capture` endpoint to send a delayed capture
-request
+- your service can make a request to the `POST /v1/payments/{PAYMENT_ID}/capture` endpoint to send a delayed capture request
 
 Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of when your user completes the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
 
-If you've turned on payment confirmation emails, GOV.UK Pay will send a
-payment confirmation email to your user once we've received and processed your service’s capture request.
+If you've turned on payment confirmation emails, GOV.UK Pay will send a payment confirmation email to your user once we've received and processed your service’s capture request.
 
 You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/capture_payment_reference). You can also view [possible responses to your capture request](/api_reference/#responses).
 
 ## See the capture URL for a payment
 
-If a payment is available for capture, you can see its capture URL in
-responses to API requests. For example:
+If a payment is available for capture, you can see its capture URL in responses to API requests. For example:
 
 * `GET /v1/payments`
 * `GET /v1/payments/{PAYMENT_ID}`
@@ -59,9 +54,9 @@ Replace ``{PAYMENT_ID}`` with the ID of the payment you want to see the capture 
 
 The `_links` object will contain:
 
-```
+```json
 "capture": {
-"href": "https://publicapi.payments.service.gov.uk/v1/payments/{PAYMENT_ID}/capture",
+    "href": "https://publicapi.payments.service.gov.uk/v1/payments/{PAYMENT_ID}/capture",
     "method": "POST"
     }
 ```

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -34,14 +34,14 @@ This example request creates a £50 parking fine that the service can capture at
 }
 ```
 
-Your user will follow the standard payment flow. After your user selects __Confirm__ on the __Confirm your details__ page:
+Your paying user will follow the standard payment flow. After your user selects __Confirm__ on the __Confirm your details__ page:
 
 - the [payment's status](/api_reference/#payment-status-lifecycle) will change to `capturable`
 - you can make a request to the `POST /v1/payments/{PAYMENT_ID}/capture` endpoint when you want to capture the delayed
 
 You must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of when your user completes the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
 
-If you've turned on payment confirmation emails, GOV.UK Pay will send a payment confirmation email to your user once we've received and processed your service’s capture request.
+If you've turned on payment confirmation emails, GOV.UK Pay will send a payment confirmation email to your user. We'll send this email once we've received and processed your service’s capture request.
 
 You can see definitions and possible values of every parameter and attribute for this endpoint in our [API reference](/api_reference/capture_payment_reference). You can also view [possible responses to your capture request](/api_reference/#responses).
 

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -18,7 +18,9 @@ You cannot use delayed capture for:
 * payments made with [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
 * [recurring payments](/recurring_payments)
 
-To use this feature, include `"delayed_capture": true` in the body of your [request to create a new payment](/making_payments/#creating-a-payment):
+To use this feature, include `"delayed_capture": true` in the body of your [request to create a new payment](/making_payments/#creating-a-payment).
+
+This example request creates a £50 parking fine that the service can capture at a later point because it includes the `delayed_capture` parameter:
 
 `POST /v1/payments`
 
@@ -35,9 +37,9 @@ To use this feature, include `"delayed_capture": true` in the body of your [requ
 Your user will follow the standard payment flow. After your user selects __Confirm__ on the __Confirm your details__ page:
 
 - the [payment's status](/api_reference/#payment-status-lifecycle) will change to `capturable`
-- your service can make a request to the `POST /v1/payments/{PAYMENT_ID}/capture` endpoint to send a delayed capture request
+- you can make a request to the `POST /v1/payments/{PAYMENT_ID}/capture` endpoint when you want to capture the delayed
 
-Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of when your user completes the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
+You must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of when your user completes the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
 
 If you've turned on payment confirmation emails, GOV.UK Pay will send a payment confirmation email to your user once we've received and processed your service’s capture request.
 

--- a/source/delayed_capture/index.html.md.erb
+++ b/source/delayed_capture/index.html.md.erb
@@ -18,17 +18,29 @@ You cannot use delayed capture for:
 * payments made with [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
 * [recurring payments](/recurring_payments)
 
-To use this feature, include `"delayed_capture": true` in the body of a [Create new payment](/making_payments/#creating-a-payment) request.
+To use this feature, include `"delayed_capture": true` in the body of your [request to create a new payment](/making_payments/#creating-a-payment) request:
 
-The user experience matches the current payment flow. Once your user selects
+`POST /v1/payments`
+
+```json
+{
+  "amount": 5000,
+  "reference" : "LE2504",
+  "description": "Pay a penalty charge notice (PCN)",
+  "return_url": "https://your.service.gov.uk/completed",
+  "delayed_capture": true
+}
+```
+
+Your user will follow the standard payment flow. After your user selects
 __Confirm__ on the __Confirm your details__ page:
 
-- the [payment status](/api_reference/#payment-status-lifecycle) will change to `capturable`
+- the [payment's status](/api_reference/#payment-status-lifecycle) will change to `capturable`
 - your service can make a request to the
 `POST /v1/payments/{PAYMENT_ID}/capture` endpoint to send a delayed capture
 request
 
-Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of how long your user takes to complete the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
+Your service must send the delayed capture request within 120 hours (5 days) of creating the payment, regardless of when your user completes the payment flow. If you do not, [the payment will expire](/payment_flow/#6-your-user-confirms-payment).
 
 If you've turned on payment confirmation emails, GOV.UK Pay will send a
 payment confirmation email to your user once we've received and processed your service’s capture request.

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -34,30 +34,12 @@ You must send the following parameters in your request body when creating a paym
 
 This example request creates a £145 council tax payment:
 
-```javascript
+```json
 {
   "amount": 14500,
   "reference" : "12345",
   "description": "Pay your council tax",
-  "return_url": "https://your.service.gov.uk/completed",
-  "delayed_capture": false,
-  "metadata": {
-    "ledger_code": "AB100",
-    "an_internal_reference_number": 200
-  },
-  "email": "sherlock.holmes@example.com",
-  "prefilled_cardholder_details": {
-    "cardholder_name": "Sherlock Holmes",
-    "billing_address": {
-        "line1": "221 Baker Street",
-        "line2": "Flat b",
-        "postcode": "NW1 6XE",
-        "city": "London",
-        "country": "GB"
-    }
-  },
-  "language": "en",
-  ...
+  "return_url": "https://your.service.gov.uk/completed"
 }
 ```
 
@@ -65,7 +47,7 @@ Depending on your integration, you can also:
 
 * [delay taking a payment](/delayed_capture)
 * [prefill some of the fields on the user's payment page](/optional_features/prefill_user_details/)
-* [add custom metadata to a payment](/reporting/#add-additional-information-your-users-will-not-be-able-to-see-39-custom-metadata-39-or-39-reporting-columns-39)
+* [add custom metadata to a payment](/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39)
 * [use Welsh on your payment pages](/optional_features/welsh_language/)
 * [take the payment over the phone](/moto_payments)
 

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -16,30 +16,36 @@ To prefill fields, include the following optional parameters in the API request 
 - `email`
 - `prefilled_cardholder_details` - with optional `cardholder_name` and `billing_address` parameters
 
-For example:
+This example request creates a £100 fine and prefills the user's email address, billing address, and the cardholder name:
 
-```javascript
-"email": "sherlock.holmes@example.com",
-"prefilled_cardholder_details": {
-  "cardholder_name": "Sherlock Holmes",
-  "billing_address": {
+```json
+{
+  "amount": 10000,
+  "reference" : "54321",
+  "description": "Pay a fine you've been issued.",
+  "return_url": "https://your.service.gov.uk/completed",
+  "email": "sherlock.holmes@example.com",
+  "prefilled_cardholder_details": {
+    "cardholder_name": "Sherlock Holmes",
+    "billing_address": {
       "line1": "221 Baker Street",
       "line2": "Flat b",
       "postcode": "NW1 6XE",
       "city": "London",
       "country": "GB"
+    }
   }
 }
 ```
 
-All the parameters in `billing_address` are optional, and these parameters' values must be no longer than:
+All the parameters in `billing_address` are optional, and the values must be no longer than:
 
 - 254 characters for `email`
 - 255 characters for `cardholder_name`
 - 255 characters each for `line1`, `line2` and `city` in `billing_address`
 - 25 characters for `postcode` in `billing_address`
 
-If you include the `country` parameter, it must be an <a href="https://www.iso.org/obp/ui/#search/code/" target="_blank">ISO 3166-1 alpha-2 code</a>. If the parameter is invalid or missing, the __Country or territory__ field on the payment page will default to 'United Kingdom'.
+The `country` parameter must be an <a href="https://www.iso.org/obp/ui/#search/code/" target="_blank">ISO 3166-1 alpha-2 code</a>. If you do not include `country` or send an invalid value, the __Country or territory__ field on the payment page will default to 'United Kingdom'.
 
 ## Data collected by your GOV.UK Pay admin account
 
@@ -47,6 +53,6 @@ After your user completes their payment, your GOV.UK Pay account will collect yo
 
 - email address - even if you've turned off user email address collection
 - cardholder name
-- billing address - you can only see this by [using the API to get information about a payment](/reporting/#get-information-about-a-single-payment)
+- billing address - you can only see this by [using the API to get information about a payment](/api_reference/single_payment_reference)
 
 If your user does not complete their payment, your GOV.UK Pay account will still collect the `billing_address` value. This will happen even if you've chosen not to collect your users' billing addresses.

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -38,7 +38,7 @@ This example request creates a £100 fine and prefills the user's email address,
 }
 ```
 
-All the parameters in `billing_address` are optional, and the values must be no longer than:
+All the parameters in `billing_address` are optional and must have values no longer than:
 
 - 254 characters for `email`
 - 255 characters for `cardholder_name`

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -41,4 +41,7 @@ You can show a Welsh service name on payments that use Welsh language payment pa
 
 Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and select **Edit name** next to the service you want to add a Welsh name to.
 
-Your users will see the Welsh service name when making payments with Welsh language payment pages, and the English service name when making payments with English language payment pages.
+Your users will see:
+
+* the Welsh service name when making payments with Welsh language payment pages
+* the English service name when making payments with English language payment pages

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -11,19 +11,34 @@ GOV.UK Pay supports Welsh-language payment pages.
 
 You can also [create payment links in Welsh](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
-To use Welsh, include `"language": "cy"` in the API request when you [create a new payment](/making_payments/#creating-a-payment). Your users will see Welsh text on the payment pages as they complete the [payment flow](/payment_flow).  If you do not specify a language,
-GOV.UK Pay will default to using English-language payment pages.
+To use Welsh, include `"language": "cy"` in the API request when you [create a new payment](/making_payments/#creating-a-payment).
 
-To add a Welsh service name to your service, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and select **Edit name**.
+This example request creates a £50 fine that will use Welsh-language payment pages:
 
-If you add a Welsh service name to your service, your users will see this on Welsh-language
-payment pages instead of the English service name.
+`POST /v1/payments`
 
-When your user makes a payment, they will also see a
-[`description`](/payment_flow/#4-your-user-enters-their-payment-details). If you use Welsh-language
-payment pages, you may also want to use Welsh text in the
-`description`.
+```json
+{
+  "amount": 5000,
+  "reference" : "WA5678",
+  "description": "Talu dirwy.",
+  "return_url": "https://your.service.gov.uk/completed",
+  "language": "cy"
+}
+```
 
-GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, stop GOV.UK Pay sending emails by [selecting an account in the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
+GOV.UK Pay defaults to English-language payment pages if you do not send the `language` parameter.
+
+Your users see a [description of the payment](/payment_flow/#4-your-user-enters-their-payment-details) when they pay. If you use Welsh-language payment pages, you may also want to use Welsh text in the `description`.
+
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, stop GOV.UK Pay sending emails by selecting a service in [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
 
 [Contact us](/support_contact_and_more_information/) if you'd like us to develop a feature to automatically translate emails into Welsh.
+
+## Add a Welsh service name
+
+You can show a Welsh service name on payments that use Welsh-language payment pages. 
+
+Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and select **Edit name** next to the service you want to add a Welsh name to.
+
+Your users will see the Welsh service name when making payments with Welsh-language payment pages, and the English service name when making payments with English-language payment pages.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -7,13 +7,13 @@ weight: 5220
 
 # Use Welsh on your payment pages
 
-GOV.UK Pay supports Welsh-language payment pages.
+GOV.UK Pay supports Welsh language payment pages.
 
 You can also [create payment links in Welsh](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 To use Welsh, include `"language": "cy"` in the API request when you [create a new payment](/making_payments/#creating-a-payment).
 
-This example request creates a £50 fine that will use Welsh-language payment pages:
+This example request creates a £50 fine that will use Welsh language payment pages:
 
 `POST /v1/payments`
 
@@ -27,9 +27,9 @@ This example request creates a £50 fine that will use Welsh-language payment pa
 }
 ```
 
-GOV.UK Pay defaults to English-language payment pages if you do not send the `language` parameter.
+GOV.UK Pay defaults to English language payment pages if you do not send the `language` parameter.
 
-Your users see a [description of the payment](/payment_flow/#4-your-user-enters-their-payment-details) when they pay. If you use Welsh-language payment pages, you may also want to use Welsh text in the `description`.
+Your users see a [description of the payment](/payment_flow/#4-your-user-enters-their-payment-details) when they pay. If you use Welsh language payment pages, you may also want to use Welsh text in the `description`.
 
 GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, stop GOV.UK Pay sending emails by selecting a service in [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
 
@@ -37,8 +37,8 @@ GOV.UK Pay does not automatically translate emails into Welsh. If you want to se
 
 ## Add a Welsh service name
 
-You can show a Welsh service name on payments that use Welsh-language payment pages. 
+You can show a Welsh service name on payments that use Welsh language payment pages. 
 
 Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and select **Edit name** next to the service you want to add a Welsh name to.
 
-Your users will see the Welsh service name when making payments with Welsh-language payment pages, and the English service name when making payments with English-language payment pages.
+Your users will see the Welsh service name when making payments with Welsh language payment pages, and the English service name when making payments with English language payment pages.

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -27,11 +27,16 @@ This example request creates a £50 fine that will use Welsh language payment pa
 }
 ```
 
-GOV.UK Pay defaults to English language payment pages if you do not send the `language` parameter.
+If you do not include the `language` parameter in your request, GOV.UK Pay defaults to English language payment pages.
 
 Your users see a [description of the payment](/payment_flow/#4-your-user-enters-their-payment-details) when they pay. If you use Welsh language payment pages, you may also want to use Welsh text in the `description`.
 
-GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, stop GOV.UK Pay sending emails by selecting a service in [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting **Settings**.
+GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, stop GOV.UK Pay sending emails:
+
+1. Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+1. Select your service from the **Overview** page.
+1. Select **Settings**.
+1. Change **Payment confirmation emails** to **Off**.
 
 [Contact us](/support_contact_and_more_information/) if you'd like us to develop a feature to automatically translate emails into Welsh.
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -94,7 +94,7 @@ This is an example API request and request body to create a new payment for a pa
 
 ```POST /v1/payments```
 
-```javascript
+```json
 {
 "amount": 12000,
 "reference": "12345",

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -90,7 +90,7 @@ You can use the GOV.UK Pay API to:
 
 #### Get information about a single payment
 
-Use the following API request to get information about a single payment:
+Use the following endpoint to get information about a single payment:
 
 `GET /v1/payments/{PAYMENT_ID}`
 
@@ -399,19 +399,29 @@ You can use custom metadata to add more information to new payments when creatin
 
 Paying users cannot see metadata while they're making a payment.
 
-Include a `metadata` object in the body of your request to [create a new payment](/making_payments/#take-a-payment), for example:
+Include a `metadata` object in the body of your request to [create a new payment](/api_reference/create_a_payment_reference). 
 
-```javascript
-"metadata": {
-   "ledger_code": "AB100",
-   "an_internal_reference_number": 200,
-...
+This example request creates a payment for a £100 fine and adds a ledger code and an internal reference number as metadata:
+
+`POST /v1/payments`
+
+```json
+{
+  "amount": 10000,
+  "reference" : "WA5678",
+  "description": "Pay a fine for a late tax filing.",
+  "return_url": "https://your.service.gov.uk/completed",
+  "language": "cy",
+  "metadata": {
+    "ledger_code": "AB100",
+    "an_internal_reference_number": 200
+  }
 }
 ```
 
-The `metadata` object must contain between 1 and 10 parameters.
+The `metadata` object must contain between 1 and 10 parameters as key-value pairs.
 
-Each parameter key must be a unique case-insensitive string between 1 and 30 characters long. If 2 or more keys are identical, the API will remove all but one of the identical keys from the `metadata` object.
+Each parameter key must be a unique, case-insensitive string between 1 and 30 characters long. If 2 or more keys are identical, the API will remove all but one of the identical keys from the `metadata` object.
 
 The data type of each parameter value must be either a:
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -411,7 +411,6 @@ This example request creates a payment for a £100 fine and adds a ledger code a
   "reference" : "WA5678",
   "description": "Pay a fine for a late tax filing.",
   "return_url": "https://your.service.gov.uk/completed",
-  "language": "cy",
   "metadata": {
     "ledger_code": "AB100",
     "an_internal_reference_number": 200


### PR DESCRIPTION
### Context
We have some odd example API requests throughout the Pay documentation. Some of them are too verbose, and some pages need examples but don’t have them. 

For example, on the [Take a payment](https://docs.payments.service.gov.uk/making_payments/#creating-a-payment) page, the first request example should be as simple as possible and just contain the required parameters - `amount`, `reference`, `description`, and `return_url`. Instead, it (confusingly) contains lots of optional parameters, like `delayed_capture` and `prefilled_cardholder_details`. 

This is unnecessary when we consider the probable user of this page - a developer that’s new to Pay and wants to know how to create a basic payment.

### Changes proposed in this pull request
* Take a payment
  * removes optional parameters from the first create payment request example
  * fixes a link to the metadata page
* Delay taking a payment
  * adds a simple request example + endpoint
* Prefill payment fields
  * adds the create payment endpoint before the request example
  * adds the required create payment parameters to the example for clarity
* Use Welsh on your payment pages
  * adds a request body example + endpoint (with Welsh `description`)
  * restructures the page with a H2 because it was a bit of a wall of text
  * clarifies the Welsh service name behaviour
* Report and reconcile payments
  * adds the create payment endpoint to the metadata heading
  * adds the required create payment parameters to the metadata example
* changed some code samples that were incorrectly displaying as `javascript` into `json`