### PR TITLE
PP-13093: Changes to reflect the new test account system

### DIFF
--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -18,6 +18,7 @@ Before you start using GOV.UK Pay, you should:
 * read how to [get started](https://www.payments.service.gov.uk/getstarted/) and decide if GOV.UK
 Pay is right for your service
 * sign up to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/register/email-address)
+* create a service in the GOV.UK Pay admin tool
 * read the GOV.UK Service Manual guidance on [deploying new
 software](https://www.gov.uk/service-manual/making-software/deployment.html)
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -59,7 +59,7 @@ lets you:
 
 You'll be able to create API keys for 2 different accounts. These are your:
 
-- test ('sandbox') account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
+- test account, for [testing the GOV.UK Pay API and your service](/testing_govuk_pay)
 - live account, for taking payments from your users after you [switch to live](/switching_to_live)
 
 If your payment service provider (PSP) is Stripe, you can also ask us for a test Stripe account so you can see how [transaction fees](/reporting/#psp-fees) and payments to your bank account work.

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -26,10 +26,10 @@ Compared to your test account, your live account may have a:
 
 ## 1. Request a live GOV.UK Pay account
 
-You'll need to:
+During the going live process, you'll need to:
 
 - provide your organisation's name and address
-- tell us if you’ll be using GOV.UK Pay’s PSP Stripe, or another PSP
+- confirm the PSP you chose when you created your service
 - read and accept our legal terms
 
 Select your test ('sandbox') account or your test Stripe account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services), then select __Request a live account__.

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -26,7 +26,7 @@ Compared to your test account, your live account may have a:
 
 ## 1. Request a live GOV.UK Pay account
 
-During the going live process, you'll need to:
+During the go live process, you'll need to:
 
 - provide your organisation's name and address
 - confirm the PSP you chose when you created your service

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -18,12 +18,12 @@ Each GOV.UK Pay service has:
 
 Your test account type depends on your chosen payment service provider (PSP). 
 
-| Payment service provider (PSP) | Test account type    |
+| Payment service provider       | Test account type    |
 | ------------------------------ | -------------------  |
 | Stripe                         | Stripe test account  |
 | Worldpay                       | Sandbox test account |
 
-You're limited to one test account per GOV.UK Pay service. For example, if you have a Stripe test account and request a sandbox test account, the sandbox account will replace the Stripe test account. You will lose your test data and API keys.
+You're limited to one test account per GOV.UK Pay service. For example, if you have a sandbox test account and request a Stripe test account, the Stripe account will replace the sandbox account. You will lose your test data and API keys.
 
 ### Request a Stripe test account
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -7,7 +7,43 @@ weight: 6200
 
 # Test your integration
 
-<%= warning_text('From August 2024, we will limit each GOV.UK Pay service to one live account and one test account.<br><br>This change will not affect most GOV.UK Pay services. If your service has more than one test account, we will be in touch to help you prepare.<br><br>Please do not request additional test accounts.') %>
+<%= warning_text('From September 2024, we will limit each GOV.UK Pay service to one live account and one test account.<br><br>This change will not affect most GOV.UK Pay services. If your service has more than one test account, we will be in touch to help you prepare.<br><br>Please do not request additional test accounts.') %>
+
+## How test accounts work in GOV.UK Pay
+
+Each GOV.UK Pay service has:
+
+* one test account to test how GOV.UK Pay works
+* one live account to take real payments from users
+
+Your test account type depends on your chosen payment service provider (PSP). 
+
+| Payment service provider (PSP) | Test account type    |
+| ------------------------------ | -------------------  |
+| Stripe                         | Stripe test account  |
+| Worldpay                       | Sandbox test account |
+
+You're limited to one test account per GOV.UK Pay service. For example, if you have a Stripe test account and request a sandbox test account, the sandbox account will replace the Stripe test account. You will lose your test data and API keys.
+
+### Request a Stripe test account
+
+If you created your GOV.UK Pay service before September 2024 and chose Stripe as your PSP, you may have a sandbox test account. You can swap this for a Stripe test account. 
+
+You can use a Stripe test account to see how the following work:
+
+* [transaction fees](/reporting/#psp-fees)
+* payments to your bank account
+
+To request a Stripe test account, you need to use the admin tool. 
+
+1. [Sign in to the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+1. Select Test account (sandbox) for your service. 
+1. From the Dashboard page, select Test Stripe’s reporting functionality and follow the instructions.
+
+<%= warning_text('Your Stripe test account will replace your sandbox test account. You will lose any test data and API keys in your sandbox account.
+.') %>
+
+Stripe test accounts have [a different set of mock card numbers](#if-you-39-re-using-a-test-stripe-account).
 
 ## Testing your service
 
@@ -34,11 +70,6 @@ You can also:
 - test any [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/) you have set up
 
 You cannot use 3D Secure (3DS) with test accounts.
-
-If your payment service provider (PSP) is Stripe, you can request a test Stripe account from your account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services). You can use a test Stripe account to see how the following work:
-
-- [transaction fees](/reporting/#psp-fees)
-- payments to your bank account
 
 ## Performance testing
 


### PR DESCRIPTION
### Context
When organisations create a service, we now ask them what type of organisation they are. Their answer will determine the type of test account we give them (Stripe or sandbox)

### Changes proposed in this pull request

- **Test your integration**
  - Reword it so that the ‘default’ is for Stripe services to have a Stripe test account, Worldpay services to have sandbox test account
  - Reflect new process for requesting a Stripe test account
- **Quick start**
  - Mention that you need to add a new service (this should be there already but isn’t) 
- **Go live**
  - Change wording of ‘tell us your PSP’ to something like ‘confirm your PSP’ because organisations have already chosen their PSP during service creation