### PR TITLE
Update Test your integration page for testing modes

### DIFF
--- a/source/integrate_with_govuk_pay/index.html.md.erb
+++ b/source/integrate_with_govuk_pay/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Integrate with the GOV.UK Pay API
-last_reviewed_on: 2025-11-13
+last_reviewed_on: 2026-03-02
 review_in: 6 months
 weight: 2050
 ---
@@ -78,20 +78,13 @@ The following example UML sequence diagram shows a typical happy-path payment jo
 
 ## Identifying your user when they return to your service
 
-We recommend using a cookie-based session to identify your user when they
-return to your service. You could use either encrypted client side sessions,
-or server-side sessions using session store.
+We recommend using a cookie-based session to identify users when they return to your service. You can use encrypted client-side sessions or server-side sessions with a session store.
 
-We recommend that you do not encode any reference number or user-
-specific information  in the `return_url`. For example, do not use
-`/payment_12345` at the end of your `return_url`.
+Do not put any reference numbers or user-specific information in the `return_url`. For example, do not add `/payment_12345` at the end of your `return_url`.
 
-If you do, an attacker may be able to guess the reference in your
-`return_url` and gain access to another user's personal information displayed
-on your confirmation screen.
+If you do, an attacker may be able to guess the reference in your `return_url` and see another user’s personal information on the confirmation page.
 
-You must [use HTTPS for your `return_url`](/security/#https), but you can use
-HTTP when your service is in sandbox or 'not live yet' mode.
+You must [use HTTPS for your `return_url`](/security/#https). You can use HTTP only when your service is in sandbox or ‘not live yet’ mode.
 
 ## Make sure that all payments are processed
 

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -56,7 +56,7 @@ We will email you when MOTO payments are enabled.
 
 1. Create a new MOTO service that is separate from your online payments service. To do this, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk) and select **Add a new service**.
 
-1. Get a separate MOTO merchant code for MOTO payments. It must be different from your online (non-MOTO) merchant code. Contact Government Banking if you need one. 
+1. Get a MOTO merchant code for MOTO payments. Contact Government Banking if you need one. MOTO payments and online payments are processed with separate merchant codes. 
 
 1. Use this MOTO merchant code when you [connect your new service to your PSP](/switching_to_live/#go-live).
 

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -50,7 +50,7 @@ Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support
 * both your organisation and any suppliers or delivery partners hold a valid AOC
 * you would like to take MOTO payments on your live service
 
-We will email you when MOTO payments are enabled.
+We will email you when we have enabled MOTO payments.
 
 #### Worldpay - turn on MOTO payments on a live account
 
@@ -60,8 +60,8 @@ We will email you when MOTO payments are enabled.
 
 1. Use this MOTO merchant code when you [connect your new service to your PSP](/switching_to_live/#go-live).
 
-1. Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to confirm PCI DSS compliance for you and any suppliers or delivery partners. In the same email, ask for MOTO payments to be enabled on your account.
+1. Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to confirm PCI DSS compliance for you and any suppliers or delivery partners. In the same email, ask us to enable MOTO payments on your account.
 
-We will email you when MOTO payments are enabled.
+We will email you when we have enabled MOTO payments.
 
 You can still [take online payments](https://docs.payments.service.gov.uk/making_payments/) through your non-MOTO service.

--- a/source/moto_payments/index.html.md.erb
+++ b/source/moto_payments/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Take payments over the phone or by post ('MOTO')
-last_reviewed_on: 2025-11-13
+last_reviewed_on: 2026-03-02
 review_in: 6 months
 weight: 2400
 ---
@@ -50,16 +50,18 @@ Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support
 * both your organisation and any suppliers or delivery partners hold a valid AOC
 * you would like to take MOTO payments on your live service
 
-We’ll email you to let you know when we’ve turned on MOTO payments.
+We will email you when MOTO payments are enabled.
 
 #### Worldpay - turn on MOTO payments on a live account
 
-1. Create a new MOTO service that is separate from your online payments service - to do this, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk) and select **Add a new service**.
+1. Create a new MOTO service that is separate from your online payments service. To do this, sign in to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk) and select **Add a new service**.
 
-1. You need to process MOTO payments on a separate MOTO merchant code to the one you use for online (non-MOTO) payments. If you do not already have a merchant code for MOTO payments, ask for one by contacting Government Banking. You’ll use this merchant code when you [connect your new service to your PSP](https://docs.payments.service.gov.uk/switching_to_live/#go-live).
+1. Get a separate MOTO merchant code for MOTO payments. It must be different from your online (non-MOTO) merchant code. Contact Government Banking if you need one. 
 
-1. Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to confirm you and any suppliers or delivery partners comply with the latest version of PCI DSS. In the same email, let us know that would like to take MOTO payments on your account. 
+1. Use this MOTO merchant code when you [connect your new service to your PSP](/switching_to_live/#go-live).
 
-We’ll email you to let you know we’ve turned on MOTO payments.
+1. Email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to confirm PCI DSS compliance for you and any suppliers or delivery partners. In the same email, ask for MOTO payments to be enabled on your account.
+
+We will email you when MOTO payments are enabled.
 
 You can still [take online payments](https://docs.payments.service.gov.uk/making_payments/) through your non-MOTO service.

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Quick start
-last_reviewed_on: 2025-11-13
+last_reviewed_on: 2026-03-02
 review_in: 6 months
 weight: 1200
 ---
@@ -47,9 +47,7 @@ To set up a payment link, [create an account](https://selfservice.payments.servi
 
 ## The GOV.UK Pay API
 
-The GOV.UK Pay API is based on REST principles with endpoints returning data
-in JSON format, and standard HTTP error response codes. Our API
-lets you:
+You can use the GOV.UK Pay API to:
 
 * begin and complete payments
 * view the event history for individual payments
@@ -57,14 +55,14 @@ lets you:
 * issue full or partial refunds
 * create agreements to take recurring payments
 
-You can create 2 types of API keys for your GOV.UK Pay service. These are:
+The API follows REST principles. Endpoints return JSON data and use standard HTTP status codes for errors. 
 
-- test API keys, for [testing your service before it goes live and for testing in sandbox mode](/testing_govuk_pay)
-- live API keys, for taking payments from your users after you [go live](/switching_to_live)
+You can create 2 types of API keys for your GOV.UK Pay service:
 
-If your payment service provider (PSP) is Stripe, you can test how [transaction fees](/reporting/#psp-fees) and payments to your bank account work.
+* use test API keys for a service that is [‘not live yet’](/testing_govuk_pay)
+* use live API keys after [go live](/switching_to_live)
 
-When you've signed up for GOV.UK Pay and created a service, follow these instructions to get started with our API and make a test API request.
+When you’ve signed up for GOV.UK Pay and created a service, create a test API key and make a test payment request.
 
 ## Test the API
 
@@ -117,7 +115,7 @@ Read more about [taking payments](/making_payments/#take-a-payment).
 
 ### Simulate your users' payment journey
 
-Go to the ``next_url`` with a browser, and you’ll see the payment screen. Choose a [mock card number](/testing_govuk_pay/#mock-card-numbers) and enter it to simulate a payment. For the other required details, enter some test information which should have:
+Go to the ``next_url`` with a browser, and you’ll see the payment page. Choose a [mock card number](/testing_govuk_pay/#mock-card-numbers) and enter it to simulate a payment. For the other required details, enter some test information which should have:
 
   * an expiry date that is in the future and in the format MM/YYYY or MM/YY
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -15,8 +15,7 @@ Read this section to learn about what to do to get started with GOV.UK Pay.
 
 Before you start using GOV.UK Pay, you should:
 
-* read how to [get started](https://www.payments.service.gov.uk/getstarted/) and decide if GOV.UK
-Pay is right for your service
+* read how to [get started](https://www.payments.service.gov.uk/getstarted/) and decide if GOV.UK Pay is right for your service
 * sign up to the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/register/email-address)
 * create a service in the GOV.UK Pay admin tool
 * read the GOV.UK Service Manual guidance on [deploying new
@@ -117,17 +116,15 @@ Read more about [taking payments](/making_payments/#take-a-payment).
 
 ### Simulate your users' payment journey
 
-Go to the ``next_url`` with a browser, and you’ll see the payment page. Choose a [mock card number](/testing_govuk_pay/#use-mock-card-numbers) and enter it to simulate a payment. For the other required details, enter some test information which should have:
+Go to the `next_url` with a browser, and you’ll see the payment page. Choose a [mock card number](/testing_govuk_pay/#use-mock-card-numbers) and enter it to simulate a payment. For the other required details, enter some test information, which should have:
 
   * an expiry date that is in the future and in the format MM/YYYY or MM/YY
-
   * a valid postcode
 
 Submit the payment.
 
 ### View transactions at GOV.UK Pay admin tool
 
-Select an account in the [GOV.UK Pay admin
-tool](https://selfservice.payments.service.gov.uk/), then select __Transactions__.
+Select an account in the [GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/), then select **Transactions**.
 
 You can also view test transactions using the API.

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -115,7 +115,7 @@ Read more about [taking payments](/making_payments/#take-a-payment).
 
 ### Simulate your users' payment journey
 
-Go to the ``next_url`` with a browser, and you’ll see the payment page. Choose a [mock card number](/testing_govuk_pay/#mock-card-numbers) and enter it to simulate a payment. For the other required details, enter some test information which should have:
+Go to the ``next_url`` with a browser, and you’ll see the payment page. Choose a [mock card number](/testing_govuk_pay/#use-mock-card-numbers) and enter it to simulate a payment. For the other required details, enter some test information which should have:
 
   * an expiry date that is in the future and in the format MM/YYYY or MM/YY
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -57,12 +57,14 @@ You can use the GOV.UK Pay API to:
 
 The API follows REST principles. Endpoints return JSON data and use standard HTTP status codes for errors. 
 
-You can create 2 types of API keys for your GOV.UK Pay service:
+You can create 2 types of API keys for your GOV.UK Pay service. You can create:
 
-* use test API keys for a service that is [‘not live yet’](/testing_govuk_pay)
-* use live API keys after [go live](/switching_to_live)
+* test API keys for a service that is [‘not live yet’](/testing_govuk_pay)
+* live API keys after [go live](/switching_to_live)
 
 When you’ve signed up for GOV.UK Pay and created a service, create a test API key and make a test payment request.
+
+You can still use test API keys for a service after it goes live.
 
 ## Test the API
 

--- a/source/recurring_payments/index.html.md.erb
+++ b/source/recurring_payments/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Take recurring payments
-last_reviewed_on: 2025-11-13
+last_reviewed_on: 2026-03-03
 review_in: 6 months
 weight: 2200
 ---
@@ -322,7 +322,7 @@ You can [read more about using webhooks to automatically receive updates](/webho
 
 ### Test your recurring payments integration
 
-GOV.UK Pay have [mock card numbers for you to test your integration](/testing_govuk_pay/#mock-card-numbers), including a [mock card number for testing recurring payments](/testing_govuk_pay/#testing-recurring-payments-on-a-test-account). You can use this mock card number to set up an agreement with an initial payment, but further recurring payments will be declined.
+GOV.UK Pay have [mock card numbers for you to test your integration](/testing_govuk_pay/#use-mock-card-numbers). You can also use specific mock card numbers to test recurring payments.
 
 
 ##Contacting your users

--- a/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
+++ b/source/switch_payment_service_provider/switch_psp_to_stripe/index.html.md.erb
@@ -69,7 +69,7 @@ You need to repeat the following process for each service you want to switch.
 1. Select **Settings**.
 1. Under **Payment provider**, select **Switch to Stripe**.
 
-Complete the tasks on this screen to start switching to Stripe.
+Complete the tasks on this page to start switching to Stripe.
 
 
 ### 2b. Make a test payment to complete the switch to Stripe

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -121,7 +121,7 @@ To create a reusable payment link:
 
 You can also:
 
-* use [mock card numbers](#mock-card-numbers) to test successful and unsuccessful payments
+* use [mock card numbers](#use-mock-card-numbers) to test successful and unsuccessful payments
 * use HTTP instead of HTTPS for the `return_url` while your service is in sandbox or ‘not live yet’ mode
 * test any payment links you have already set up
 
@@ -142,7 +142,7 @@ Mock card numbers work for all test payments in sandbox and ‘not live yet’ m
 There are separate sets of mock card numbers for:
 
 * [Stripe services](#mock-card-numbers-for-stripe)
-* [Worldpay services](#moc-card-numbers-for-worldpay)
+* [Worldpay services](#mock-card-numbers-for-worldpay)
 
 ### Mock card numbers for Stripe
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -1,125 +1,194 @@
 ---
 title: Test your integration
-last_reviewed_on: 2025-03-27
+last_reviewed_on: 2026-03-02
 review_in: 6 months
 weight: 6200
 ---
 
 # Test your integration
 
-<%= warning_text('In November 2025, we updated the GOV.UK Pay admin tool. This update removed the concept of test accounts, replacing them with a sandbox mode for live services, and a &#39;not live yet&#39; mode for new services.<br><br>We will update this page soon to reflect these new testing modes. Until then, some of the content on this page is outdated.') %>
+Use GOV.UK Pay testing features to check your integration before you go live, and to test changes after your service is live.
 
-## How test accounts work in GOV.UK Pay
+The way you test depends on:
 
-Each GOV.UK Pay service has:
+* whether your service is live
+* which payment service provider (PSP) you use
+* whether you are testing the GOV.UK Pay API, the full user journey, or both
 
-* one test account to test how GOV.UK Pay works
-* one live account to take real payments from users
+## Choose a testing mode
 
-Your test account type depends on your chosen payment service provider (PSP). 
+Each GOV.UK Pay service has one test point.
 
-| Payment service provider       | Test account type    |
-| ------------------------------ | -------------------  |
-| Stripe                         | Stripe test account  |
-| Worldpay                       | Sandbox test account |
+You can use it in 2 modes:
 
-You're limited to one test account per GOV.UK Pay service. For example, if you have a sandbox test account, you cannot request a Stripe test account on the same GOV.UK Pay service.
+* ‘not live yet’ for a new service
+* sandbox for a live service
 
-### Get a Stripe test account
+### Use ‘not live yet’ for a new service
 
-You can use a Stripe test account to see how the following work:
+When you first create a GOV.UK Pay service, it is labelled ‘not live yet’ in the GOV.UK Pay admin tool.
 
+Use this mode to:
+
+* explore how the GOV.UK Pay API works
+* test payments
+* test service settings
+* check your integration before you go live
+
+### Use sandbox for a live service
+
+After your service goes live, use sandbox mode to test changes.
+
+To enter sandbox mode:
+
+1. From the admin tool dashboard, select **Enter sandbox mode**.
+1. On the Enter sandbox mode page, select **Enter sandbox mode**.
+
+You can use sandbox mode to:
+
+* make demo payments
+* view test transactions
+* try different settings and functionality
+* run automated smoke tests
+
+Changes in sandbox mode do not affect your live service. Users can still make payments to the live version.
+
+You can leave sandbox mode at any time.
+
+### Important limitations
+
+Do not use both testing modes for automated integration tests that run when you change your code.
+
+If you need automated integration tests, build a stub to simulate the GOV.UK Pay API instead. For example, you can use [WireMock](https://wiremock.org/).
+
+In sandbox mode, use the same test API keys created in ‘not live yet’ mode. Create new live API keys only when you [go live](/switching_to_live) to take payments.
+
+## What you can test by payment service provider
+
+### If your PSP is Stripe
+
+If your service uses Stripe, you can use ‘not live yet’ and sandbox modes to test:
 * [transaction fees](/reporting/#psp-fees)
 * payments to your bank account
+* 3D Secure (3DS) with specific test card numbers
 
-You already have a Stripe test account if you created your GOV.UK Pay service after September 2024 and chose Stripe as your PSP.
+### If your PSP is Worldpay
 
-You may have a sandbox test account if you created your GOV.UK Pay service before September 2024 and chose Stripe as your PSP.
-
-It is not possible to swap a sandbox test account for a Stripe test account within the same GOV.UK Pay service. To get a Stripe test account, you need to create a new GOV.UK Pay service.
-
-1. [Sign in to the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk/my-services).
-1. Select **Add a new service**. 
-1. When asked which type of organisation you work for, select **Local authority, armed forces or police**.
-1. Select **Create service**.
-
-Your new service will have a Stripe test account.
-
-Test data and API keys in your sandbox test account will not be available in your Stripe test account.
-
-Stripe test accounts have [a different set of mock card numbers](#if-you-39-re-using-a-test-stripe-account).
-
-### Get a Worldpay test account
-
-It’s possible to link a Worldpay test account to GOV.UK Pay. Some services might find a Worldpay test account useful to connect GOV.UK Pay to Worldpay’s reporting products.
-
-For most organisations, a Worldpay test account is not necessary and we do not recommend using it. GOV.UK Pay cannot support you if you encounter problems.
-
-You can test the entire payment journey with a standard GOV.UK Pay test account, as well as:
+If your service uses Worldpay, you can use ‘not live yet’ and sandbox modes for:
 
 * reporting on payments
-* smoke testing
-* viewing and refunding transactions
+* [smoke testing](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy)
+* viewing transactions
+* refunding transactions
 
-If you get a Worldpay test account, you should not use it for long term, automated testing.
+Worldpay does not support 3DS testing in sandbox mode.
 
-Email GOV.UK Pay support (govuk-pay-support@digital.cabinet-office.gov.uk) to request a Worldpay test account. If GOV.UK Pay support approves your request, we will add your Worldpay test account as a separate GOV.UK Pay service.
+## Worldpay test accounts
 
-## Testing your service
+You can link a Worldpay test account to GOV.UK Pay.
 
-You can use your test account to:
+Some services use a Worldpay test account to connect GOV.UK Pay to Worldpay reporting products.
 
-- explore how the GOV.UK Pay API works
-- run automated [smoke tests](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy)
+Most organisations do not need a Worldpay test account. We do not recommend using one unless you have a clear reason.
 
-Do not use your test account for automated integration tests that run every time you change your code. Build a ‘stub’ to simulate the GOV.UK Pay API instead, using a tool like [WireMock](https://wiremock.org/).
+If you use a Worldpay test account:
 
-## Testing the whole user journey
+* GOV.UK Pay cannot support problems with the account
+* you should not use it for long-term automated testing
 
-You should test the whole user journey. To help you do this, you can create a reusable payment that will behave as if it was created through the API.
+To ask for a Worldpay test account, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). 
 
-This feature is for services that intend to integrate with the GOV.UK Pay API but have not yet finished building their integration.
+If we approve your request, we will add the test account as a separate GOV.UK Pay service.
 
-You will get a link to a GOV.UK Pay payment page that you can add to your prototypes. You can also specify a return URL that GOV.UK Pay will return you to after finishing the test payment. This lets you test the whole user journey.
+## Test the whole user journey
 
-1. Sign in to [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk).
+Test the full user journey as well as the API.
+
+You can create a reusable link in the GOV.UK Pay admin tool. It behaves like a payment link created through the API.
+
+You can use the link to:
+
+* open a GOV.UK Pay payment page from your prototype
+* complete a test payment
+* send the user back to your service with a `return_url`
+* test the full payment journey
+
+To create a reusable payment link:
+
+1. Sign in to the [the GOV.UK Pay admin tool](https://selfservice.payments.service.gov.uk).
 1. Select the service you want to test in **My services**.
 1. Select **Test with your users** to create the link.
 
 You can also:
 
-- use [mock card numbers](#mock-card-numbers) to test both successful and unsuccessful payments
-- use HTTP instead of HTTPs for the `return_url` with your test account, so you do not need to set up a secure url for testing
-- test any [payment links](https://www.payments.service.gov.uk/govuk-payment-pages/) you have set up
+* use [mock card numbers](#mock-card-numbers) to test successful and unsuccessful payments
+* use HTTP instead of HTTPS for the `return_url` while your service is in sandbox or ‘not live yet’ mode
+* test any payment links you have already set up
 
-You cannot use 3D Secure (3DS) with test accounts.
+You do not need to set up a secure URL for testing.
 
 ## Performance testing
 
 You must [contact us](/support_contact_and_more_information) to get written approval before you do any performance testing.
 
-## Mock card numbers and email addresses
+## Use mock card numbers
 
-Use mock card numbers and email addresses with your test account when you try payments as a user.
+Use mock card numbers when you test payments. Do not use real card numbers.
 
-Do not use real card numbers or fake email addresses with your test account.
+You can use any valid value for the other payment fields. For example, the card expiry date can be any future date.
 
-You must use mock email addresses when doing automated testing. If you are testing manually, you can use real email addresses.
-
-You can enter any valid value for other payment fields. For example, the card expiry date can be any date in the future.
-
-### Mock card numbers
-
-Mock card numbers do not work with your live account.
+Mock card numbers work for all test payments in sandbox and ‘not live yet’ modes.
 
 There are separate sets of mock card numbers for:
 
-* [GOV.UK Pay test accounts](#if-you-39-re-using-a-test-39-sandbox-39-account) 
-* [Stripe test accounts](#if-you-39-re-using-a-test-stripe-account)
+* [Stripe services](#mock-card-numbers-for-stripe)
+* [Worldpay services](#moc-card-numbers-for-worldpay)
 
-#### If you're using a test ('sandbox') account
+### Mock card numbers for Stripe
 
-|Testing action |Card number | Card brand | Card type |
+The [PSP transaction fee](/reporting/#psp-fees) depends on the card country.
+
+| Testing action | Card number | Card brand | Card type | Country |
+|--|--|--|--|--|--|
+|Successful payment |4000008260000000| Visa | Credit | UK |
+|Successful payment |4000058260000005| Visa | Debit | UK |
+|Successful payment |4000002500000003| Visa | Credit | France |
+|Successful payment |4242424242424242| Visa | Credit | US |
+|Successful payment |4000056655665556| Visa | Debit | US |
+|Successful payment |5105105105105100| Mastercard | Debit | US |
+|Successful payment |5200828282828210| Mastercard | Debit | US |
+|Successful payment |371449635398431| American Express | Credit | US |
+|Requires 3DS check |4000002500003155| Visa | Credit | France |
+|Card declined|4000000000000002|Visa| Credit or debit | US |
+|Card expired|4000000000000069|Visa| Credit or debit | US |
+|Invalid CVC code|4000000000000127|Visa| Credit or debit | US |
+|Payment disputed and lost|4000000000000259|Visa|Credit| US |
+|Payment disputed and won|4000000000002685|Visa|Credit| US |
+|General error|4000000000000119|Visa| Credit or debit | US |
+
+#### Test recurring payments for a Stripe service
+
+There are additional mock card numbers to test recurring payments with Stripe. 
+
+Use these mock card numbers to test recurring payments with Stripe.
+
+[Recurring payments](/recurring_payments/#how-recurring-payments-work) have 2 steps:
+
+1. Take an initial payment to set up an agreement.
+1. Take later recurring payments automatically.
+
+Each test card gives a result for both steps.
+
+| Testing actions                                                            | Card number      | Card brand | Card type | Country |
+| -------------------------------------------------------------------------- | ---------------- | ---------- | --------- | ------- |
+| Successful set up payment without 3DS<br><br>Successful recurring payments | 4242424242424242 | Visa       | Credit    | US      |
+| Successful set up payment with 3DS<br><br>Successful recurring payments    | 4000002500003155 | Visa       | Credit    | France  |
+| Successful set up payment with 3DS<br><br>Unsuccessful recurring payments  | 4000002760003184 | Visa       | Credit    | Germany |
+| Unsuccessful set up payment                                                | 4000000000009995 | Visa       | Credit    | US      |
+
+### Mock card numbers for Worldpay
+
+| Testing action | Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |
 |Successful payment | 4444333322221111 | Visa | Credit |
 |Successful payment |4242424242424242| Visa | Credit |
@@ -141,64 +210,28 @@ There are separate sets of mock card numbers for:
 |Invalid CVC code|4000000000000127|Visa| Credit or debit |
 |General error|4000000000000119|Visa| Credit or debit |
 
-##### Testing recurring payments on a test account
+#### Test recurring payments for a Worldpay service
 
-Recurring payments are made up of two stages:
+Use these mock card numbers to test recurring payments with Worldpay.
 
-1. An initial payment to set up the agreement for recurring payments.
-2. Further recurring payments that are taken automatically without a user's input.
+[Recurring payments](/recurring_payments/#how-recurring-payments-work) have 2 steps:
 
-To test both stages, we offer mock cards that have two testing actions - one for the initial payment and one for the further recurring payments.
+1. Take an initial payment to set up an agreement.
+1. Take later recurring payments automatically.
 
-|Testing actions |Card number | Card brand | Card type |
+Each test card gives a result for both steps.
+
+| Testing actions | Card number | Card brand | Card type |
 | -------- | ------- | ------- | ------- |
-|1. Successul set up payment<br><br>2. Successful recurring payment | 4000056655665556 | Visa | Debit |
+|1. Successful set up payment<br><br>2. Successful recurring payment | 4000056655665556 | Visa | Debit |
 |1. Successful set up payment<br><br>2. Unsuccessful recurring payment | 5105105105105100 | Mastercard | Debit |
 
-#### If you're using a test Stripe account
+## Use mock email addresses
 
-The [PSP transaction fee](/reporting/#psp-fees) depends on which country the test card is from.
+If you are testing manually, you can use real email addresses.
 
-|Testing action |Card number |Card brand |Card type | Country |
-|--|--|--|--|--|--|
-|Successful payment |4000008260000000| Visa | Credit | UK |
-|Successful payment |4000058260000005| Visa | Debit | UK |
-|Successful payment |4000002500000003| Visa | Credit | France |
-|Successful payment |4242424242424242| Visa | Credit | US |
-|Successful payment |4000056655665556| Visa | Debit | US |
-|Successful payment |5105105105105100| Mastercard | Debit | US |
-|Successful payment |5200828282828210| Mastercard | Debit | US |
-|Successful payment |371449635398431| American Express | Credit | US |
-|Requires 3DS check |4000002500003155| Visa | Credit | France |
-|Card declined|4000000000000002|Visa| Credit or debit | US |
-|Card expired|4000000000000069|Visa| Credit or debit | US |
-|Invalid CVC code|4000000000000127|Visa| Credit or debit | US |
-|Payment disputed and lost|4000000000000259|Visa|Credit| US |
-|Payment disputed and won|4000000000002685|Visa|Credit| US |
-|General error|4000000000000119|Visa| Credit or debit | US |
+If you are doing automated tests, you must use one of these mock email addresses.
 
-##### Testing recurring payments on a test Stripe account
-
-There are additional mock card numbers to test recurring payments with Stripe. 
-
-Use these cards to test the two main steps of [the recurring payment flow](/recurring_payments/#how-recurring-payments-work):
-
-* taking a payment to set up an agreement for recurring payments
-* taking further recurring payments without user input
-
-Each card has a different result for these two steps.
-
-| Testing actions                                                            | Card number      | Card brand | Card type | Country |
-| -------------------------------------------------------------------------- | ---------------- | ---------- | --------- | ------- |
-| Successful set up payment without 3DS<br><br>Successful recurring payments | 4242424242424242 | Visa       | Credit    | US      |
-| Successful set up payment with 3DS<br><br>Successful recurring payments    | 4000002500003155 | Visa       | Credit    | France  |
-| Successful set up payment with 3DS<br><br>Unsuccessful recurring payments  | 4000002760003184 | Visa       | Credit    | Germany |
-| Unsuccessful set up payment                                                | 4000000000009995 | Visa       | Credit    | US      |
-
-### Mock email addresses
-
-Use one of the following mock email addresses when doing automated testing:
-
-- simulate-delivered@notifications.service.gov.uk
-- simulate-delivered-2@notifications.service.gov.uk
-- simulate-delivered-3@notifications.service.gov.uk
+* simulate-delivered@notifications.service.gov.uk
+* simulate-delivered-2@notifications.service.gov.uk
+* simulate-delivered-3@notifications.service.gov.uk

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -46,7 +46,7 @@ To enter sandbox mode:
 
 You can use sandbox mode to:
 
-* make demo payments
+* make test payments
 * view test transactions
 * try different settings and functionality
 * run automated smoke tests
@@ -55,7 +55,7 @@ Changes in sandbox mode do not affect your live service. Users can still make pa
 
 You can leave sandbox mode at any time.
 
-### Important limitations
+### Important limitations when testing GOV.UK Pay
 
 Do not use both testing modes for automated integration tests that run when you change your code.
 

--- a/source/testing_govuk_pay/index.html.md.erb
+++ b/source/testing_govuk_pay/index.html.md.erb
@@ -68,6 +68,7 @@ In sandbox mode, use the same test API keys created in ‘not live yet’ mode. 
 ### If your PSP is Stripe
 
 If your service uses Stripe, you can use ‘not live yet’ and sandbox modes to test:
+
 * [transaction fees](/reporting/#psp-fees)
 * payments to your bank account
 * 3D Secure (3DS) with specific test card numbers
@@ -149,7 +150,7 @@ There are separate sets of mock card numbers for:
 The [PSP transaction fee](/reporting/#psp-fees) depends on the card country.
 
 | Testing action | Card number | Card brand | Card type | Country |
-|--|--|--|--|--|--|
+| -------------- | ----------- | ---------- | --------- | ------- |
 |Successful payment |4000008260000000| Visa | Credit | UK |
 |Successful payment |4000058260000005| Visa | Debit | UK |
 |Successful payment |4000002500000003| Visa | Credit | France |
@@ -189,7 +190,7 @@ Each test card gives a result for both steps.
 ### Mock card numbers for Worldpay
 
 | Testing action | Card number | Card brand | Card type |
-| -------- | ------- | ------- | ------- |
+| -------------- | ----------- | ---------- | --------- |
 |Successful payment | 4444333322221111 | Visa | Credit |
 |Successful payment |4242424242424242| Visa | Credit |
 |Successful payment |4000056655665556| Visa | Debit |
@@ -222,7 +223,7 @@ Use these mock card numbers to test recurring payments with Worldpay.
 Each test card gives a result for both steps.
 
 | Testing actions | Card number | Card brand | Card type |
-| -------- | ------- | ------- | ------- |
+| --------------- | ----------- | ---------- | --------- |
 |1. Successful set up payment<br><br>2. Successful recurring payment | 4000056655665556 | Visa | Debit |
 |1. Successful set up payment<br><br>2. Unsuccessful recurring payment | 5105105105105100 | Mastercard | Debit |
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -29,12 +29,11 @@ You can create webhooks in the GOV.UK Pay admin tool.
 Set up an endpoint (callback URL) to receive webhook messages before you create the webhook. It must:
 
 * accept the `POST` body from your webhook
-* return a `2xx` successful rresponse immediately (before processing the message to avoid timeouts)
-* use HTTPS with a valid certiifcate (TLS 1.2 is required)
+* return a `2xx` successful response immediately (before processing the message to avoid timeouts)
+* use HTTPS with a valid certificate (TLS 1.2 is required)
 * end with a `.gov.uk` domain (unless in [sandbox or ‘not live yet’ modes](/testing_govuk_pay/))
 
 If you cannot use a `.gov.uk` domain, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to request an exception. We allow only domains that belong to your service or its parent organisation. Approval may take time because we may need to discuss your request.
-
 
 ## Create a webhook
 

--- a/source/webhooks/index.html.md.erb
+++ b/source/webhooks/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Receive automatic payment event updates using webhooks
-last_reviewed_on: 2025-11-13
+last_reviewed_on: 2026-03-02
 review_in: 6 months
 weight: 3300
 ---
@@ -26,15 +26,15 @@ You can create webhooks in the GOV.UK Pay admin tool.
 
 ## Set up a callback URL to receive a webhook message
 
-You need to set up an endpoint (callback URL) that can receive webhook messages before creating the webhook.
+Set up an endpoint (callback URL) to receive webhook messages before you create the webhook. It must:
 
-You must set up your endpoint to receive the `POST` body from your webhook and respond with a `2xx` successful response as soon as possible. To avoid timeouts, return this response before you process the webhook message.
+* accept the `POST` body from your webhook
+* return a `2xx` successful rresponse immediately (before processing the message to avoid timeouts)
+* use HTTPS with a valid certiifcate (TLS 1.2 is required)
+* end with a `.gov.uk` domain (unless in [sandbox or ‘not live yet’ modes](/testing_govuk_pay/))
 
-Your callback URL must use HTTPS and present a valid certificate. GOV.UK webhooks support TLS version 1.2.
+If you cannot use a `.gov.uk` domain, email [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk) to request an exception. We allow only domains that belong to your service or its parent organisation. Approval may take time because we may need to discuss your request.
 
-Your callback URL must have a domain that ends with `.gov.uk`. This restriction does not apply if you're using webhooks on a service in sandbox or 'not live yet' modes.
-
-We can allow other domains if you cannot host your callback URL on a domain that ends with `.gov.uk`. You can ask us to allow a domain by emailing support at [govuk-pay-support@digital.cabinet-office.gov.uk](mailto:govuk-pay-support@digital.cabinet-office.gov.uk). We'll only allow domains that exclusively belong to your service or your service's parent organisation. There may be a delay before we allow your domain to give us time to discuss your request.
 
 ## Create a webhook
 


### PR DESCRIPTION
Migrates 'test accounts' to 'Not live yet' and sandbox modes after November 2025 admin changes.

Restructure page for clarity: remove obsolete sections like Stripe test accounts. Update PSP differences, API keys, mock cards, testing behaviours.

Reviewed by Pay content designer, interaction designer.

### Context
Jira ticket PP-14695. November 2025 admin tool migration from test accounts to testing modes, user research findings.

### Changes proposed in this pull request

- Migrated 'Test your integration' page to new terminology ('Not live yet', sandbox mode).
- Removed obsolete sections (Stripe test accounts).
- Restructured for clarity; added PSP differences.
- Updated API keys, mock cards, testing behaviours.

### Guidance to review
Check GOV.UK style compliance (short sentences, active voice). 