### PR TITLE
PP-11927: Redundant entry info for WCAG 2.2

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -57,6 +57,13 @@ Your user has 90 minutes to complete their payment once you have created it.
 
 You can see definitions, values, and the limits of every parameter for this endpoint in our [API reference](/api_reference/create_a_payment_reference).
 
+### Avoid redundant entry
+
+[Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry) specifies that ‘services should avoid asking users for the same information twice in the same session’. 
+
+Consider prefilling some payment fields if your service already collects any details the user will need to enter when they pay. To do this, include the `prefilled_cardholder_details` object when you create the payment. You can [read more about how to prefill payment fields](/optional_features/prefill_user_details).
+
+
 #### amount
 
 The `amount` parameter sets the payment amount in pence. `amount` must be a number.

--- a/source/optional_features/prefill_user_details/index.html.md.erb
+++ b/source/optional_features/prefill_user_details/index.html.md.erb
@@ -9,6 +9,8 @@ weight: 5240
 
 If you collect your users' details in your service before you redirect them to GOV.UK Pay, you can prefill some of the fields on the __Enter payment details__ page. If you prefill fields, your users should not need to enter their details twice.
 
+This can also help you meet [the ‘redundant entry’ requirement for the Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry), which specifies that services should not ask for the same information twice in the same session.
+
 Your users can still edit these details before they complete their payment.
 
 To prefill fields, include the following optional parameters in the API request when you [create a new payment](/making_payments/#creating-a-payment):


### PR DESCRIPTION
### Context
WCAG 2.2 specifies that services should not ask users for the same information twice in a single session. We should encourage Pay services to use the `prefilled_cardholder_information` object if they already gather user's information before handing over to Pay.

### Changes proposed in this pull request
* suggests prefilling cardholder information in the Take a payment page
* explains that prefilling can help WCAG 2.2 in the Prefill cardholder information page

