### PR TITLE
PP-13009 - Updated PCI 3.2.1 reference to 4.0

### DIFF
--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -37,7 +37,7 @@ How you turn on MOTO payments on a live account differs depending on whether you
 
 #### Stripe - turn on MOTO payments on a live account
 
-1. Make sure you comply with the [Payment Card Industry Data Security Standards (PCI DSS)](https://www.pcisecuritystandards.org/document_library?category=pcidss&document=pci_dss).
+1. Make sure you comply with the most recent version of the [Payment Card Industry Data Security Standards (PCI DSS)](https://www.pcisecuritystandards.org/document_library?category=pcidss&document=pci_dss).
 
 1. Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to confirm you are PCI DSS compliant and would like to take MOTO payments on your account. We’ll email you to let you know we’ve turned on MOTO payments.
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -95,12 +95,15 @@ data must comply with the [Payment Card Industry Data Security
 Standards](https://www.pcisecuritystandards.org/document_library?category=pcidss&document=pci_dss) (PCI DSS).
 
 GOV.UK Pay is certified as fully compliant as a Level 1 Service Provider with
-PCI DSS version 3.2.1. All GOV.UK Pay partners must be compliant with PCI DSS,
-and must validate their compliance annually.
+PCI DSS version 4.0. 
 
-A Qualified Security Assessor will audit GOV.UK Pay against PCI DSS v4.0 in summer 2024. After this audit, we'll update all relevant PCI DSS documentation. 
+All GOV.UK Pay partners and any services that take MOTO payments through GOV.UK Pay must comply with PCI DSS v4.0 by March 2025.
 
-You may be asked to provide certain information from GOV.UK Pay as part of your own PCI DSS compliance process. Some of this information may not be available until we've completed our PCI DSS v4.0 transition work. This should not affect your ability to comply with PCI DSS v4.0 because there is a recognised transition period.
+If your service takes MOTO payments, you should familiarise yourself with the [the changes from PCI DSS v3.2.1 to v4.0](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r2.pdf). You must make sure your organisation complies with these changes by March 2025.
+
+GOV.UK Pay services that take MOTO payments must also validate their PCI DSS compliance annually.
+
+You may be asked to provide certain information from GOV.UK Pay as part of your own PCI DSS compliance process. You can see our PCI DSS Attestation of Compliance by signing into [the GOV.UK Pay admin tool](https://selfservice.pymnt.uk/my-services) and selecting Attestation of Compliance for PCI in the footer.
 
 ### Use your Merchant ID to report PCI DSS compliance
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -97,11 +97,9 @@ Standards](https://www.pcisecuritystandards.org/document_library?category=pcidss
 GOV.UK Pay is certified as fully compliant as a Level 1 Service Provider with
 PCI DSS version 4.0. 
 
-All GOV.UK Pay partners and any services that take MOTO payments through GOV.UK Pay must comply with PCI DSS v4.0 by March 2025.
+All GOV.UK Pay partners and any services that take MOTO payments through GOV.UK Pay must comply with PCI DSS v4.0 by 31 March 2025.
 
-If your service takes MOTO payments, you should familiarise yourself with the [the changes from PCI DSS v3.2.1 to v4.0](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r2.pdf). You must make sure your organisation complies with these changes by March 2025.
-
-GOV.UK Pay services that take MOTO payments must also validate their PCI DSS compliance annually.
+If your service takes MOTO payments, you should familiarise yourself with the [the changes from PCI DSS v3.2.1 to v4.0](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r2.pdf).
 
 You may be asked to provide certain information from GOV.UK Pay as part of your own PCI DSS compliance process. You can see our PCI DSS Attestation of Compliance by signing into [the GOV.UK Pay admin tool](https://selfservice.pymnt.uk/my-services) and selecting Attestation of Compliance for PCI in the footer.
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -101,7 +101,7 @@ All GOV.UK Pay partners and any services that take MOTO payments through GOV.UK 
 
 If your service takes MOTO payments, you should familiarise yourself with the [the changes from PCI DSS v3.2.1 to v4.0](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r2.pdf).
 
-You may be asked to provide certain information from GOV.UK Pay as part of your own PCI DSS compliance process. You can see our PCI DSS Attestation of Compliance by signing into [the GOV.UK Pay admin tool](https://selfservice.pymnt.uk/my-services) and selecting Attestation of Compliance for PCI in the footer.
+You may be asked to provide certain information from GOV.UK Pay as part of your own PCI DSS compliance process. You can see our PCI DSS Attestation of Compliance by signing into [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services) and selecting Attestation of Compliance for PCI in the footer.
 
 ### Use your Merchant ID to report PCI DSS compliance
 


### PR DESCRIPTION
### Context
GOV.UK Pay is now compatible with PCI DSS v4.0. Our services need to comply by March 2025.

### Changes proposed in this pull request
This PR updates references to 3.2.1 to 4.0. It also removes text about our 'upcoming 4.0 updates'.