### PR TITLE
PP-14307: Adds information to Go live to catch Blue Badge services

### DIFF
--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -77,7 +77,7 @@ You need to make the following changes to your live account if you made them to 
 - switch on sending refund confirmation emails
 - add payment links
 
-If you’re taking payment for Blue Badges, you can connect your GOV.UK Pay service to the Department for Transport’s (DfT) [Manage Blue Badge application](https://admin.apply-blue-badge.service.gov.uk/sign-in). If you do not already have a Manage Blue Badge account, you’ll need to get in touch with the Manage Blue Badge admin within your local authority. You can also read [DfT’s guidance](https://confluence.bluebadge-support.org.uk/display/BBDS/GOV.UK+Pay) or let us know if you want to know more.
+If you’re taking payment for Blue Badges, you can connect your GOV.UK Pay service to the Department for Transport’s (DfT) [Manage Blue Badge application](https://admin.apply-blue-badge.service.gov.uk/sign-in). If you do not already have a Manage Blue Badge account, you’ll need to get in touch with the Manage Blue Badge admin within your local authority. You can also read [DfT’s guidance](https://confluence.bluebadge-support.org.uk/display/BBDS/GOV.UK+Pay) or tell us if you want to know more.
 
 ## 5. Check your live account works
 


### PR DESCRIPTION
### Context
We're concerned some Blue Badge services are not aware of Pay's special integration with the Manage Blue Badges application from DfT.

Along with some Zendesk macro changes, this PR hopes to catch some services as they go live.

### Changes proposed in this pull request
* adds a paragraph to the go-live page explaining that it is possible (but not required) that Blue Badge services can integrate with DfT's Manage Blue Badge app.