### PR TITLE
ZD-6045891 Remove reference to Mountebank

### DIFF
--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -72,7 +72,7 @@ You can use your test account to:
 - explore how the GOV.UK Pay API works
 - run automated [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy)
 
-Do not use your test account for automated integration tests that run every time you change your code. Build a ‘stub’ to simulate the GOV.UK Pay API instead, using a tool like [WireMock](http://wiremock.org/) or [mountebank](http://www.mbtest.org/).
+Do not use your test account for automated integration tests that run every time you change your code. Build a ‘stub’ to simulate the GOV.UK Pay API instead, using a tool like [WireMock](http://wiremock.org/) or [Nock](https://github.com/nock/nock).
 
 ## Testing the whole user journey
 


### PR DESCRIPTION
### Context
- Mountebank has been deprecated.
- Want to remove reference to Mountebank.

### Changes proposed in this pull request
- Replaced with a reference to Nock - as an example of a popular stubbing tool.

### Guidance to review
- Check this page no longer has a reference to Mountebank.
- Check that their is a reference and link to Nock.