### PR TITLE
PP-13395: Restructured custom branding section, minor page changes for simplified Settings

### DIFF
--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Add custom branding
-last_reviewed_on: 2024-03-24
+last_reviewed_on: 2025-03-27
 review_in: 12 months
 weight: 5210
 ---

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -7,16 +7,14 @@ weight: 5210
 
 # Add custom branding
 
-GOV.UK Pay supports custom branding of your [payment pages](/payment_flow/#1-your-user-needs-to-make-a-payment) and your payment confirmation emails.
-
-You can use custom branding regardless of whether you [integrate your service with the GOV.UK Pay API](/integrate_with_govuk_pay/#how-to-integrate-with-the-gov-uk-pay-api), or use [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/).
+GOV.UK Pay supports custom branding of your [payment pages](/payment_flow/#1-your-user-needs-to-make-a-payment), payment confirmation emails, and refund confirmation emails.
 
 For payment pages and emails, you can customise:
 
 * the logo displayed in the top banner
 * the background colour of the top banner
 
-For payment pages only, you can also customise the border colour of the top banner.
+On payment pages, you can also customise the border colour of the top banner.
 
 <%= image_tag "/images/custom-branding-diagram-large.svg", { :alt => '' } %>
 
@@ -24,26 +22,22 @@ Custom branding applies to the test and live environments for a service.
 
 To set up custom branding:
 
-1. Send us your customised banner logo and banner colours.
-2. Include contact information on your payment confirmation emails.
+1. Send us your banner logo, banner colours, and a reply-to email address (if you are customising your emails).
+2. Add contact information to your payment confirmation emails.
 
-## Send us your banner logo and banner colours
+## 1. Send us your logo, colours, and a reply-to email address
 
-[Send the GOV.UK Pay team](/support_contact_and_more_information/):
+Send an [email to the GOV.UK Pay team](/support_contact_and_more_information/) with:
 
-  - an image of your banner logo
-  - the colours of your banner background and border
+  * the services you want to apply custom branding to
+  * whether you want to apply custom branding to your payment pages, your emails, or both
+  * an image of your banner logo
+  * your banner background and border colour as a [hexadecimal colour code](https://www.w3schools.com/colors/colors_picker.asp)
+  * an email address that will receive replies from users (if you are using custom branding on payment confirmation emails)
 
-In your email, you must tell us:
+### Banner logo restrictions
 
-* which service you want to apply custom branding to
-* whether you want to apply custom branding to your payment pages, your emails, or both
-
-If you want custom branding on your emails but you do not expect to start taking payments for a while, you should wait before sending us your custom branding. Instead, send your custom branding in the weeks before you go live.
-
-### Customise your banner logo
-
-To customise your banner logo, email us an image of your banner logo. Your image should be:
+To make your banner logo is clear on every device, your image must be:
 
 * in PNG or SVG format
 * at least 600 pixels in width
@@ -51,29 +45,27 @@ To customise your banner logo, email us an image of your banner logo. Your image
 * cropped to leave minimal whitespace around the logo
 * compressed (optimised for web)
 
-If you follow these requirements, your banner logo will look clear on both mobile and non-mobile displays.
+## 2. Include contact information on your payment confirmation emails
 
-### Customise your banner colours
+If you add custom branding on your payment confirmation emails, those emails must tell your users how to contact your service. You must [add a custom paragraph to your payment confirmation emails](/optional_features/custom_paragraph) to tell users how to get in touch.
 
-For payment pages, you can customise both the background and border colours of the top banner.
+If you monitor the email address you gave us for replies from users, you can explain this in your custom paragraph. For example:
 
-For payment confirmation emails, you can only customise the background colour of the top banner.
+```
+If you have any questions about this payment, reply to this email.
+```
 
-To customise these features, email us your [hexadecimal colour codes](https://www.w3schools.com/colors/colors_picker.asp).
+If you do not monitor the email address you gave us for replies from users, you must tell your users:
 
-## Include contact information on your payment emails
+* that they should not reply to this email
+* how they can contact your service
 
-When you have custom branding on your payment confirmation emails, those emails must tell your users how to contact you.
+For example:
 
-You can include this information on your emails by using, for example, a reply-to email address or a contact form.
+```
+This email address is not monitored. Please do not reply to this email.
+												
+If you need to speak to us about this payment, please email example@example.com or call us on 0300 123 4567
+```
 
-If you use a reply-to email address, this email address can be a monitored email inbox for your service, or an unmonitored email address with an automated response.
-
-If you use an unmonitored automated email response, you should tell your users:
-
-- that the email address is unmonitored
-- how they can contact your service
-
-You can customise your email responses in the GOV.UK Pay admin tool using the `customParagraph` field in the payment receipt email template.
-
-You cannot customise your refund email.
+You cannot add custom content to your refund email.

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 5210
 
 # Add custom branding
 
-GOV.UK Pay supports custom branding of your [payment pages](/payment_flow/#1-your-user-needs-to-make-a-payment), payment confirmation emails, and refund confirmation emails.
+GOV.UK Pay supports custom branding of your payment pages, payment confirmation emails, and refund confirmation emails.
 
 For payment pages and emails, you can customise:
 
@@ -18,7 +18,7 @@ On payment pages, you can also customise the border colour of the top banner.
 
 <%= image_tag "/images/custom-branding-diagram-large.svg", { :alt => '' } %>
 
-Custom branding applies to the test and live environments for a service.
+Custom branding applies to the test and live versions of a service.
 
 To set up custom branding:
 
@@ -47,7 +47,7 @@ To make your banner logo is clear on every device, your image must be:
 
 ## 2. Include contact information on your payment confirmation emails
 
-If you add custom branding on your payment confirmation emails, those emails must tell your users how to contact your service. You must [add a custom paragraph to your payment confirmation emails](/optional_features/custom_paragraph) to tell users how to get in touch.
+If you add custom branding to payment confirmation emails, you must [add a paragraph to those emails](/optional_features/custom_paragraph) that tells users how to contact you.
 
 If you monitor the email address you gave us for replies from users, you can explain this in your custom paragraph. For example:
 

--- a/source/optional_features/custom_paragraph/index.html.md.erb
+++ b/source/optional_features/custom_paragraph/index.html.md.erb
@@ -1,0 +1,16 @@
+---
+title: Add content to your payment confirmation emails
+weight: 5215
+---
+
+# Add content to your payment confirmation emails
+
+You can add a custom paragraph to payment confirmation emails from GOV.UK Pay. A custom paragraph can give users extra information related to your service.
+
+1. Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+1. Select the service you want to change.
+1. Select **Settings**.
+1. Under **About your service**, select **Email notifications**.
+1. Select **Add a custom paragraph**.
+
+If you [have added custom branding to your payment confirmation emails](/optional_features/custom_branding/), you must use the custom paragraph to tell your users how to contact your service.

--- a/source/optional_features/custom_paragraph/index.html.md.erb
+++ b/source/optional_features/custom_paragraph/index.html.md.erb
@@ -1,5 +1,7 @@
 ---
 title: Add content to your payment confirmation emails
+last_reviewed_on: 2025-03-27
+review_in: 12 months
 weight: 5215
 ---
 

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -1,5 +1,7 @@
 ---
 title: Customise your payment pages and emails
+last_reviewed_on: 2025-03-27
+review_in: 12 months
 weight: 5200
 ---
 

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -1,13 +1,14 @@
 ---
-title: Customise your payment pages
+title: Customise your payment pages and emails
 weight: 5200
 ---
 
-# Customise your payment pages
+# Customise your payment pages and emails
 
 You can customise your payments pages with GOV.UK Pay in the following ways:
 
-* [add custom branding](/optional_features/custom_branding/#add-custom-branding) to payment pages
+* [add custom branding](/optional_features/custom_branding/#add-custom-branding) to payment pages and confirmation emails
+* [add custom content to payment confirmation emails](/optional_features/custom_paragraph)
 * [use Welsh](/optional_features/welsh_language/#use-welsh-on-your-payment-pages) on payment pages
 * [use your own payment failure pages](/optional_features/use_your_own_error_pages)
 * [prefill fields](/optional_features/prefill_user_details/) on the **Enter payment details** page

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -34,8 +34,9 @@ Your users see a [description of the payment](/payment_flow/#4-your-user-enters-
 GOV.UK Pay does not automatically translate emails into Welsh. If you want to send your own emails in Welsh, stop GOV.UK Pay sending emails:
 
 1. Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
-1. Select your service from the **Overview** page.
+1. Select your service from **My services**.
 1. Select **Settings**.
+1. Under **About your service**, select **Email notifications**.
 1. Change **Payment confirmation emails** to **Off**.
 
 [Contact us](/support_contact_and_more_information/) if you'd like us to develop a feature to automatically translate emails into Welsh.
@@ -44,7 +45,11 @@ GOV.UK Pay does not automatically translate emails into Welsh. If you want to se
 
 You can show a Welsh service name on payments that use Welsh language payment pages. 
 
-Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login) and select **Edit name** next to the service you want to add a Welsh name to.
+1. Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
+1. Select the service you want to add a Welsh name to.
+1. Select **Settings**.
+1. Under **About your service**, select **Service name**.
+1. Select **Add Welsh service name**.
 
 Your users will see:
 

--- a/source/optional_features/welsh_language/index.html.md.erb
+++ b/source/optional_features/welsh_language/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use Welsh on your payment pages
-last_reviewed_on: 2023-07-18
+last_reviewed_on: 2025-03-27
 review_in: 12 months
 weight: 5220
 ---

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Security
-last_reviewed_on: 2024-03-24
+last_reviewed_on: 2025-03-27
 review_in: 6 months
 weight: 9200
 ---

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -28,14 +28,12 @@ source code repositories.
 Follow these steps to revoke your API key immediately if you believe it has been accidentally shared or compromised:
 
 1. Sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/login).
+1. Select your service from **My services**.
+1. Select **Settings**.
+1. Under **Developers**, select **Live API keys** or **Test API keys**.
+1. Revoke all compromised API keys.
 
-2. Select the correct accounts in the [My services](https://selfservice.payments.service.gov.uk/my-services) section.
-
-3. Select **API keys**.
-
-4. Revoke all compromised API keys.
-
-<%= warning_text('If you believe your key has been used to make fraudulent payments, contact the GOV.UK support team using the urgent contact methods provided to your service manager.') %>
+<%= warning_text('If you believe your key has been used to make fraudulent payments, contact the GOV.UK Pay support team using the urgent contact methods provided to your service manager.') %>
 
 To further secure your live developer keys:
 


### PR DESCRIPTION
This PR:

* makes the following pages reflect the new simplified Settings screens:
  * using Welsh
  * Security
* updates the documented custom branding by:
  * improving what we ask for services in custom branding requests
  * correcting information about reply-to email addresses
  * adding templates for services to tell users how to get in touch in payment confirmation emails
  * adding a new page for custom content in payment confirmation emails
* changes the name of the 'Customise your payment pages' section to 'Customise your payment pages and emails' to better reflect the content
* adds link to the top-level page to the new sub-page