### PR TITLE
PP-10644: Small fixes to MOTO API documentation

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -193,6 +193,7 @@ These error descriptions are intended for developers, not your users.
 
 | Error code | Endpoint(s) | Meaning |
 |--------------|------------|---------|
+| P0010 | Send card details to authorise a MOTO payment | The paying user's bank rejected the payment authorisation.<br><br>This is because the user entered incorrect payment details or they did not have sufficient funds in their account. |
 | P0101 | Create a payment<br><br>Send card details to authorise a MOTO payment | The request you sent is missing a required parameter.<br><br>Check the `field` attribute in the response to see which parameter is missing. |
 | P0102 | Create a payment<br><br>Send card details to authorise a MOTO payment | A header or parameter value you sent in your request is invalid.<br><br>Check the `description` attribute in the response to find out which value is invalid. |
 | P0104 | Create a payment | You included `return_url` and `"authorisation_mode": "moto_api"` in your request. These parameters cannot be used together.<br><br>Remove the `return_url` parameter to create [a Mail Order / Telephone Order (MOTO) payment that accepts card details sent through the API](/moto_payments/moto_send_card_details_api).<br><br>Remove the `authorisation_mode` parameter to [create a standard payment](/making_payments). |

--- a/source/moto_payments/moto_send_card_details_api/index.html.md.erb
+++ b/source/moto_payments/moto_send_card_details_api/index.html.md.erb
@@ -127,7 +127,18 @@ curl "https://publicapi.payments.service.gov.uk/v1/auth" \
 
 If the authorisation request is successful, you’ll receive a `204` response. The response body will be empty.
 
-If the authorisation request is unsuccessful, you’ll receive a `4xx` HTTP status code and an error code in the `code` attribute. You can see [the meanings of GOV.UK Pay API error codes in our API reference](/api_reference/#http-status-codes).
+If the authorisation request is unsuccessful, you’ll receive a `402` HTTP status code. The response body will contain a `P0010` code and a `description` of the error. 
+
+For example:
+
+```json
+{
+  "code": "P0010",
+  "description": "The payment was rejected"
+}
+```
+
+You can see [the meanings of GOV.UK Pay API error codes in our API reference](/api_reference/#gov-uk-pay-api-error-codes).
 
 We time out requests to `/v1/auth` after about 10 seconds. If your request times out, you’ll receive a `500` HTTP status code and a `P0050` API error code.
 


### PR DESCRIPTION
### Context
This is an old ticket.

The documentation around payment rejections for the MOTO API is unclear.

### Changes proposed in this pull request
This PR:

* adds the `P0100` error code to the error codes section of the API reference
* adds an example code snippet of a MOTO API failure response