### PR TITLE
PP-12559 Migrate from google analytics to gtag

### DIFF
--- a/source/javascripts/analytics.js
+++ b/source/javascripts/analytics.js
@@ -1,99 +1,26 @@
 /**
- * Load and configure google analytics, managed independently from the core
+ * Load and configure google analytics (GA4), managed independently from the core
  * tech docs gem to allow running it exclusively based on custom
  * payments.service.gov.uk analytics consent rules.
  */
-function initialiseGoogleAnalytics() {
-  loadGoogleAnalytics()
-}
 
-function getCookieDomain () {
-  return window.location.hostname.replace(/^(www.){0,1}(docs.){0,1}/, '.')
-}
 
-/**
- * Allow only fetching files from Google if consent has been provided by the
- * user.
- * Forked from https://github.com/alphagov/tech-docs-gem/blob/90b6ac06e79aa155592f6ffe08d522b922483c6c/lib/source/layouts/_analytics.erb
- */
-function loadGoogleAnalytics() {
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+function initialiseGtag() {
+    var gtagScript = document.createElement('script')
+    gtagScript.async = true
+    gtagScript.setAttribute('src', 'https://www.googletagmanager.com/gtag/js?id=G-XE9K05CFFE')
+    document.head.appendChild(gtagScript)
 
-  ga('create', 'UA-72121642-9', getCookieDomain());
-  ga('set', 'anonymizeIp', true);
-  ga('set', 'displayFeaturesTask', null);
-  ga('set', 'transport', 'beacon');
-  ga('set', 'page', location.pathname+location.search+location.hash);
-  ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
 
-	configureGoogleAnalytics(jQuery)
-}
-
-/**
- * Customise Google Analytics for the tech docs format, only configured provided
- * user consent and fetched analytics files from Google.
- * Forked from https://github.com/alphagov/tech-docs-gem/blob/f28d9dced2fbc0bc7d221ed82f696b81c958a03e/lib/assets/javascripts/_analytics.js
- */
-function configureGoogleAnalytics($) {
-	function trackLinkClick (action, $element) {
-    var linkText = $.trim($element.text())
-    var linkURL = $element.attr('href')
-    var label = linkText + '|' + linkURL
-
-    ga(
-      'send',
-      'event',
-      'SM Technical Documentation', // Event Category
-      action, // Event Action
-      label // Event Label
-    )
-  }
-
-  function linkTrackingEventHandler (action) {
-    return function () {
-      trackLinkClick(action, $(this))
-    }
-  }
-
-  function catchBrokenFragmentLinks () {
-    var fragment = window.location.hash
-    var $target = $(fragment)
-    if (!$target.get(0)) {
-      ga(
-        'send',
-        'event',
-        'Broken fragment ID', // Event Category
-        'pageview', // Event Action
-        window.location.pathname + fragment // Event Label
-      )
-    }
-  }
-
-  $(document).on('ready', function () {
-    if (typeof ga === 'undefined') {
-      return
+    function gtag() {
+        dataLayer.push(arguments);
     }
 
-    $('.technical-documentation a').on('click', linkTrackingEventHandler('inTextClick'))
-    $('.header a').on('click', linkTrackingEventHandler('topNavigationClick'))
-    $('.toc a').on('click', linkTrackingEventHandler('tableOfContentsNavigationClick'))
-    catchBrokenFragmentLinks()
-
-    // Borrowed from:
-    // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
-    window.stripPIIFromString = function (string) {
-      var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
-      var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
-      var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
-      var stripped = string.replace(EMAIL_PATTERN, '[email]')
-        .replace(DATE_PATTERN, '[date]')
-        .replace(POSTCODE_PATTERN, '[postcode]')
-      return stripped
+    gtagScript.onload = function () {
+        gtag('js', new Date());
+        gtag('config', 'G-XE9K05CFFE');
     }
-  })
 }
 
-window.initialiseGoogleAnalytics = initialiseGoogleAnalytics
+window.initialiseGtag = initialiseGtag

--- a/source/javascripts/application.min.js
+++ b/source/javascripts/application.min.js
@@ -4,10 +4,10 @@
 
 window.addEventListener('DOMContentLoaded', function() {
   if (window.GovUkPay) {
-    window.GovUkPay.cookies.showBannerIfConsentNotSet(window.initialiseGoogleAnalytics)
+    window.GovUkPay.cookies.showBannerIfConsentNotSet(window.initialiseGtag)
 
     if (window.GovUkPay.cookies.hasAnalyticsConsent()) {
-      window.initialiseGoogleAnalytics()
+      window.initialiseGtag()
     }
   }
 })

--- a/source/javascripts/application.test.js
+++ b/source/javascripts/application.test.js
@@ -11,7 +11,7 @@ describe("Application JS", () => {
     document.cookie = "govuk_pay_cookie_policy=;expires=Thu, 01 Jan 1970 00:00:00 UTC;domain=.example.org";
 
     window.GovUkPay.cookies.showBannerIfConsentNotSet = jest.fn()
-    window.initialiseGoogleAnalytics = jest.fn()
+    window.initialiseGtag = jest.fn()
 
     // Override Document ready function in the test
     window.addEventListener = (event, callback) => {
@@ -33,7 +33,7 @@ describe("Application JS", () => {
     require("./application")
 
     expect(
-      window.initialiseGoogleAnalytics.mock.calls.length
+      window.initialiseGtag.mock.calls.length
       ).toBe(0);
   });
 
@@ -43,7 +43,7 @@ describe("Application JS", () => {
     require("./application")
 
     expect(
-      window.initialiseGoogleAnalytics.mock.calls.length
+      window.initialiseGtag.mock.calls.length
       ).toBe(0);
   });
 
@@ -54,7 +54,7 @@ describe("Application JS", () => {
     require("./application")
 
     expect(
-      window.initialiseGoogleAnalytics.mock.calls.length
+      window.initialiseGtag.mock.calls.length
     ).toBe(1);
   });
 });


### PR DESCRIPTION
### Context
Google is sunsetting Universal Analytics (GA3) at the end of June 2024.

The new version of analytics, GA4, recommends the use of Google Tag Manager. This is a functionality provided by Google, whereby arbitrary code may be entered into the Google Analytics console and then injected into a script on the application page.

The Google Tag Manager process bypasses Pay's [secure development requirements](https://manual.payments.service.gov.uk/manual/policies-and-procedures/software-development-lifecycle.html) (prioritisation, code written by trained software developers, code review and security testing) and is therefore not acceptable for use in any applications in the card data environment (CDE) or any applications that affect the CDE, as our PCI compliance would be at risk.

Google tag ('gtag') may be used as a static alternative to Google Tag Manager (see [Google's documentation for more information about the difference between the two](https://support.google.com/tagmanager/answer/7582054?hl=en)). This method does not include any code modifiable in the console and as such is suitable for use by GOV.UK Pay.


### Changes proposed in this pull request
Implementation of gtag and removal of GA code.

### Guidance to review
See Jira ticket [PP-12559](https://payments-platform.atlassian.net/browse/PP-12559) . If you want to see this working locally you will need to rename the `application.min.js` file `application.js`

[PP-12559]: https://payments-platform.atlassian.net/browse/PP-12559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ