### PR TITLE
PP-13550: Update accessibility statement and page titles

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,7 +3,7 @@ host: https://docs.payments.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true
-service_name: Pay
+service_name: Pay technical documentation
 service_link: https://www.payments.service.gov.uk/
 
 # Links to show on right-hand-side of header

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GOV.UK Pay's technical documentation
-last_reviewed_on: 2024-03-24
+last_reviewed_on: 2025-02-04
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -9,44 +9,35 @@ hide_in_navigation: true
 
 This accessibility statement applies to the GOV.UK Pay technical documentation at [https://docs.payments.service.gov.uk/](https://docs.payments.service.gov.uk/).
 
-This website is run by the GOV.UK Pay team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+This documentation is run by the GOV.UK Pay team at the Government Digital Service (GDS). We want as many people as possible to be able to use this documentation. This means you should be able to:
 
 + change colours, contrast levels and fonts
 + zoom in up to 300% without problems
-+ navigate most of the website using just a keyboard
-+ navigate most of the website using speech recognition software
-+ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
++ navigate most of the documentation using just a keyboard
++ navigate most of the documentation using speech recognition software
++ listen to most of the documentation using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
 
-We’ve also made the website text as simple as possible to understand.
+We’ve also made the text as simple as possible to understand.
 
 [AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
 
 ## How accessible this website is
 
-The GOV.UK Pay technical documentation is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
+The GOV.UK Pay technical documentation is compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG22/) AA standard.
 
-## Feedback and contact information
+This documentation was last tested for accessibility issues in January 2025.
 
-If you need any part of this service in a different format like large print, audio recording or braille, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+## What to do if you have difficulty using this documentation
 
-We’ll aim to get back to you within 3 working days.
+This documentation was last tested for accessibility issues in October 2024.
 
-## Reporting accessibility problems with this website
+If you need any part of this documentation in a different format like large print, audio recording or braille, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-## Enforcement procedure
+### If you're not happy with our response
 
-The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact [the Equality Advisory and Support Service](https://www.equalityadvisoryservice.com/), which is run on behalf of the EHRC.
 
-## Technical information about this website’s accessibility
 
-GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
-
-## How we tested this website
-
-We last tested this website for accessibility issues in October 2021.
-
-## Preparation of this accessibility statement
-
-This statement was prepared on 3 September 2020. It was last reviewed on 18 July 2023 .
+This statement was prepared on 3 September 2020. It was last reviewed on 4 February 2025.

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -33,7 +33,7 @@ This documentation was last tested for accessibility issues in October 2024.
 
 If you need any part of this documentation in a different format like large print, audio recording or braille, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
-If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
+If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk).
 
 ### If you're not happy with our response
 


### PR DESCRIPTION
### Context
In late 2024 and early 2025, we ran an accessibility audit on different parts of GOV.UK Pay, including the tech docs.

This audit identified one potential change.

### Changes proposed in this pull request
* updates the accessibility statement with new wording and headings
* updates the suffix in the page title from `Pay` to `Pay technical documentation` to make tabs more identifiable for screen reader users