### PR TITLE
PP-12251: Adds some signposting to some API-only features

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 2100
 
 This section tells you how to take a payment using the GOV.UK Pay API.
 
-If you want to take payments using our no-code solution, you can use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+If you want to take payments using a no-code solution instead, you can use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 When your user makes a payment, your service should supply a `reference`. If
 possible, this should be a unique identifier for the payment. If your
@@ -23,7 +23,7 @@ payment journey on GOV.UK Pay ends.
 
 ## Creating a payment
 
-The endpoint to create a payment with the GOV.UK Pay API is:
+To create a payment with the GOV.UK Pay API, use this endpoint:
 
 `POST  /v1/payments`
 

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 2100
 
 This section tells you how to take a payment using the GOV.UK Pay API.
 
-If you want to take payments using a no-code solution instead, you can use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+You can also take payments using our no-code solution, [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
 
 When your user makes a payment, your service should supply a `reference`. If
 possible, this should be a unique identifier for the payment. If your

--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -9,6 +9,8 @@ weight: 2100
 
 This section tells you how to take a payment using the GOV.UK Pay API.
 
+If you want to take payments using our no-code solution, you can use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+
 When your user makes a payment, your service should supply a `reference`. If
 possible, this should be a unique identifier for the payment. If your
 organisation already has an existing identifier for payments, you can use it
@@ -21,7 +23,7 @@ payment journey on GOV.UK Pay ends.
 
 ## Creating a payment
 
-The request to create a payment with the GOV.UK Pay API is:
+The endpoint to create a payment with the GOV.UK Pay API is:
 
 `POST  /v1/payments`
 

--- a/source/moto_payments/moto_api/index.html.md.erb
+++ b/source/moto_payments/moto_api/index.html.md.erb
@@ -15,13 +15,20 @@ Make sure you've [turned on MOTO (telephone or post) payments on your account](/
 
 <%= warning_text('If your payment service provider is Worldpay, you must use an API key from your MOTO service.')%>
 
-1. [Use the API to create a payment](/making_payments/#creating-a-payment) (`POST /v1/payments`) and include `"moto": true` in the request body.
-
-1. Go to the [`next_url`](/making_payments/#receiving-the-api-response) included in the body of the response to your API request.
-
-1. Fill in your user’s payment details on the **Enter payment details** page. The **Enter payment details** page will not have a billing address field, even if you've turned on  billing address collection on your service.
-
-1. Confirm the payment on the **Confirm your payment** page. You will not need to do 3D Secure confirmation.
+1. [Use the API to create a payment](/making_payments/#creating-a-payment) (`POST /v1/payments`) and include `"moto": true` in the request body:
+  
+    ```json
+    {
+      "amount": 14500,
+      "reference" : "12345",
+      "description": "Pay your council tax",
+      "return_url": "https://your.service.gov.uk/payment_complete_page",
+      "moto": true
+    }
+    ```
+2. Go to the `next_url` included in the response to your API request.
+3. Enter your user’s payment details on the **Enter payment details** page. The **Enter payment details** page will not have a billing address field, even if you've turned on  billing address collection on your service.
+4. Confirm the payment on the **Confirm your payment** page. You will not need to do 3D Secure confirmation.
 
 ### Taking a payment by post
 

--- a/source/moto_payments/moto_api/index.html.md.erb
+++ b/source/moto_payments/moto_api/index.html.md.erb
@@ -15,7 +15,7 @@ Make sure you've [turned on MOTO (telephone or post) payments on your account](/
 
 <%= warning_text('If your payment service provider is Worldpay, you must use an API key from your MOTO service.')%>
 
-1. [Use the API to create a payment](/making_payments/#creating-a-payment) (`POST /v1/payments`) and include `"moto": true` in the request body:
+1. Use the [`POST /v1/payments` endpoint](/making_payments/#creating-a-payment) to request a payment and include `"moto": true` in the request body:
   
     ```json
     {

--- a/source/moto_payments/moto_api/index.html.md.erb
+++ b/source/moto_payments/moto_api/index.html.md.erb
@@ -27,8 +27,8 @@ Make sure you've [turned on MOTO (telephone or post) payments on your account](/
     }
     ```
 2. Go to the `next_url` included in the response to your API request.
-3. Enter your user’s payment details on the **Enter payment details** page. The **Enter payment details** page will not have a billing address field, even if you've turned on  billing address collection on your service.
-4. Confirm the payment on the **Confirm your payment** page. You will not need to do 3D Secure confirmation.
+3. On the **Enter payment details** page, enter your user’s payment details. The **Enter payment details** page does not have a billing address field, even if you've turned on billing address collection on your service.
+4. On the **Confirm your payment** page, confirm the payment details. You will not need to do a 3D Secure confirmation.
 
 ### Taking a payment by post
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 1300
 
 # How GOV.UK Pay works
 
-This section outlines the payment flow for paying users and services using GOV.UK Pay.
+This section outlines the payment flow for paying users and services using GOV.UK Pay. It focuses on services that integrate with the GOV.UK Pay API.
 
 ## Overview
 

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -21,9 +21,9 @@ Your service has [additional responsibilities when taking recurring payments](/r
 * telling users when you’re going to take or change payments 
 * letting users amend their recurring payments
 
-It would be helpful to familiarise yourself [the standard GOV.UK Pay payment flow](/payment_flow) before reading about recurring payments.
+You should be familiar with [the standard GOV.UK Pay payment flow](/payment_flow) before reading about recurring payments.
 
-This section outlines the recurring payment flow, your responsibilities, and how to set up and use agreements to take recurring payments.
+This page explains the recurring payment flow, your responsibilities, and how to set up and use agreements to take recurring payments.
 
 ## How recurring payments work
 

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -9,6 +9,8 @@ weight: 2200
 
 You can take recurring payments from a user using GOV.UK Pay. The user consents to making recurring payments, enters into an ‘agreement’ with your service, and provides their payment details. The agreement lets you take further payments through our API without the user interacting with your service again.
 
+You'll need a technical team to integrate with our API and start taking recurring payments. We do not currently offer a no-code way of taking recurring payments.
+
 Your service has [additional responsibilities when taking recurring payments](/recurring_payments/#1-understand-what-your-service-is-responsible-for). You’re responsible for:
 
 * managing the relationship between your service and users
@@ -18,6 +20,8 @@ Your service has [additional responsibilities when taking recurring payments](/r
 * managing payment schedules
 * telling users when you’re going to take or change payments 
 * letting users amend their recurring payments
+
+It would be helpful to be familiar with [the standard GOV.UK Pay payment flow](/payment_flow) before reading about recurring payments.
 
 This section outlines the recurring payment flow, your responsibilities, and how to set up and use agreements to take recurring payments.
 

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -21,7 +21,7 @@ Your service has [additional responsibilities when taking recurring payments](/r
 * telling users when you’re going to take or change payments 
 * letting users amend their recurring payments
 
-It would be helpful to be familiar with [the standard GOV.UK Pay payment flow](/payment_flow) before reading about recurring payments.
+It would be helpful to familiarise yourself [the standard GOV.UK Pay payment flow](/payment_flow) before reading about recurring payments.
 
 This section outlines the recurring payment flow, your responsibilities, and how to set up and use agreements to take recurring payments.
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -7,9 +7,9 @@ weight: 4100
 
 # Refund a payment
 
-You can refund all or part of a payment using the GOV.UK Pay API.
+<%= warning_text('If you are a member of the public trying to get a refund, please contact the department you made the payment to. This page is for civil servants that take payments with GOV.UK Pay. ') %>
 
-You can also refund a payment by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+You can refund all or part of a payment using the GOV.UK Pay API or by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login). This page focuses on refunding through our API.
 
 Your user will receive the refund in the same account they originally paid from. You cannot refund a payment to another card or bank account.
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -7,9 +7,9 @@ weight: 4100
 
 # Refund a payment
 
-<%= warning_text('If you are a member of the public trying to get a refund, please contact the department you made the payment to. This page is for civil servants that take payments with GOV.UK Pay. ') %>
+<%= warning_text('If you are a member of the public trying to get a refund, please contact the government department you made the payment to. This page is for civil servants that take payments with GOV.UK Pay. ') %>
 
-You can refund all or part of a payment using the GOV.UK Pay API or by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login). This page focuses on refunding through our API.
+You can refund all or part of a payment using the GOV.UK Pay API or by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login). This page focuses on refunding payments using our API.
 
 Your user will receive the refund in the same account they originally paid from. You cannot refund a payment to another card or bank account.
 

--- a/source/refunding_payments/index.html.md.erb
+++ b/source/refunding_payments/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 4100
 
 # Refund a payment
 
-<%= warning_text('If you are a member of the public trying to get a refund, please contact the government department you made the payment to. This page is for civil servants that take payments with GOV.UK Pay. ') %>
+<%= warning_text('If you are a member of the public requesting a refund, please contact the department you made the payment to. This page is for civil servants that take payments with GOV.UK Pay. ') %>
 
 You can refund all or part of a payment using the GOV.UK Pay API or by signing into the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login). This page focuses on refunding payments using our API.
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 3300
 
 # Receive automatic payment event updates using webhooks
 
-This section tells you how to use webhooks to automatically receive updates after payment events. You'll need a technical team to build webhooks integration.
+This section tells you how to use webhooks to automatically receive updates after payment events. You'll need a technical team to build a webhooks integration.
 
 A webhook is when GOV.UK Pay sends automatic `POST` requests to your service after payment events. A payment event is when a payment reaches a milestone in its journey and its `state` updates, such as when it’s created, paid, or refunded.
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 3300
 
 # Receive automatic payment event updates using webhooks
 
-This section tells you how to use webhooks to automatically receive updates after payment events.
+This section tells you how to use webhooks to automatically receive updates after payment events. You'll need a technical team to build webhooks integration.
 
 A webhook is when GOV.UK Pay sends automatic `POST` requests to your service after payment events. A payment event is when a payment reaches a milestone in its journey and its `state` updates, such as when it’s created, paid, or refunded.
 


### PR DESCRIPTION
### Context
A lot of the pages in the tech docs have pre-requisites that we don’t really spell out. For example, ‘Take recurring payments’ makes more sense if readers have an understanding of how standard payments work. Similarly, ‘Take a payment’ requires users to have some technical knowledge to understand how APIs work.

### Changes proposed in this pull request
This PR:

* tells services that they'll need a technical team to:
  * take recurring payments 
  * use webhooks
* directs services to payment links if they don't have a tech team
* warns members of the public that the 'Refunding a payment' page is not for them
* adds a request example to a MOTO payment docs page

### Guidance to review
