### PR TITLE
BAU - update number of metadata key-values allowed

### DIFF
--- a/source/reporting/index.html.md.erb
+++ b/source/reporting/index.html.md.erb
@@ -447,7 +447,7 @@ This example request creates a payment for a £100 fine and adds a ledger code a
 }
 ```
 
-The `metadata` object must contain between 1 and 10 parameters as key-value pairs.
+The `metadata` object must contain between 1 and 15 parameters as key-value pairs.
 
 Each parameter key must be a unique, case-insensitive string between 1 and 30 characters long. If 2 or more keys are identical, the API will remove all but one of the identical keys from the `metadata` object.
 


### PR DESCRIPTION
### Context
- We now support up to 15 key-value pairs in the metadata
