### PR TITLE
Removes an irrelevant line about corporate fees

### DIFF
--- a/source/corporate_card_surcharges/index.html.md.erb
+++ b/source/corporate_card_surcharges/index.html.md.erb
@@ -11,7 +11,7 @@ GOV.UK Pay supports adding a fee or 'surcharge' if your user pays with a corpora
 credit or debit card. You can [contact GOV.UK Pay support](/support_contact_and_more_information/) to ask the team to
 set this up for you.
 
-Each surcharge is a flat amount added to a payment. If you’d like to discuss adding surcharges as percentages, please contact us.
+Each surcharge is a flat amount added to a payment. 
 
 You can set a different surcharge for each of the following 3 corporate card types:
 


### PR DESCRIPTION
### Context
We do not, and do not plan to, support percentage-based corporate card fees.

### Changes proposed in this pull request
This PR  removes a line about services asking about this