### PR TITLE
PP-12629 Update API docs with quoted field names

### DIFF
--- a/source/api_reference/create_an_agreement_reference/index.html.md.erb
+++ b/source/api_reference/create_an_agreement_reference/index.html.md.erb
@@ -42,9 +42,9 @@ This example request creates an agreement for the service to take council tax fr
 
 ```json
 {
-reference : "CT-22-23-0001",
-description : "Dorset Council 2022/23 council tax subscription."
-user_identifier: "user-3fb81107-76b7-4910"
+"reference": "CT-22-23-0001",
+"description": "Dorset Council 2022/23 council tax subscription."
+"user_identifier": "user-3fb81107-76b7-4910"
 }
 ```
 

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -463,10 +463,10 @@ Example response:
 
 ```json
 {
-  total: 45,
-  count: 20,
-  page: 1,
-  results: [
+  "total": 45,
+  "count": 20,
+  "page": 1,
+  "results": [
     {
       "agreement_id": "cgc1ocvh0pt9fqs0ma67r42l58",
       "reference": "CT-22-23-0001",


### PR DESCRIPTION
With this change, we are updating the public tech docs, making sure that all JSON fields are quoted.

Further information in JIRA.

https://payments-platform.atlassian.net/browse/PP-12629

