### PR TITLE
PP-12761: Rename default branch to main

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: Static
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ bundle update govuk_tech_docs
 
 Read [the changelog for the gem][gem-changelog] for the latest changes.
 
-[gem-changelog]: https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md
+[gem-changelog]: https://github.com/alphagov/tech-docs-gem/blob/main/CHANGELOG.md
 
 [rvm]: https://www.ruby-lang.org/en/documentation/installation/#managers
 [bundler]: http://bundler.io/


### PR DESCRIPTION
### Context

Long overdue renaming of the default branch, to avoid outdated language and be consistent with our other repositories. I've already renamed the branch in the settings - as you can see, this PR is now attempting to merge into `main`. 

This PR changes the post-deploy workflow to trigger on merges to the `main` branch.

The tech-docs-gem repo renamed its default branch a while back, so I've updated its README link too.