### PR TITLE
PP-8405: Adds information about users outside of the UK

### DIFF
--- a/source/making_payments/index.html.md.erb
+++ b/source/making_payments/index.html.md.erb
@@ -236,3 +236,16 @@ that’s not `null`, you can cancel the payment. For example:
   "method": "POST"
 }
 ```
+
+## Other considerations when taking a payment
+
+### Taking payments from users outside of the UK
+
+GOV.UK Pay only supports payments in British pounds (GBP), however users from outside of the UK can still make payments.
+
+In this situation:
+
+* the user’s bank will do a currency conversion into GBP if the payment card uses a foreign currency
+* the user’s bank may charge a conversion fee and give the user an unfavourable exchange rate
+* payments are more likely to be declined during fraud checks
+* your PSP may charge you additional transaction fees for cards issued outside the UK

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -58,7 +58,9 @@ When your service redirects your user to `next_url`, they’ll see an **Enter pa
 * billing address
 * email address
 
-If your service takes [digital wallet payments](/digital_wallets/), your user can also choose to pay with Apple Pay or Google Pay from this page.
+If your service takes [digital wallet payments](/digital_wallets/), your user can also choose to pay with Apple Pay or Google Pay from this page. 
+
+We also support [users paying from outside of the UK](/making_payments/#taking-payments-from-users-outside-of-the-uk).
 
 This page also shows the `description` and the amount your user has to pay, making it clear what they’re paying for.
 


### PR DESCRIPTION
### Context
We’ve had a few support requests wanting information about whether users can make payments from outside the UK and, if they can, how they differ from payments from within the UK.

There is not a natural place for this to live in the docs as they are, so I’m going to add a ‘Additional considerations when taking payments’ heading to the bottom of the [‘Taking a payment’ page](https://docs.payments.service.gov.uk/making_payments). This will act as a bit of a catch-all for information that does not have a natural home.

### Changes proposed in this pull request
This PR:

* adds a section to the bottom to the 'Take a payment' page of the docs
* adds a link to the new section to 'How GOV.UK Pay works'
