### PR TITLE
PP-12763 - Adds a warning about upcoming test account changes

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 6200
 
 # Test your integration
 
-<%= warning_text('From August 2024, we will limit each GOV.UK Pay service to one live account and one test account. This is because we are simplifying our architecture.<br><br>This change will not affect most GOV.UK Pay services. If your service has more than one test account, we will be in touch to help you prepare.<br><br>Please do not request additional test accounts.') %>
+<%= warning_text('From August 2024, we will limit each GOV.UK Pay service to one live account and one test account.<br><br>This change will not affect most GOV.UK Pay services. If your service has more than one test account, we will be in touch to help you prepare.<br><br>Please do not request additional test accounts.') %>
 
 ## Testing your service
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -7,6 +7,8 @@ weight: 6200
 
 # Test your integration
 
+<%= warning_text('From August 2024, we will limit each GOV.UK Pay service to one live account and one test account. This is because we are simplifying our architecture.<br><br>This change will not affect most GOV.UK Pay services. If your service has more than one test account, we will be in touch to help you prepare.<br><br>Please do not request additional test accounts.') %>
+
 ## Testing your service
 
 You can use your test account to:


### PR DESCRIPTION
### Context


### Changes proposed in this pull request
Adds a small warning to the top of the 'Test your integration' page, telling users we will be limiting test accounts and to not request any more.
