### PR TITLE
PP-12078: Removed Postman and Insomnia recommendations

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -88,7 +88,7 @@ Make sure you [keep your API keys safe](/security/#securing-your-developer-keys)
 
 You can make test API requests to GOV.UK Pay, using your test API key for [authentication](/api_reference/#authentication).
 
-You can use API testing tools such as <a href="https://www.getpostman.com/">Postman</a> or <a href="https://insomnia.rest/">Insomnia REST</a> to make test API requests.
+You can use API testing tools such as [Bruno](https://www.usebruno.com/) to make test API requests.
 
 This is an example API request and request body to create a new payment for a passport application:
 


### PR DESCRIPTION
Change stems from docs review.

This PR removes Postman and Insomnia as recommended API clients for testing, because of recent security concerns.

Replaced with Bruno, the client the team has been widely using since Postman.