### PR TITLE
BAU — Remove references to mountebank

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -72,7 +72,7 @@ You can use your test account to:
 - explore how the GOV.UK Pay API works
 - run automated [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy)
 
-Do not use your test account for automated integration tests that run every time you change your code. Build a ‘stub’ to simulate the GOV.UK Pay API instead, using a tool like [WireMock](http://wiremock.org/) or [mountebank](http://www.mbtest.org/).
+Do not use your test account for automated integration tests that run every time you change your code. Build a ‘stub’ to simulate the GOV.UK Pay API instead, using a tool like [WireMock](https://wiremock.org/).
 
 ## Testing the whole user journey
 


### PR DESCRIPTION
Per https://github.com/bbyars/mountebank mountebank is no longer maintained and the mbtest.org domain is no longer controlled by the project so remove references to it (we still suggest WireMock).