### PR TITLE
PP-14369: Minor changes for August 2025

### DIFF
--- a/source/account_structure/set_up_where_payments_go/index.html.md.erb
+++ b/source/account_structure/set_up_where_payments_go/index.html.md.erb
@@ -28,7 +28,7 @@ You can send payments from a group of your services to the same bank account.
 If you need to know which service each payment came from when you [report on payments](/reporting), you can:
 
 - add references and descriptions that say which service a payment is from when you [create that payment](/making_payments/#creating-a-payment)
-- use [custom metadata](/reporting/#add-additional-information-your-users-will-not-be-able-to-see-39-custom-metadata-39-or-39-reporting-columns-39)
+- use [custom metadata (reporting columns)](/reporting/#add-additional-information-your-users-will-not-be-able-to-see-39-custom-metadata-39-or-39-reporting-columns-39)
 
 Follow the separate guidance on [creating a single GOV.UK Pay service instead](/account_structure/set_up_where_services_link_to#link-your-services-to-a-single-gov-uk-pay-service) if you need to:
 

--- a/source/account_structure/set_up_where_services_link_to/index.html.md.erb
+++ b/source/account_structure/set_up_where_services_link_to/index.html.md.erb
@@ -30,7 +30,7 @@ You will not be able to:
 If you need to know which service each payment came from when you [report on payments](/reporting), you can:
 
 - add references and descriptions that say which service a payment is from when you [create that payment](/making_payments/#creating-a-payment)
-- use [custom metadata](/reporting/#add-additional-information-your-users-will-not-be-able-to-see-39-custom-metadata-39-or-39-reporting-columns-39)
+- use [custom metadata (reporting columns)](/reporting/#add-additional-information-your-users-will-not-be-able-to-see-39-custom-metadata-39-or-39-reporting-columns-39)
 - use different [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/)
 
 ## Link your services to different GOV.UK Pay services

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 2300
 
 Your users can make payments with [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/). Apple Pay and Google Pay are often called 'digital wallets'.
 
-This page tells you how to turn on digital wallets, test Apple Pay and Google Pay, and the restrictions around digital wallets.
+This page tells you how to turn on digital wallets and test Apple Pay and Google Pay. It also explains the restrictions around digital wallets.
 
 Users can use Apple Pay and Google Pay with:
 

--- a/source/digital_wallets/index.html.md.erb
+++ b/source/digital_wallets/index.html.md.erb
@@ -1,15 +1,17 @@
 ---
-title: Take a digital wallet payment
+title: Take payments with Apple Pay and Google Pay
 last_reviewed_on: 2025-03-25
 review_in: 6 months
 weight: 2300
 ---
 
-# Take a digital wallet payment
+# Take payments with Apple Pay and Google Pay
 
-Your users can make payments with [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/). This page tells you how to turn on digital wallet payments, test digital wallet payments, and the restrictions around digital wallets.
+Your users can make payments with [Google Pay](https://pay.google.com/intl/en_uk/about/) and [Apple Pay](https://www.apple.com/uk/apple-pay/). Apple Pay and Google Pay are often called 'digital wallets'.
 
-Users can use digital wallets with:
+This page tells you how to turn on digital wallets, test Apple Pay and Google Pay, and the restrictions around digital wallets.
+
+Users can use Apple Pay and Google Pay with:
 
 * payment links
 * payments created through the GOV.UK Pay API
@@ -18,13 +20,13 @@ Users can only use Google Pay if they're making payments in a supported browser,
 
 Users can only use Apple Pay if they're making payments on a compatible Mac, iPhone, or iPad in a supported browser, such as Safari.
 
-If your payment service provider (PSP) is Stripe, both digital wallets are turned on by default. 
+If your payment service provider (PSP) is Stripe, Apple Pay and Google Pay are turned on by default. 
 
 If your PSP is Worldpay, Apple Pay is turned on by default, but you'll need to turn on Google Pay manually.
 
 You can turn off Apple Pay and Google Pay in the GOV.UK Pay admin tool.
 
-There are no additional PSP fees if your service takes digital wallet payments.
+There are no additional PSP fees if your service takes payments with Apple Pay and Google Pay.
 
 If you have turned off any card brands through the GOV.UK Pay admin tool, these card brands will also be turned off for digital wallet payments.
 
@@ -118,7 +120,7 @@ To test Apple Pay:
 
 ## Strong Customer Authentication (3D Secure)
 
-Apple Pay needs your users to authenticate digital wallet transactions using a secure method such as a fingerprint scan. Your Apple Pay users do not need to complete a Strong Customer Authentication (SCA) method such as 3D Secure separately.
+Apple Pay needs your users to authenticate digital wallet transactions using a secure method such as a fingerprint scan. Your Apple Pay users do not need to separately complete a Strong Customer Authentication (SCA) method such as 3D Secure.
 
 Google Pay supports, but does not need, your users to authenticate digital wallet transactions using a secure method. Your users who do not use Google Pay’s secure authentication may have to complete SCA separately.
 
@@ -126,9 +128,9 @@ See the [GOV.UK Pay page on Apple Pay and Google Pay](https://www.payments.servi
 
 ## Restrictions of digital wallet payments
 
-GOV.UK Pay cannot apply [corporate card surcharges](/corporate_card_surcharges/#add-corporate-card-fees) to digital wallet payments made with a corporate card.
+GOV.UK Pay cannot apply [corporate card surcharges](/corporate_card_surcharges/#add-corporate-card-fees) to payments made with a corporate card through Apple Pay or Google Pay.
 
-Users cannot make recurring payments with digital wallets.
+Users cannot make recurring payments with Apple Pay or Google Pay.
 
 ### Stored cardholder information in digital wallet payments
 

--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Integrate with the GOV.UK Pay API
 last_reviewed_on: 2025-03-27
 review_in: 6 months
-weight: 6100
+weight: 2050
 ---
 
 # Integrate with the GOV.UK Pay API
@@ -133,6 +133,10 @@ This change can take up to 15 minutes to take effect.
 If you collect your users' billing addresses in your service before you redirect them to GOV.UK Pay, you can [prefill the billing address field](/optional_features/prefill_user_details) on the __Enter payment details__ page.
 
 <%= warning_text('If you turn off billing address collection, your service will receive a `null` `billing_address` object in API responses. <br><br> The `billing_address` object is inside the `card_details` object. <br><br> You should check if disabling billing address collection will affect your service‘s integration with GOV.UK Pay.') %>
+
+## Test your new integration
+
+You should thoroughly test your integration. You can use [our guidance on testing the GOV.UK Pay API](/testing_govuk_pay).
 
 ## Existing integrations with GOV.UK Pay
 

--- a/source/moto_payments/moto_api/index.html.md.erb
+++ b/source/moto_payments/moto_api/index.html.md.erb
@@ -47,7 +47,7 @@ When taking payments over the phone, you can hide the card information of paying
 * the card number
 * the card verification value (CVV) or card verification code (CVC)
 
-To hide or unhide this information, you need Administrator permissions for your MOTO service. To see if you're an admin for a service, select the service from **My services**, then select **Settings**. Under **About your service**, select **Team members**. EYour email address will be under the role you have for this service.
+To hide or unhide this information, you need Administrator permissions for your MOTO service. To see if you're an admin for a service, select the service from **My services**, then select **Settings**. Under **About your service**, select **Team members**. Your email address will be under the role you have for this service.
 
 This change takes immediate effect, so you should tell your service team staff before changing these settings.
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 5210
 
 # Add your organisation's branding
 
-GOV.UK Pay supports custom branding of your payment pages, payment confirmation emails, and refund confirmation emails. This lets you add your organisation's branding to your user's payment journey.
+GOV.UK Pay supports custom branding of your payment pages, payment confirmation emails, and refund confirmation emails. This lets you add your organisation's branding to your users' payment journeys. 
 
 For payment pages and emails, you can customise:
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -33,7 +33,7 @@ Send an [email to the GOV.UK Pay team](/support_contact_and_more_information/) w
   * whether you want to apply your branding to your payment pages, your emails, or both
   * an image of your banner logo
   * your banner background and border colour as a [hexadecimal colour code](https://www.w3schools.com/colors/colors_picker.asp)
-  * an email address that will receive replies from users (if you are using your branding on payment confirmation emails)
+  * an email address that will receive replies from users (if you're using your branding on payment confirmation emails)
 
 ### Banner logo restrictions
 

--- a/source/optional_features/custom_branding/index.html.md.erb
+++ b/source/optional_features/custom_branding/index.html.md.erb
@@ -1,13 +1,13 @@
 ---
-title: Add custom branding
+title: Add your organisation's branding
 last_reviewed_on: 2025-03-27
 review_in: 12 months
 weight: 5210
 ---
 
-# Add custom branding
+# Add your organisation's branding
 
-GOV.UK Pay supports custom branding of your payment pages, payment confirmation emails, and refund confirmation emails.
+GOV.UK Pay supports custom branding of your payment pages, payment confirmation emails, and refund confirmation emails. This lets you add your organisation's branding to your user's payment journey.
 
 For payment pages and emails, you can customise:
 
@@ -18,9 +18,9 @@ On payment pages, you can also customise the border colour of the top banner.
 
 <%= image_tag "/images/custom-branding-diagram-large.svg", { :alt => '' } %>
 
-Custom branding applies to the test and live versions of a service.
+Your branding applies to the test and live versions of a service.
 
-To set up custom branding:
+To set up your branding:
 
 1. Send us your banner logo, banner colours, and a reply-to email address (if you are customising your emails).
 2. Add contact information to your payment confirmation emails.
@@ -29,11 +29,11 @@ To set up custom branding:
 
 Send an [email to the GOV.UK Pay team](/support_contact_and_more_information/) with:
 
-  * the services you want to apply custom branding to
-  * whether you want to apply custom branding to your payment pages, your emails, or both
+  * the services you want to apply your branding to
+  * whether you want to apply your branding to your payment pages, your emails, or both
   * an image of your banner logo
   * your banner background and border colour as a [hexadecimal colour code](https://www.w3schools.com/colors/colors_picker.asp)
-  * an email address that will receive replies from users (if you are using custom branding on payment confirmation emails)
+  * an email address that will receive replies from users (if you are using your branding on payment confirmation emails)
 
 ### Banner logo restrictions
 
@@ -47,7 +47,7 @@ To make your banner logo is clear on every device, your image must be:
 
 ## 2. Include contact information on your payment confirmation emails
 
-If you add custom branding to payment confirmation emails, you must [add a paragraph to those emails](/optional_features/custom_paragraph) that tells users how to contact you.
+If you add your branding to payment confirmation emails, you must [add a paragraph to those emails](/optional_features/custom_paragraph) that tells users how to contact you.
 
 If you monitor the email address you gave us for replies from users, you can explain this in your custom paragraph. For example:
 

--- a/source/optional_features/custom_paragraph/index.html.md.erb
+++ b/source/optional_features/custom_paragraph/index.html.md.erb
@@ -15,4 +15,4 @@ You can add a custom paragraph to payment confirmation emails from GOV.UK Pay. A
 1. Under **About your service**, select **Email notifications**.
 1. Select **Add a custom paragraph**.
 
-If you [have added custom branding to your payment confirmation emails](/optional_features/custom_branding/), you must use the custom paragraph to tell your users how to contact your service.
+If you [have added your organisation's branding to your payment confirmation emails](/optional_features/custom_branding/), you must use the custom paragraph to tell your users how to contact your service.

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 5200
 
 You can customise your payments pages with GOV.UK Pay in the following ways:
 
-* [add your organisation's branding](/optional_features/custom_branding/#add-custom-branding) to payment pages and confirmation emails
+* [add your organisation's branding](/optional_features/custom_branding) to payment pages and confirmation emails
 * [add custom content to payment confirmation emails](/optional_features/custom_paragraph)
 * [use Welsh](/optional_features/welsh_language/#use-welsh-on-your-payment-pages) on payment pages
 * [use your own payment failure pages](/optional_features/use_your_own_error_pages)

--- a/source/optional_features/index.html.md.erb
+++ b/source/optional_features/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 5200
 
 You can customise your payments pages with GOV.UK Pay in the following ways:
 
-* [add custom branding](/optional_features/custom_branding/#add-custom-branding) to payment pages and confirmation emails
+* [add your organisation's branding](/optional_features/custom_branding/#add-custom-branding) to payment pages and confirmation emails
 * [add custom content to payment confirmation emails](/optional_features/custom_paragraph)
 * [use Welsh](/optional_features/welsh_language/#use-welsh-on-your-payment-pages) on payment pages
 * [use your own payment failure pages](/optional_features/use_your_own_error_pages)

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -58,7 +58,7 @@ When your service redirects your user to `next_url`, they’ll see an **Enter pa
 * billing address
 * email address
 
-If your service takes [digital wallet payments](/digital_wallets/), your user can also choose to pay with Apple Pay or Google Pay from this page. 
+Your user can also choose to pay with Apple Pay or Google from this page if you have turned on [digital wallet payments](/digital_wallets/). 
 
 We also support [users paying from outside of the UK](/making_payments/#taking-payments-from-users-outside-of-the-uk).
 

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 1300
 
 This section outlines the payment flow for paying users and services using GOV.UK Pay. It focuses on services that integrate with the GOV.UK Pay API.
 
-## Overview
+## Overview of a payment journey on GOV.UK Pay
 
 1. Your user reaches a page in your service where they need to make a payment.
 1. You make an API request to create a new payment.

--- a/source/payment_flow/index.html.md.erb
+++ b/source/payment_flow/index.html.md.erb
@@ -58,7 +58,7 @@ When your service redirects your user to `next_url`, they’ll see an **Enter pa
 * billing address
 * email address
 
-Your user can also choose to pay with Apple Pay or Google from this page if you have turned on [digital wallet payments](/digital_wallets/). 
+Your user can also choose to pay with Apple Pay or Google Pay from this page if you've turned on [digital wallet payments](/digital_wallets/). 
 
 We also support [users paying from outside of the UK](/making_payments/#taking-payments-from-users-outside-of-the-uk).
 

--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -493,5 +493,5 @@ Read about [how to get a list of payments here](#get-a-list-of-payments-matching
 
 To change what appears on your users’ bank statements, you can either:
 
-* if your PSP is Stripe, [contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#support)
+* if your PSP is Stripe, [contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information)
 * if you’re using Worldpay, [contact Government Banking](mailto:serviceteam.gbs@hmrc.gov.uk)

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -66,7 +66,7 @@ If you think you’re receiving fraudulent payments, you can:
 
 - [block users from paying with prepaid cards](/block_prepaid_cards/#block-prepaid-cards)
 - [delay capture of payments](/delayed_capture/#delay-taking-a-payment) if you need time to do your own anti-fraud checks
-- check your payment service provider's (PSP's) security settings, or [contact us](/support_contact_and_more_information/#support) if your PSP is Stripe
+- check your payment service provider's (PSP's) security settings, or [contact us](/support_contact_and_more_information) if your PSP is Stripe
 
 You can also set up your account to make risk management fraud checks if your PSP is [Worldpay](http://support.worldpay.com/support/kb/gg/merchantadmininterface/Merchant%20Interface%20Guide.htm#5risk/risk_management.htm%3FTocPath%3DRisk%7C_____2)
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Security
+title: Security and compliance
 last_reviewed_on: 2025-03-27
 review_in: 6 months
 weight: 9200
 ---
 
-# Security
+# Security and compliance
 
 ## Reporting vulnerabilities
 

--- a/source/support_contact_and_more_information/index.html.md.erb
+++ b/source/support_contact_and_more_information/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Support
+title: Get support
 last_reviewed_on: 2024-03-24
 review_in: 6 months
 weight: 9400
 ---
 
-# Support
+# Get support
 
 You can get notifications about GOV.UK Pay’s status to your email, phone, RSS reader or website, by subscribing on our [status page](https://payments.statuspage.io/#).
 


### PR DESCRIPTION
### Context
This is a compilation of suggestions gathered over the course of a few months.

### Changes proposed in this pull request
In this PR, we:

- fix a typo on the MOTO pages
- add ‘reporting columns’ references to metadata
- adjust weighting of ‘integrate with API’ page to be higher
- improve ‘[Overview’ heading on How Pay works](https://docs.payments.service.gov.uk/payment_flow/#overview)
- add a little use case to custom branding page / rename to ‘Add your organisation branding’
- add a note to the Test your integration page that explains some features (e.g. 3DS) may behave differently when they go live
- change ‘digital wallet’ title to ‘Apple Pay and google Pay’ in a few places
- change ‘Security’ to ‘Security and compliance’
- change ‘Support’ to ‘Get support’