### PR TITLE
PP-13107: Add instructions for requesting a Worldpay test account

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -62,6 +62,8 @@ You can test the entire payment journey with a standard GOV.UK Pay test account,
 * smoke testing
 * viewing and refunding transactions through the admin tool
 
+If you get a Worldpay test account, you should not use it for long term, automated testing.
+
 Email GOV.UK Pay support (govuk-pay-support@digital.cabinet-office.gov.uk) to request a Worldpay test account.
 
 ## Testing your service

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -49,6 +49,21 @@ Test data and API keys in your sandbox test account will not be available in you
 
 Stripe test accounts have [a different set of mock card numbers](#if-you-39-re-using-a-test-stripe-account).
 
+### Get a Worldpay test account
+
+It’s possible to link a Worldpay test account to GOV.UK Pay. Some services might find a Worldpay test account useful to connect GOV.UK Pay to Worldpay’s reporting products.
+
+For most organisations, a Worldpay test account is not necessary and we do not recommend using it. GOV.UK Pay cannot support you if you encounter problems.
+
+You can test the entire payment journey with a standard GOV.UK Pay test account, as well as:
+
+* the full API-initiated payment journey
+* reporting using our API
+* smoke testing
+* viewing and refunding transactions through the admin tool
+
+Email GOV.UK Pay support (govuk-pay-support@digital.cabinet-office.gov.uk) to request a Worldpay test account.
+
 ## Testing your service
 
 You can use your test account to:

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -57,7 +57,6 @@ For most organisations, a Worldpay test account is not necessary and we do not r
 
 You can test the entire payment journey with a standard GOV.UK Pay test account, as well as:
 
-* the full API-initiated payment journey
 * reporting using our API
 * smoke testing
 * viewing and refunding transactions through the admin tool

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -57,9 +57,9 @@ For most organisations, a Worldpay test account is not necessary and we do not r
 
 You can test the entire payment journey with a standard GOV.UK Pay test account, as well as:
 
-* reporting using our API
+* reporting on payments
 * smoke testing
-* viewing and refunding transactions through the admin tool
+* viewing and refunding transactions
 
 If you get a Worldpay test account, you should not use it for long term, automated testing.
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -63,7 +63,7 @@ You can test the entire payment journey with a standard GOV.UK Pay test account,
 
 If you get a Worldpay test account, you should not use it for long term, automated testing.
 
-Email GOV.UK Pay support (govuk-pay-support@digital.cabinet-office.gov.uk) to request a Worldpay test account.
+Email GOV.UK Pay support (govuk-pay-support@digital.cabinet-office.gov.uk) to request a Worldpay test account. If GOV.UK Pay support approves your request, we will add your Worldpay test account as a separate GOV.UK Pay service.
 
 ## Testing your service
 


### PR DESCRIPTION
### Context
Services can connect Worldpay test accounts to Pay, but we want to heavily discourage them.

### Changes proposed in this pull request
Adds a small section to the 'Test your integration' page that outlines how to request a Worldpay test account.